### PR TITLE
Fix garden user admin addition

### DIFF
--- a/plant-swipe/src/lib/gardens.ts
+++ b/plant-swipe/src/lib/gardens.ts
@@ -205,6 +205,26 @@ export async function addGardenMember(params: { gardenId: string; userId: string
   if (error) throw new Error(error.message)
 }
 
+export async function updateGardenMemberRole(params: { gardenId: string; userId: string; role: 'member' | 'owner' }): Promise<void> {
+  const { gardenId, userId, role } = params
+  const { error } = await supabase
+    .from('garden_members')
+    .update({ role })
+    .eq('garden_id', gardenId)
+    .eq('user_id', userId)
+  if (error) throw new Error(error.message)
+}
+
+export async function removeGardenMember(params: { gardenId: string; userId: string }): Promise<void> {
+  const { gardenId, userId } = params
+  const { error } = await supabase
+    .from('garden_members')
+    .delete()
+    .eq('garden_id', gardenId)
+    .eq('user_id', userId)
+  if (error) throw new Error(error.message)
+}
+
 export async function addMemberByEmail(params: { gardenId: string; email: string; role?: 'member' | 'owner' }): Promise<{ ok: boolean; reason?: string }> {
   const { gardenId, email, role = 'member' } = params
   const { data, error } = await supabase.rpc('get_user_id_by_email', { _email: email })

--- a/plant-swipe/src/pages/GardenDashboardPage.tsx
+++ b/plant-swipe/src/pages/GardenDashboardPage.tsx
@@ -785,7 +785,7 @@ function MemberCard({ member, gardenId, onChanged }: { member: { userId: string;
   const [open, setOpen] = React.useState(false)
   const [busy, setBusy] = React.useState(false)
   const canPromote = member.role !== 'owner'
-  const canRemove = true
+  const canRemove = member.role !== 'owner'
   const doPromote = async () => {
     if (!canPromote || busy) return
     setBusy(true)
@@ -817,7 +817,9 @@ function MemberCard({ member, gardenId, onChanged }: { member: { userId: string;
           <div className="text-xs opacity-60">{member.role}</div>
         </div>
         <div className="relative">
-          <Button variant="secondary" className="rounded-xl px-2" onClick={(e: any) => { e.stopPropagation(); setOpen((o) => !o) }}>⋯</Button>
+          {member.role !== 'owner' && (
+            <Button variant="secondary" className="rounded-xl px-2" onClick={(e: any) => { e.stopPropagation(); setOpen((o) => !o) }}>⋯</Button>
+          )}
           {open && (
             <div className="absolute right-0 mt-2 w-44 bg-white border rounded-xl shadow-lg z-10">
               <button disabled={!canPromote || busy} onClick={(e) => { e.stopPropagation(); doPromote() }} className={`w-full text-left px-3 py-2 rounded-t-xl hover:bg-stone-50 ${!canPromote ? 'opacity-60 cursor-not-allowed' : ''}`}>Promote to owner</button>

--- a/plant-swipe/src/pages/GardenDashboardPage.tsx
+++ b/plant-swipe/src/pages/GardenDashboardPage.tsx
@@ -4,6 +4,7 @@ import { useParams } from 'react-router-dom'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { SchedulePickerDialog } from '@/components/plant/SchedulePickerDialog'
 import type { Garden } from '@/types/garden'
@@ -51,6 +52,7 @@ export const GardenDashboardPage: React.FC = () => {
   const [inviteOpen, setInviteOpen] = React.useState(false)
   const [inviteEmail, setInviteEmail] = React.useState('')
   const [inviteError, setInviteError] = React.useState<string | null>(null)
+  const [inviteAdmin, setInviteAdmin] = React.useState(false)
 
   const load = React.useCallback(async () => {
     if (!id) return
@@ -246,13 +248,14 @@ export const GardenDashboardPage: React.FC = () => {
   const submitInvite = async () => {
     if (!id || !inviteEmail.trim()) return
     setInviteError(null)
-    const res = await addMemberByEmail({ gardenId: id, email: inviteEmail.trim() })
+    const res = await addMemberByEmail({ gardenId: id, email: inviteEmail.trim(), role: inviteAdmin ? 'owner' : 'member' })
     if (!res.ok) {
       setInviteError(res.reason === 'no_account' ? 'No account with this email' : 'Failed to add member')
       return
     }
     setInviteOpen(false)
     setInviteEmail('')
+    setInviteAdmin(false)
     await load()
   }
 
@@ -548,6 +551,10 @@ export const GardenDashboardPage: React.FC = () => {
               </DialogHeader>
               <div className="space-y-3">
                 <Input placeholder="member@email.com" type="email" value={inviteEmail} onChange={(e: React.ChangeEvent<HTMLInputElement>) => setInviteEmail(e.target.value)} />
+                <div className="flex items-center gap-2">
+                  <input id="invite-admin" type="checkbox" checked={inviteAdmin} onChange={(e: React.ChangeEvent<HTMLInputElement>) => setInviteAdmin(e.target.checked)} />
+                  <Label htmlFor="invite-admin">Make admin</Label>
+                </div>
                 {inviteError && <div className="text-sm text-red-600">{inviteError}</div>}
                 <div className="flex justify-end gap-2">
                   <Button variant="secondary" className="rounded-2xl" onClick={() => setInviteOpen(false)}>Cancel</Button>

--- a/plant-swipe/src/pages/GardenDashboardPage.tsx
+++ b/plant-swipe/src/pages/GardenDashboardPage.tsx
@@ -9,7 +9,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/u
 import { SchedulePickerDialog } from '@/components/plant/SchedulePickerDialog'
 import type { Garden } from '@/types/garden'
 import type { Plant } from '@/types/plant'
-import { getGarden, getGardenPlants, getGardenMembers, addMemberByEmail, fetchScheduleForPlants, markGardenPlantWatered, updateGardenPlantFrequency, deleteGardenPlant, reseedSchedule, addPlantToGarden, fetchServerNowISO, upsertGardenTask, getGardenTasks, ensureDailyTasksForGardens, upsertGardenPlantSchedule, getGardenPlantSchedule, getGardenInventory, adjustInventoryAndLogTransaction } from '@/lib/gardens'
+import { getGarden, getGardenPlants, getGardenMembers, addMemberByEmail, fetchScheduleForPlants, markGardenPlantWatered, updateGardenPlantFrequency, deleteGardenPlant, reseedSchedule, addPlantToGarden, fetchServerNowISO, upsertGardenTask, getGardenTasks, ensureDailyTasksForGardens, upsertGardenPlantSchedule, getGardenPlantSchedule, getGardenInventory, adjustInventoryAndLogTransaction, updateGardenMemberRole, removeGardenMember } from '@/lib/gardens'
 import { supabase } from '@/lib/supabaseClient'
 
 
@@ -52,7 +52,6 @@ export const GardenDashboardPage: React.FC = () => {
   const [inviteOpen, setInviteOpen] = React.useState(false)
   const [inviteEmail, setInviteEmail] = React.useState('')
   const [inviteError, setInviteError] = React.useState<string | null>(null)
-  const [inviteAdmin, setInviteAdmin] = React.useState(false)
 
   const load = React.useCallback(async () => {
     if (!id) return
@@ -248,14 +247,13 @@ export const GardenDashboardPage: React.FC = () => {
   const submitInvite = async () => {
     if (!id || !inviteEmail.trim()) return
     setInviteError(null)
-    const res = await addMemberByEmail({ gardenId: id, email: inviteEmail.trim(), role: inviteAdmin ? 'owner' : 'member' })
+    const res = await addMemberByEmail({ gardenId: id, email: inviteEmail.trim(), role: 'member' })
     if (!res.ok) {
       setInviteError(res.reason === 'no_account' ? 'No account with this email' : 'Failed to add member')
       return
     }
     setInviteOpen(false)
     setInviteEmail('')
-    setInviteAdmin(false)
     await load()
   }
 
@@ -465,10 +463,7 @@ export const GardenDashboardPage: React.FC = () => {
                   </div>
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
                     {members.map(m => (
-                      <Card key={m.userId} className="rounded-2xl p-4">
-                        <div className="font-medium">{m.displayName || m.userId}</div>
-                        <div className="text-xs opacity-60">{m.role}</div>
-                      </Card>
+                      <MemberCard key={m.userId} member={m} gardenId={id!} onChanged={load} />
                     ))}
                   </div>
                 </div>
@@ -551,10 +546,6 @@ export const GardenDashboardPage: React.FC = () => {
               </DialogHeader>
               <div className="space-y-3">
                 <Input placeholder="member@email.com" type="email" value={inviteEmail} onChange={(e: React.ChangeEvent<HTMLInputElement>) => setInviteEmail(e.target.value)} />
-                <div className="flex items-center gap-2">
-                  <input id="invite-admin" type="checkbox" checked={inviteAdmin} onChange={(e: React.ChangeEvent<HTMLInputElement>) => setInviteAdmin(e.target.checked)} />
-                  <Label htmlFor="invite-admin">Make admin</Label>
-                </div>
                 {inviteError && <div className="text-sm text-red-600">{inviteError}</div>}
                 <div className="flex justify-end gap-2">
                   <Button variant="secondary" className="rounded-2xl" onClick={() => setInviteOpen(false)}>Cancel</Button>
@@ -787,6 +778,55 @@ function EditPlantButton({ gp, gardenId, onChanged, serverToday }: { gp: any; ga
         </DialogContent>
       </Dialog>
     </>
+  )
+}
+
+function MemberCard({ member, gardenId, onChanged }: { member: { userId: string; displayName?: string | null; role: 'owner' | 'member' }; gardenId: string; onChanged: () => Promise<void> }) {
+  const [open, setOpen] = React.useState(false)
+  const [busy, setBusy] = React.useState(false)
+  const canPromote = member.role !== 'owner'
+  const canRemove = true
+  const doPromote = async () => {
+    if (!canPromote || busy) return
+    setBusy(true)
+    try {
+      await updateGardenMemberRole({ gardenId, userId: member.userId, role: 'owner' })
+      await onChanged()
+    } finally {
+      setBusy(false)
+      setOpen(false)
+    }
+  }
+  const doRemove = async () => {
+    if (busy) return
+    if (!confirm('Remove this member from the garden?')) return
+    setBusy(true)
+    try {
+      await removeGardenMember({ gardenId, userId: member.userId })
+      await onChanged()
+    } finally {
+      setBusy(false)
+      setOpen(false)
+    }
+  }
+  return (
+    <Card className="rounded-2xl p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div className="font-medium">{member.displayName || member.userId}</div>
+          <div className="text-xs opacity-60">{member.role}</div>
+        </div>
+        <div className="relative">
+          <Button variant="secondary" className="rounded-xl px-2" onClick={(e: any) => { e.stopPropagation(); setOpen((o) => !o) }}>⋯</Button>
+          {open && (
+            <div className="absolute right-0 mt-2 w-44 bg-white border rounded-xl shadow-lg z-10">
+              <button disabled={!canPromote || busy} onClick={(e) => { e.stopPropagation(); doPromote() }} className={`w-full text-left px-3 py-2 rounded-t-xl hover:bg-stone-50 ${!canPromote ? 'opacity-60 cursor-not-allowed' : ''}`}>Promote to owner</button>
+              <button disabled={!canRemove || busy} onClick={(e) => { e.stopPropagation(); doRemove() }} className="w-full text-left px-3 py-2 rounded-b-xl hover:bg-stone-50 text-red-600">Remove member</button>
+            </div>
+          )}
+        </div>
+      </div>
+    </Card>
   )
 }
 

--- a/plant-swipe/supabase/gardens_schema.sql
+++ b/plant-swipe/supabase/gardens_schema.sql
@@ -258,6 +258,19 @@ as $$
   select id from auth.users where email ilike _email limit 1;
 $$;
 
+-- Return profiles (id, display_name) for all members of a garden
+create or replace function public.get_profiles_for_garden(_garden_id uuid)
+returns table(user_id uuid, display_name text)
+language sql
+security definer
+set search_path = public
+as $$
+  select p.id as user_id, p.display_name
+  from public.garden_members gm
+  join public.profiles p on p.id = gm.user_id
+  where gm.garden_id = _garden_id;
+$$;
+
 -- Events: members can select/insert
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname = 'public' and tablename = 'garden_plant_events' and policyname = 'gpe_select') then

--- a/plant-swipe/supabase/gardens_schema.sql
+++ b/plant-swipe/supabase/gardens_schema.sql
@@ -179,8 +179,9 @@ do $$ begin
   end if;
   create policy gm_select on public.garden_members for select to authenticated
     using (
-      user_id = auth.uid() or exists (
-        select 1 from public.gardens g where g.id = garden_id and g.created_by = auth.uid()
+      exists (
+        select 1 from public.garden_members gm2
+        where gm2.garden_id = garden_id and gm2.user_id = auth.uid()
       )
     );
 end $$;
@@ -202,9 +203,11 @@ do $$ begin
   end if;
   create policy gm_delete on public.garden_members for delete to authenticated
     using (
-      user_id = auth.uid() or exists (
-        select 1 from public.garden_members gm
-        where gm.garden_id = garden_id and gm.user_id = auth.uid() and gm.role = 'owner'
+      role <> 'owner' and (
+        user_id = auth.uid() or exists (
+          select 1 from public.garden_members gm
+          where gm.garden_id = garden_id and gm.user_id = auth.uid() and gm.role = 'owner'
+        )
       )
     );
 end $$;


### PR DESCRIPTION
Fix user invitation by email, allow any garden owner to manage members, and add an option to invite as admin.

The previous `addMemberByEmail` function incorrectly looked up users by email in the `profiles` table, which doesn't store email, causing invitations to fail. RLS policies also restricted member management to only the garden creator. This PR introduces a secure RPC to resolve users by email from `auth.users`, updates RLS to allow any garden owner to manage members, and adds a UI option to assign the 'owner' role during invitation.

---
<a href="https://cursor.com/background-agent?bcId=bc-d398226c-275d-467b-ba49-744beafdb84f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d398226c-275d-467b-ba49-744beafdb84f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

