### PR TITLE
Show plant schedule calendar on creation

### DIFF
--- a/plant-swipe/src/components/plant/SchedulePickerDialog.tsx
+++ b/plant-swipe/src/components/plant/SchedulePickerDialog.tsx
@@ -1,0 +1,207 @@
+// @ts-nocheck
+import React from 'react'
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+
+type Period = 'week' | 'month' | 'year'
+
+export interface ScheduleSelection {
+  weeklyDays?: number[]
+  monthlyDays?: number[]
+  yearlyDays?: string[]
+}
+
+export function SchedulePickerDialog(props: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  period: Period
+  amount: number
+  onSave: (selection: ScheduleSelection) => Promise<void>
+}) {
+  const { open, onOpenChange, period, amount, onSave } = props
+
+  const [saving, setSaving] = React.useState(false)
+  const [error, setError] = React.useState<string | null>(null)
+
+  const [weeklyDays, setWeeklyDays] = React.useState<number[]>([])
+  const [monthlyDays, setMonthlyDays] = React.useState<number[]>([])
+  const [yearlyDays, setYearlyDays] = React.useState<string[]>([])
+
+  React.useEffect(() => {
+    // Reset selection on open
+    if (open) {
+      setWeeklyDays([])
+      setMonthlyDays([])
+      setYearlyDays([])
+      setError(null)
+    }
+  }, [open])
+
+  const countSelected = period === 'week' ? weeklyDays.length : period === 'month' ? monthlyDays.length : yearlyDays.length
+
+  const remaining = Math.max(0, amount - countSelected)
+  const disabledMore = remaining === 0
+
+  const toggleWeekday = (d: number) => {
+    setWeeklyDays((cur) => {
+      if (cur.includes(d)) return cur.filter((x) => x !== d)
+      if (disabledMore) return cur
+      return [...cur, d]
+    })
+  }
+
+  const toggleMonthDay = (d: number) => {
+    setMonthlyDays((cur) => {
+      if (cur.includes(d)) return cur.filter((x) => x !== d)
+      if (disabledMore) return cur
+      return [...cur, d]
+    })
+  }
+
+  const toggleYearDay = (mmdd: string) => {
+    setYearlyDays((cur) => {
+      if (cur.includes(mmdd)) return cur.filter((x) => x !== mmdd)
+      if (disabledMore) return cur
+      return [...cur, mmdd]
+    })
+  }
+
+  const save = async () => {
+    setError(null)
+    if (countSelected !== amount) {
+      setError(`Select exactly ${amount} ${period === 'week' ? 'day(s) per week' : period === 'month' ? 'day(s) per month' : 'date(s) per year'}`)
+      return
+    }
+    setSaving(true)
+    try {
+      const selection: ScheduleSelection = {}
+      if (period === 'week') selection.weeklyDays = weeklyDays.sort((a, b) => a - b)
+      if (period === 'month') selection.monthlyDays = monthlyDays.sort((a, b) => a - b)
+      if (period === 'year') selection.yearlyDays = [...yearlyDays].sort()
+      await onSave(selection)
+      onOpenChange(false)
+    } catch (e: any) {
+      setError(e?.message || 'Failed to save schedule')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="rounded-2xl max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>Pick your watering schedule</DialogTitle>
+          <DialogDescription>
+            {period === 'week' && `${amount} time(s) per week`}
+            {period === 'month' && `${amount} time(s) per month`}
+            {period === 'year' && `${amount} time(s) per year`}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="text-sm opacity-70">Selected: {countSelected} / {amount}</div>
+
+          {period === 'week' && (
+            <WeekPicker selected={weeklyDays} onToggle={toggleWeekday} disabledMore={disabledMore} />
+          )}
+
+          {period === 'month' && (
+            <MonthPicker selected={monthlyDays} onToggle={toggleMonthDay} disabledMore={disabledMore} />
+          )}
+
+          {period === 'year' && (
+            <YearPicker selected={yearlyDays} onToggle={toggleYearDay} disabledMore={disabledMore} />
+          )}
+
+          {error && <div className="text-sm text-red-600">{error}</div>}
+
+          <div className="flex justify-end gap-2 pt-2">
+            <Button variant="secondary" className="rounded-2xl" onClick={() => onOpenChange(false)} disabled={saving}>Cancel</Button>
+            <Button className="rounded-2xl" onClick={save} disabled={saving || countSelected !== amount}>{saving ? 'Saving…' : 'Save schedule'}</Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function WeekPicker({ selected, onToggle, disabledMore }: { selected: number[]; onToggle: (d: number) => void; disabledMore: boolean }) {
+  const days = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat']
+  return (
+    <div className="grid grid-cols-7 gap-2">
+      {days.map((label, idx) => {
+        const isOn = selected.includes(idx)
+        return (
+          <button
+            key={idx}
+            type="button"
+            onClick={() => onToggle(idx)}
+            className={`h-12 rounded-xl border text-sm ${isOn ? 'bg-black text-white' : 'bg-white hover:bg-stone-50'} ${!isOn && disabledMore ? 'opacity-60 cursor-not-allowed' : ''}`}
+            disabled={!isOn && disabledMore}
+          >
+            {label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+function MonthPicker({ selected, onToggle, disabledMore }: { selected: number[]; onToggle: (d: number) => void; disabledMore: boolean }) {
+  const days = Array.from({ length: 31 }, (_, i) => i + 1)
+  return (
+    <div className="grid grid-cols-7 gap-2">
+      {days.map((d) => {
+        const isOn = selected.includes(d)
+        return (
+          <button
+            key={d}
+            type="button"
+            onClick={() => onToggle(d)}
+            className={`h-10 rounded-xl border text-sm ${isOn ? 'bg-black text-white' : 'bg-white hover:bg-stone-50'} ${!isOn && disabledMore ? 'opacity-60 cursor-not-allowed' : ''}`}
+            disabled={!isOn && disabledMore}
+          >
+            {d}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+function YearPicker({ selected, onToggle, disabledMore }: { selected: string[]; onToggle: (mmdd: string) => void; disabledMore: boolean }) {
+  const months = [
+    ['Jan', 31], ['Feb', 29], ['Mar', 31], ['Apr', 30], ['May', 31], ['Jun', 30],
+    ['Jul', 31], ['Aug', 31], ['Sep', 30], ['Oct', 31], ['Nov', 30], ['Dec', 31],
+  ] as Array<[string, number]>
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-3 max-h-[60vh] overflow-auto pr-1">
+      {months.map(([label, count], monthIdx) => (
+        <div key={label} className="rounded-xl border p-2">
+          <div className="text-xs opacity-70 mb-2">{label}</div>
+          <div className="grid grid-cols-7 gap-1">
+            {Array.from({ length: count }, (_, i) => i + 1).map((d) => {
+              const mm = String(monthIdx + 1).padStart(2, '0')
+              const dd = String(d).padStart(2, '0')
+              const mmdd = `${mm}-${dd}`
+              const isOn = selected.includes(mmdd)
+              return (
+                <button
+                  key={mmdd}
+                  type="button"
+                  onClick={() => onToggle(mmdd)}
+                  className={`h-9 rounded-lg border text-[11px] ${isOn ? 'bg-black text-white' : 'bg-white hover:bg-stone-50'} ${!isOn && disabledMore ? 'opacity-60 cursor-not-allowed' : ''}`}
+                  disabled={!isOn && disabledMore}
+                >
+                  {d}
+                </button>
+              )
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+

--- a/plant-swipe/src/lib/gardens.ts
+++ b/plant-swipe/src/lib/gardens.ts
@@ -77,7 +77,7 @@ export async function getGardenPlants(gardenId: string): Promise<Array<GardenPla
   const plantIds = Array.from(new Set(rows.map(r => r.plant_id)))
   const { data: plantRows } = await supabase
     .from('plants')
-    .select('id, name, scientific_name, colors, seasons, rarity, meaning, description, image_url, care_sunlight, care_water, care_soil, care_difficulty, seeds_available')
+    .select('id, name, scientific_name, colors, seasons, rarity, meaning, description, image_url, care_sunlight, care_water, care_soil, care_difficulty, seeds_available, water_freq_unit, water_freq_value, water_freq_period, water_freq_amount')
     .in('id', plantIds)
   const idToPlant: Record<string, Plant> = {}
   for (const p of plantRows || []) {
@@ -98,6 +98,10 @@ export async function getGardenPlants(gardenId: string): Promise<Array<GardenPla
         difficulty: p.care_difficulty || 'Easy',
       },
       seedsAvailable: Boolean(p.seeds_available ?? false),
+      waterFreqUnit: p.water_freq_unit || undefined,
+      waterFreqValue: p.water_freq_value ?? null,
+      waterFreqPeriod: p.water_freq_period || undefined,
+      waterFreqAmount: p.water_freq_amount ?? null,
     }
   }
   return rows.map(r => ({
@@ -383,5 +387,20 @@ export async function adjustInventoryAndLogTransaction(params: { gardenId: strin
     .from('garden_transactions')
     .insert({ garden_id: gardenId, plant_id: plantId, type: transactionType, quantity: qty, occurred_at: new Date().toISOString(), notes })
   if (tErr) throw new Error(tErr.message)
+}
+
+export async function upsertGardenPlantSchedule(params: { gardenPlantId: string; period: 'week' | 'month' | 'year'; amount: number; weeklyDays?: number[] | null; monthlyDays?: number[] | null; yearlyDays?: string[] | null }): Promise<void> {
+  const { gardenPlantId, period, amount, weeklyDays = null, monthlyDays = null, yearlyDays = null } = params
+  const { error } = await supabase
+    .from('garden_plant_schedule')
+    .upsert({
+      garden_plant_id: gardenPlantId,
+      period,
+      amount,
+      weekly_days: weeklyDays,
+      monthly_days: monthlyDays,
+      yearly_days: yearlyDays,
+    }, { onConflict: 'garden_plant_id' })
+  if (error) throw new Error(error.message)
 }
 

--- a/plant-swipe/src/types/plant.ts
+++ b/plant-swipe/src/types/plant.ts
@@ -15,4 +15,9 @@ export interface Plant {
     difficulty: "Easy" | "Moderate" | "Hard"
   }
   seedsAvailable: boolean
+  // Optional frequency hints from plants table
+  waterFreqUnit?: 'day' | 'week' | 'month' | 'year'
+  waterFreqValue?: number | null
+  waterFreqPeriod?: 'week' | 'month' | 'year'
+  waterFreqAmount?: number | null
 }


### PR DESCRIPTION
Add a schedule picker dialog to the 'Add Plant' flow, allowing users to define watering schedules based on the plant's default frequency.

---
<a href="https://cursor.com/background-agent?bcId=bc-2d046562-be2e-4ea7-8027-b37ff6fed3eb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2d046562-be2e-4ea7-8027-b37ff6fed3eb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

