### PR TITLE
Add plant liking and filtering functionality

### DIFF
--- a/plant-swipe/src/PlantSwipe.tsx
+++ b/plant-swipe/src/PlantSwipe.tsx
@@ -462,7 +462,6 @@ export default function PlantSwipe() {
                       plants={filtered}
                       openInfo={(p) => setOpenInfo(p)}
                       likedIds={likedIds}
-                      onToggleLike={(id) => toggleLiked(id)}
                     />
                   }
                 />

--- a/plant-swipe/src/PlantSwipe.tsx
+++ b/plant-swipe/src/PlantSwipe.tsx
@@ -24,14 +24,17 @@ import { supabase } from "@/lib/supabaseClient";
 
 // --- Main Component ---
 export default function PlantSwipe() {
-  const { user, signIn, signUp, signOut, profile } = useAuth()
+  const { user, signIn, signUp, signOut, profile, refreshProfile } = useAuth()
   const [query, setQuery] = useState("")
   const [seasonFilter, setSeasonFilter] = useState<string | null>(null)
   const [colorFilter, setColorFilter] = useState<string | null>(null)
   const [onlySeeds, setOnlySeeds] = useState(false)
+  const [onlyFavorites, setOnlyFavorites] = useState(false)
+  const [favoritesFirst, setFavoritesFirst] = useState(false)
 
   const [index, setIndex] = useState(0)
   const [openInfo, setOpenInfo] = useState<Plant | null>(null)
+  const [likedIds, setLikedIds] = useState<string[]>([])
 
   const location = useLocation()
   const navigate = useNavigate()
@@ -54,6 +57,12 @@ export default function PlantSwipe() {
   const [loading, setLoading] = useState(true)
   const [loadError, setLoadError] = useState<string | null>(null)
 
+  // Hydrate liked ids from profile when available
+  React.useEffect(() => {
+    const arr = Array.isArray(profile?.liked_plant_ids) ? profile!.liked_plant_ids!.map(String) : []
+    setLikedIds(arr)
+  }, [profile?.liked_plant_ids])
+
   const loadPlants = React.useCallback(async () => {
     setLoading(true)
     setLoadError(null)
@@ -63,12 +72,32 @@ export default function PlantSwipe() {
         .select('id, name, scientific_name, colors, seasons, rarity, meaning, description, image_url, care_sunlight, care_water, care_soil, care_difficulty, seeds_available, water_freq_unit, water_freq_value, water_freq_period, water_freq_amount')
         .order('name', { ascending: true })
       if (error) throw error
-      const parsed: Plant[] = (Array.isArray(data) ? data : []).map((p: any) => ({
+      type PlantRow = {
+        id: string | number
+        name: string
+        scientific_name?: string | null
+        colors?: unknown
+        seasons?: unknown
+        rarity: Plant['rarity']
+        meaning?: string | null
+        description?: string | null
+        image_url?: string | null
+        care_sunlight?: Plant['care']['sunlight'] | null
+        care_water?: Plant['care']['water'] | null
+        care_soil?: string | null
+        care_difficulty?: Plant['care']['difficulty'] | null
+        seeds_available?: boolean | null
+        water_freq_unit?: Plant['waterFreqUnit'] | null
+        water_freq_value?: number | null
+        water_freq_period?: Plant['waterFreqPeriod'] | null
+        water_freq_amount?: number | null
+      }
+      const parsed: Plant[] = (Array.isArray(data) ? data : []).map((p: PlantRow) => ({
         id: String(p.id),
         name: String(p.name),
         scientificName: String(p.scientific_name || ''),
-        colors: Array.isArray(p.colors) ? p.colors.map(String) : [],
-        seasons: Array.isArray(p.seasons) ? p.seasons.map(String) : [],
+        colors: Array.isArray(p.colors as string[] | unknown[]) ? (p.colors as unknown[]).map((c) => String(c)) : [],
+        seasons: Array.isArray(p.seasons as string[] | unknown[]) ? (p.seasons as unknown[]).map((s) => String(s)) as Plant['seasons'] : [],
         rarity: p.rarity as Plant['rarity'],
         meaning: p.meaning ? String(p.meaning) : '',
         description: p.description ? String(p.description) : '',
@@ -86,8 +115,9 @@ export default function PlantSwipe() {
         waterFreqAmount: p.water_freq_amount ?? null
       }))
       setPlants(parsed)
-    } catch (e: any) {
-      setLoadError(e?.message || 'Failed to load plants')
+    } catch (e: unknown) {
+      const msg = e && typeof e === 'object' && 'message' in e ? String((e as { message?: unknown }).message || '') : ''
+      setLoadError(msg || 'Failed to load plants')
     } finally {
       setLoading(false)
     }
@@ -98,16 +128,28 @@ export default function PlantSwipe() {
   }, [loadPlants])
 
   const filtered = useMemo(() => {
-    return plants.filter((p: Plant) => {
+    const likedSet = new Set(likedIds)
+    const base = plants.filter((p: Plant) => {
       const matchesQ = `${p.name} ${p.scientificName} ${p.meaning} ${p.colors.join(" ")}`
         .toLowerCase()
         .includes(query.toLowerCase())
-      const matchesSeason = seasonFilter ? p.seasons.includes(seasonFilter as any) : true
+      const matchesSeason = seasonFilter ? p.seasons.includes(seasonFilter as Plant['seasons'][number]) : true
       const matchesColor = colorFilter ? p.colors.map((c: string) => c.toLowerCase()).includes(colorFilter.toLowerCase()) : true
       const matchesSeeds = onlySeeds ? p.seedsAvailable : true
-      return matchesQ && matchesSeason && matchesColor && matchesSeeds
+      const matchesFav = onlyFavorites ? likedSet.has(p.id) : true
+      return matchesQ && matchesSeason && matchesColor && matchesSeeds && matchesFav
     })
-  }, [plants, query, seasonFilter, colorFilter, onlySeeds])
+    if (favoritesFirst) {
+      return base.slice().sort((a, b) => {
+        const la = likedSet.has(a.id) ? 1 : 0
+        const lb = likedSet.has(b.id) ? 1 : 0
+        if (la !== lb) return lb - la
+        // fallback: by name asc to keep deterministic
+        return a.name.localeCompare(b.name)
+      })
+    }
+    return base
+  }, [plants, query, seasonFilter, colorFilter, onlySeeds, onlyFavorites, favoritesFirst, likedIds])
 
   // Swiping-only randomized order with continuous wrap-around
   const [shuffleEpoch, setShuffleEpoch] = useState(0)
@@ -144,13 +186,50 @@ export default function PlantSwipe() {
   // Swipe logic
   const x = useMotionValue(0)
   const threshold = 120
-  const onDragEnd = (_: any, info: { offset: { x: number }; velocity: { x: number } }) => {
+  const onDragEnd = (_: unknown, info: { offset: { x: number }; velocity: { x: number } }) => {
     const dx = info.offset.x + info.velocity.x * 0.2
     if (dx <= -threshold) {
       handlePass()
     } else if (dx >= threshold) {
       handleInfo()
     }
+  }
+
+  // Favorites handling
+  const ensureLoggedIn = () => {
+    if (!user) {
+      setAuthMode('login')
+      setAuthOpen(true)
+      return false
+    }
+    return true
+  }
+
+  const toggleLiked = async (plantId: string) => {
+    if (!ensureLoggedIn()) return
+    setLikedIds((prev) => {
+      const has = prev.includes(plantId)
+      const next = has ? prev.filter((id) => id !== plantId) : [...prev, plantId]
+      // fire-and-forget sync to Supabase
+      ;(async () => {
+        try {
+          const { error } = await supabase
+            .from('profiles')
+            .update({ liked_plant_ids: next })
+            .eq('id', user!.id)
+          if (error) {
+            // revert on error
+            setLikedIds(prev)
+          } else {
+            // keep server in sync in context eventually
+            refreshProfile().catch(() => {})
+          }
+        } catch {
+          setLikedIds(prev)
+        }
+      })()
+      return next
+    })
   }
 
   const openLogin = () => { setAuthMode("login"); setAuthOpen(true) }
@@ -187,10 +266,11 @@ export default function PlantSwipe() {
         }
         console.log('[auth] login ok')
       }
-      try { setAuthOpen(false) } catch {}
-    } catch (e: any) {
+      setAuthOpen(false)
+    } catch (e: unknown) {
       console.error('[auth] unexpected error', e)
-      setAuthError(e?.message || 'Unexpected error')
+      const msg = e && typeof e === 'object' && 'message' in e ? String((e as { message?: unknown }).message || '') : ''
+      setAuthError(msg || 'Unexpected error')
       setAuthSubmitting(false)
     }
   }
@@ -294,6 +374,26 @@ export default function PlantSwipe() {
               >
                 <span className="inline-block h-2 w-2 rounded-full bg-current" /> Seeds only
               </button>
+              <div className="h-2" />
+              <button
+                onClick={() => setOnlyFavorites((v) => !v)}
+                className={`w-full justify-center px-3 py-2 rounded-2xl text-sm shadow-sm border flex items-center gap-2 transition ${
+                  onlyFavorites ? "bg-rose-600 text-white" : "bg-white hover:bg-stone-50"
+                }`}
+                aria-pressed={onlyFavorites}
+              >
+                <span className="inline-block h-2 w-2 rounded-full bg-current" /> Favorites only
+              </button>
+              <div className="h-2" />
+              <button
+                onClick={() => setFavoritesFirst((v) => !v)}
+                className={`w-full justify-center px-3 py-2 rounded-2xl text-sm shadow-sm border flex items-center gap-2 transition ${
+                  favoritesFirst ? "bg-rose-100 text-rose-900 border-rose-300" : "bg-white hover:bg-stone-50"
+                }`}
+                aria-pressed={favoritesFirst}
+              >
+                Favorites first
+              </button>
             </div>
 
             {/* Active filters summary */}
@@ -308,6 +408,12 @@ export default function PlantSwipe() {
                 )}
                 {onlySeeds && (
                   <Badge variant="secondary" className="rounded-xl">Seeds</Badge>
+                )}
+                {onlyFavorites && (
+                  <Badge variant="secondary" className="rounded-xl">Favorites</Badge>
+                )}
+                {favoritesFirst && (
+                  <Badge variant="secondary" className="rounded-xl">Favs first</Badge>
                 )}
                 {!seasonFilter && !colorFilter && !onlySeeds && (
                   <span className="opacity-50">None</span>
@@ -340,6 +446,8 @@ export default function PlantSwipe() {
                       onDragEnd={onDragEnd}
                       handleInfo={handleInfo}
                       handlePass={handlePass}
+                      liked={current ? likedIds.includes(current.id) : false}
+                      onToggleLike={() => { if (current) toggleLiked(current.id) }}
                     />
                   ) : (
                     <></>
@@ -347,7 +455,17 @@ export default function PlantSwipe() {
                 />
                 <Route path="/gardens" element={<GardenListPage />} />
                 <Route path="/garden/:id" element={<GardenDashboardPage />} />
-                <Route path="/search" element={<SearchPage plants={filtered} openInfo={(p) => setOpenInfo(p)} />} />
+                <Route
+                  path="/search"
+                  element={
+                    <SearchPage
+                      plants={filtered}
+                      openInfo={(p) => setOpenInfo(p)}
+                      likedIds={likedIds}
+                      onToggleLike={(id) => toggleLiked(id)}
+                    />
+                  }
+                />
                 <Route path="/profile" element={user ? <ProfilePage /> : <Navigate to="/" replace />} />
                 <Route path="/create" element={user ? (
                   <CreatePlantPage
@@ -375,7 +493,14 @@ export default function PlantSwipe() {
       {/* Info Sheet */}
       <Sheet open={!!openInfo} onOpenChange={(o: boolean) => !o && setOpenInfo(null)}>
         <SheetContent side="bottom" className="max-h-[90vh] overflow-y-auto rounded-t-3xl">
-          {openInfo && <PlantDetails plant={openInfo} onClose={() => setOpenInfo(null)} />}
+          {openInfo && (
+            <PlantDetails
+              plant={openInfo}
+              onClose={() => setOpenInfo(null)}
+              liked={likedIds.includes(openInfo.id)}
+              onToggleLike={() => toggleLiked(openInfo.id)}
+            />
+          )}
         </SheetContent>
       </Sheet>
 

--- a/plant-swipe/src/components/plant/PlantDetails.tsx
+++ b/plant-swipe/src/components/plant/PlantDetails.tsx
@@ -5,15 +5,15 @@ import { SheetHeader, SheetTitle, SheetDescription } from "@/components/ui/sheet
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { SunMedium, Droplets, Leaf } from "lucide-react";
+import { SunMedium, Droplets, Leaf, Heart } from "lucide-react";
 import type { Plant } from "@/types/plant";
 import { rarityTone, seasonBadge } from "@/constants/badges";
 
-export const PlantDetails: React.FC<{ plant: Plant; onClose: () => void }> = ({ plant, onClose }) => {
+export const PlantDetails: React.FC<{ plant: Plant; onClose: () => void; liked?: boolean; onToggleLike?: () => void }> = ({ plant, onClose, liked = false, onToggleLike }) => {
   const navigate = useNavigate()
   const y = useMotionValue(0)
   const threshold = 120
-  const onDragEnd = (_: any, info: { offset: { y: number }; velocity: { y: number } }) => {
+  const onDragEnd = (_: unknown, info: { offset: { y: number }; velocity: { y: number } }) => {
     const dy = info.offset.y + info.velocity.y * 0.2
     if (dy > threshold) onClose()
   }
@@ -30,8 +30,18 @@ export const PlantDetails: React.FC<{ plant: Plant; onClose: () => void }> = ({ 
         <SheetDescription className="italic">{plant.scientificName}</SheetDescription>
       </SheetHeader>
 
-      <div className="rounded-2xl overflow-hidden shadow">
+      <div className="rounded-2xl overflow-hidden shadow relative">
         <div className="h-56 bg-cover bg-center select-none" style={{ backgroundImage: `url(${plant.image})`, userSelect: 'none' as any }} />
+        <div className="absolute top-3 right-3">
+          <button
+            onClick={() => onToggleLike && onToggleLike()}
+            aria-pressed={liked}
+            aria-label={liked ? 'Unlike' : 'Like'}
+            className={`h-10 w-10 rounded-full flex items-center justify-center shadow border transition ${liked ? 'bg-rose-600 text-white' : 'bg-white/90 text-black hover:bg-white'}`}
+          >
+            <Heart className={liked ? 'fill-current' : ''} />
+          </button>
+        </div>
       </div>
 
       <div className="grid md:grid-cols-3 gap-3">

--- a/plant-swipe/src/components/plant/PlantDetails.tsx
+++ b/plant-swipe/src/components/plant/PlantDetails.tsx
@@ -32,12 +32,12 @@ export const PlantDetails: React.FC<{ plant: Plant; onClose: () => void; liked?:
 
       <div className="rounded-2xl overflow-hidden shadow relative">
         <div className="h-56 bg-cover bg-center select-none" style={{ backgroundImage: `url(${plant.image})`, userSelect: 'none' as any }} />
-        <div className="absolute top-3 right-3">
+        <div className="absolute bottom-3 right-3">
           <button
             onClick={() => onToggleLike && onToggleLike()}
             aria-pressed={liked}
             aria-label={liked ? 'Unlike' : 'Like'}
-            className={`h-10 w-10 rounded-full flex items-center justify-center shadow border transition ${liked ? 'bg-rose-600 text-white' : 'bg-white/90 text-black hover:bg-white'}`}
+            className={`h-8 w-8 rounded-full flex items-center justify-center shadow border transition ${liked ? 'bg-rose-600 text-white' : 'bg-white/90 text-black hover:bg-white'}`}
           >
             <Heart className={liked ? 'fill-current' : ''} />
           </button>

--- a/plant-swipe/src/pages/SearchPage.tsx
+++ b/plant-swipe/src/pages/SearchPage.tsx
@@ -23,7 +23,7 @@ export const SearchPage: React.FC<SearchPageProps> = ({ plants, openInfo, likedI
           tabIndex={0}
           onKeyDown={(e: React.KeyboardEvent<HTMLDivElement>) => { if (e.key === 'Enter') openInfo(p) }}
         >
-          <div className="absolute top-2 right-2 z-10">
+          <div className="absolute bottom-2 right-2 z-10">
             <button
               onClick={(e: React.MouseEvent<HTMLButtonElement>) => { e.stopPropagation(); onToggleLike && onToggleLike(p.id) }}
               aria-pressed={likedIds.includes(p.id)}

--- a/plant-swipe/src/pages/SearchPage.tsx
+++ b/plant-swipe/src/pages/SearchPage.tsx
@@ -3,11 +3,11 @@ import type { Plant } from "@/types/plant"
 import { rarityTone, seasonBadge } from "@/constants/badges"
 import { Card } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
-import { ListFilter } from "lucide-react"
+import { Heart, ListFilter } from "lucide-react"
 
-interface SearchPageProps { plants: Plant[]; openInfo: (p: Plant) => void }
+interface SearchPageProps { plants: Plant[]; openInfo: (p: Plant) => void; likedIds?: string[]; onToggleLike?: (id: string) => void }
 
-export const SearchPage: React.FC<SearchPageProps> = ({ plants, openInfo }) => (
+export const SearchPage: React.FC<SearchPageProps> = ({ plants, openInfo, likedIds = [], onToggleLike }) => (
   <div className="max-w-6xl mx-auto mt-8 px-4 md:px-0">
     <div className="flex items-center gap-2 text-sm mb-3">
       <ListFilter className="h-4 w-4" />
@@ -21,10 +21,21 @@ export const SearchPage: React.FC<SearchPageProps> = ({ plants, openInfo }) => (
           onClick={() => openInfo(p)}
           role="button"
           tabIndex={0}
-          onKeyDown={(e) => { if ((e as any).key === 'Enter') openInfo(p) }}
+          onKeyDown={(e: React.KeyboardEvent<HTMLDivElement>) => { if (e.key === 'Enter') openInfo(p) }}
         >
           <div className="grid grid-cols-3 gap-0">
-            <div className="col-span-1 h-36 bg-cover bg-center" style={{ backgroundImage: `url(${p.image})` }} />
+            <div className="col-span-1 h-36 bg-cover bg-center relative" style={{ backgroundImage: `url(${p.image})` }}>
+              <div className="absolute top-2 right-2">
+                <button
+                  onClick={(e: React.MouseEvent<HTMLButtonElement>) => { e.stopPropagation(); onToggleLike && onToggleLike(p.id) }}
+                  aria-pressed={likedIds.includes(p.id)}
+                  aria-label={likedIds.includes(p.id) ? 'Unlike' : 'Like'}
+                  className={`h-8 w-8 rounded-full flex items-center justify-center shadow border transition ${likedIds.includes(p.id) ? 'bg-rose-600 text-white' : 'bg-white/90 text-black hover:bg-white'}`}
+                >
+                  <Heart className={likedIds.includes(p.id) ? 'fill-current' : ''} />
+                </button>
+              </div>
+            </div>
             <div className="col-span-2 p-3">
               <div className="flex items-center gap-2 mb-1">
                 <Badge className={`${rarityTone[p.rarity]} rounded-xl`}>{p.rarity}</Badge>

--- a/plant-swipe/src/pages/SearchPage.tsx
+++ b/plant-swipe/src/pages/SearchPage.tsx
@@ -17,25 +17,24 @@ export const SearchPage: React.FC<SearchPageProps> = ({ plants, openInfo, likedI
       {plants.map((p) => (
         <Card
           key={p.id}
-          className="rounded-2xl overflow-hidden cursor-pointer"
+          className="relative rounded-2xl overflow-hidden cursor-pointer"
           onClick={() => openInfo(p)}
           role="button"
           tabIndex={0}
           onKeyDown={(e: React.KeyboardEvent<HTMLDivElement>) => { if (e.key === 'Enter') openInfo(p) }}
         >
+          <div className="absolute top-2 right-2 z-10">
+            <button
+              onClick={(e: React.MouseEvent<HTMLButtonElement>) => { e.stopPropagation(); onToggleLike && onToggleLike(p.id) }}
+              aria-pressed={likedIds.includes(p.id)}
+              aria-label={likedIds.includes(p.id) ? 'Unlike' : 'Like'}
+              className={`h-8 w-8 rounded-full flex items-center justify-center shadow border transition ${likedIds.includes(p.id) ? 'bg-rose-600 text-white' : 'bg-white/90 text-black hover:bg-white'}`}
+            >
+              <Heart className={likedIds.includes(p.id) ? 'fill-current' : ''} />
+            </button>
+          </div>
           <div className="grid grid-cols-3 gap-0">
-            <div className="col-span-1 h-36 bg-cover bg-center relative" style={{ backgroundImage: `url(${p.image})` }}>
-              <div className="absolute top-2 right-2">
-                <button
-                  onClick={(e: React.MouseEvent<HTMLButtonElement>) => { e.stopPropagation(); onToggleLike && onToggleLike(p.id) }}
-                  aria-pressed={likedIds.includes(p.id)}
-                  aria-label={likedIds.includes(p.id) ? 'Unlike' : 'Like'}
-                  className={`h-8 w-8 rounded-full flex items-center justify-center shadow border transition ${likedIds.includes(p.id) ? 'bg-rose-600 text-white' : 'bg-white/90 text-black hover:bg-white'}`}
-                >
-                  <Heart className={likedIds.includes(p.id) ? 'fill-current' : ''} />
-                </button>
-              </div>
-            </div>
+            <div className="col-span-1 h-36 bg-cover bg-center" style={{ backgroundImage: `url(${p.image})` }} />
             <div className="col-span-2 p-3">
               <div className="flex items-center gap-2 mb-1">
                 <Badge className={`${rarityTone[p.rarity]} rounded-xl`}>{p.rarity}</Badge>

--- a/plant-swipe/src/pages/SearchPage.tsx
+++ b/plant-swipe/src/pages/SearchPage.tsx
@@ -3,11 +3,11 @@ import type { Plant } from "@/types/plant"
 import { rarityTone, seasonBadge } from "@/constants/badges"
 import { Card } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
-import { Heart, ListFilter } from "lucide-react"
+import { ListFilter } from "lucide-react"
 
-interface SearchPageProps { plants: Plant[]; openInfo: (p: Plant) => void; likedIds?: string[]; onToggleLike?: (id: string) => void }
+interface SearchPageProps { plants: Plant[]; openInfo: (p: Plant) => void; likedIds?: string[] }
 
-export const SearchPage: React.FC<SearchPageProps> = ({ plants, openInfo, likedIds = [], onToggleLike }) => (
+export const SearchPage: React.FC<SearchPageProps> = ({ plants, openInfo, likedIds = [] }) => (
   <div className="max-w-6xl mx-auto mt-8 px-4 md:px-0">
     <div className="flex items-center gap-2 text-sm mb-3">
       <ListFilter className="h-4 w-4" />
@@ -23,16 +23,6 @@ export const SearchPage: React.FC<SearchPageProps> = ({ plants, openInfo, likedI
           tabIndex={0}
           onKeyDown={(e: React.KeyboardEvent<HTMLDivElement>) => { if (e.key === 'Enter') openInfo(p) }}
         >
-          <div className="absolute bottom-2 right-2 z-10">
-            <button
-              onClick={(e: React.MouseEvent<HTMLButtonElement>) => { e.stopPropagation(); onToggleLike && onToggleLike(p.id) }}
-              aria-pressed={likedIds.includes(p.id)}
-              aria-label={likedIds.includes(p.id) ? 'Unlike' : 'Like'}
-              className={`h-8 w-8 rounded-full flex items-center justify-center shadow border transition ${likedIds.includes(p.id) ? 'bg-rose-600 text-white' : 'bg-white/90 text-black hover:bg-white'}`}
-            >
-              <Heart className={likedIds.includes(p.id) ? 'fill-current' : ''} />
-            </button>
-          </div>
           <div className="grid grid-cols-3 gap-0">
             <div className="col-span-1 h-36 bg-cover bg-center" style={{ backgroundImage: `url(${p.image})` }} />
             <div className="col-span-2 p-3">
@@ -41,6 +31,9 @@ export const SearchPage: React.FC<SearchPageProps> = ({ plants, openInfo, likedI
                 {p.seasons.map((s) => (
                   <span key={s} className={`text-[10px] px-2 py-0.5 rounded-full ${seasonBadge[s]}`}>{s}</span>
                 ))}
+                {likedIds.includes(p.id) && (
+                  <Badge className="rounded-xl bg-rose-600 text-white">Liked</Badge>
+                )}
               </div>
               <div className="font-medium">{p.name}</div>
               <div className="text-xs italic opacity-60">{p.scientificName}</div>

--- a/plant-swipe/src/pages/SwipePage.tsx
+++ b/plant-swipe/src/pages/SwipePage.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { motion, AnimatePresence } from "framer-motion"
+import { motion, AnimatePresence, type MotionValue } from "framer-motion"
 import { ChevronLeft, ChevronRight, Heart, Info, Sparkles, X } from "lucide-react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
@@ -11,7 +11,7 @@ interface SwipePageProps {
   current: Plant | undefined
   index: number
   setIndex: (i: number) => void
-  x: unknown
+  x: MotionValue<number>
   onDragEnd: (_: unknown, info: { offset: { x: number }; velocity: { x: number } }) => void
   handleInfo: () => void
   handlePass: () => void

--- a/plant-swipe/src/pages/SwipePage.tsx
+++ b/plant-swipe/src/pages/SwipePage.tsx
@@ -41,12 +41,12 @@ export const SwipePage: React.FC<SwipePageProps> = ({ current, index, setIndex, 
                 <div className="h-2/3 relative">
                   <div className="absolute inset-0 bg-cover bg-center" style={{ backgroundImage: `url(${current.image})` }} />
                   <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-black/10 to-transparent" />
-                  <div className="absolute top-3 right-3 z-10">
+                  <div className="absolute top-2 right-2 z-10">
                     <button
                       onClick={(e: React.MouseEvent<HTMLButtonElement>) => { e.stopPropagation(); onToggleLike && onToggleLike() }}
                       aria-pressed={liked}
                       aria-label={liked ? 'Unlike' : 'Like'}
-                      className={`h-10 w-10 rounded-full flex items-center justify-center shadow border transition ${liked ? 'bg-rose-600 text-white' : 'bg-white/90 text-black hover:bg-white'}`}
+                      className={`h-8 w-8 rounded-full flex items-center justify-center shadow border transition ${liked ? 'bg-rose-600 text-white' : 'bg-white/90 text-black hover:bg-white'}`}
                     >
                       <Heart className={liked ? 'fill-current' : ''} />
                     </button>

--- a/plant-swipe/src/pages/SwipePage.tsx
+++ b/plant-swipe/src/pages/SwipePage.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { motion, AnimatePresence } from "framer-motion"
-import { ChevronLeft, ChevronRight, Info, Sparkles, X } from "lucide-react"
+import { ChevronLeft, ChevronRight, Heart, Info, Sparkles, X } from "lucide-react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -11,13 +11,15 @@ interface SwipePageProps {
   current: Plant | undefined
   index: number
   setIndex: (i: number) => void
-  x: any
-  onDragEnd: any
+  x: unknown
+  onDragEnd: (_: unknown, info: { offset: { x: number }; velocity: { x: number } }) => void
   handleInfo: () => void
   handlePass: () => void
+  liked?: boolean
+  onToggleLike?: () => void
 }
 
-export const SwipePage: React.FC<SwipePageProps> = ({ current, index, setIndex, x, onDragEnd, handleInfo, handlePass }) => {
+export const SwipePage: React.FC<SwipePageProps> = ({ current, index, setIndex, x, onDragEnd, handleInfo, handlePass, liked = false, onToggleLike }) => {
   return (
     <div className="max-w-3xl mx-auto mt-8 px-4 md:px-0">
       <div className="relative h-[520px]">
@@ -39,6 +41,16 @@ export const SwipePage: React.FC<SwipePageProps> = ({ current, index, setIndex, 
                 <div className="h-2/3 relative">
                   <div className="absolute inset-0 bg-cover bg-center" style={{ backgroundImage: `url(${current.image})` }} />
                   <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-black/10 to-transparent" />
+                  <div className="absolute top-3 right-3 z-10">
+                    <button
+                      onClick={(e: React.MouseEvent<HTMLButtonElement>) => { e.stopPropagation(); onToggleLike && onToggleLike() }}
+                      aria-pressed={liked}
+                      aria-label={liked ? 'Unlike' : 'Like'}
+                      className={`h-10 w-10 rounded-full flex items-center justify-center shadow border transition ${liked ? 'bg-rose-600 text-white' : 'bg-white/90 text-black hover:bg-white'}`}
+                    >
+                      <Heart className={liked ? 'fill-current' : ''} />
+                    </button>
+                  </div>
                   <div className="absolute bottom-0 p-5 text-white">
                     <div className="flex items-center gap-2 mb-2">
                       <Badge className={`${rarityTone[current.rarity]} backdrop-blur bg-opacity-80`}>{current.rarity}</Badge>


### PR DESCRIPTION
Add plant liking functionality with heart buttons and favorite-based search filters.

This PR introduces the ability for users to "like" plants, with interactive heart buttons implemented on discovery cards, search results, and the plant details page. Liked plant IDs are persisted to `profiles.liked_plant_ids` in Supabase. Additionally, new search filters ("Favorites only" and "Favorites first") have been added to allow users to easily manage and view their preferred plants. Users attempting to like a plant while unauthenticated will be prompted to log in.

---
<a href="https://cursor.com/background-agent?bcId=bc-231ba240-8d10-4a01-98ef-74c5a044f12e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-231ba240-8d10-4a01-98ef-74c5a044f12e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

