### PR TITLE
Enforce database frequency and update month selection

### DIFF
--- a/plant-swipe/src/components/plant/SchedulePickerDialog.tsx
+++ b/plant-swipe/src/components/plant/SchedulePickerDialog.tsx
@@ -210,12 +210,18 @@ export function SchedulePickerDialog(props: {
             {(!lockToYear && period === 'month') && 'Max 4 per month (otherwise use week).'}
             {(lockToYear || period === 'year') && 'Max 12 per year (otherwise use month).'}
           </div>
+          {allowedPeriods && allowedPeriods.length === 1 && (
+            <div className="text-[11px] opacity-60">Frequency period is enforced by the plant. You can change the amount.</div>
+          )}
 
           {(!lockToYear && period === 'week') && (
             <WeekPicker selectedNumbers={weeklyDays} onToggleNumber={toggleWeekdayUIIndex} disabledMore={disabledMore} />
           )}
           {period === 'month' && (
-            <MonthNthWeekdayPicker selected={monthlyNthWeekdays} onToggle={toggleMonthlyNthWeekday} onToggleHeader={toggleMonthlyNthWeekdayColumn} disabledMore={disabledMore} />
+            <>
+              <div className="text-xs opacity-70">Pick weeks (1–4) and weekdays. Example: 1st Mon.</div>
+              <MonthNthWeekdayPicker selected={monthlyNthWeekdays} onToggle={toggleMonthlyNthWeekday} onToggleHeader={toggleMonthlyNthWeekdayColumn} disabledMore={disabledMore} />
+            </>
           )}
 
           {(lockToYear || period === 'year') && (

--- a/plant-swipe/src/pages/GardenDashboardPage.tsx
+++ b/plant-swipe/src/pages/GardenDashboardPage.tsx
@@ -285,17 +285,16 @@ export const GardenDashboardPage: React.FC = () => {
       setAddOpen(false)
       setSelectedPlant(null)
       setPlantQuery('')
-      // Enforce allowed schedule to week/month, keep amount editable
+      // Enforce DB frequency period exactly (week, month, or year) while allowing amount changes
       const recommended = (selectedPlant.waterFreqPeriod || (selectedPlant.waterFreqUnit as any)) as 'week'|'month'|'year' | undefined
-      const mapped = recommended === 'year' ? 'week' : (recommended as any)
-      const defaultPeriod = (mapped && ['week','month'].includes(mapped)) ? mapped : 'week'
+      const defaultPeriod = (recommended && ['week','month','year'].includes(recommended)) ? recommended : 'week'
       const defaultAmount = Number(selectedPlant.waterFreqAmount ?? selectedPlant.waterFreqValue ?? 1) || 1
       setPendingGardenPlantId(gp.id)
       setPendingPeriod(defaultPeriod as any)
       setPendingAmount(defaultAmount > 0 ? defaultAmount : 1)
       setInitialSelectionState(undefined)
       setScheduleLockYear(false)
-      setScheduleAllowedPeriods(['week','month'])
+      setScheduleAllowedPeriods([defaultPeriod as any])
       setScheduleOpen(true)
     } catch (e: any) {
       setError(e?.message || 'Failed to add plant')


### PR DESCRIPTION
Enforce plant's database frequency period during garden addition and add guidance for monthly scheduling.

---
<a href="https://cursor.com/background-agent?bcId=bc-d0ee63e6-be7b-4c2f-8753-c3420758a4f4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d0ee63e6-be7b-4c2f-8753-c3420758a4f4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

