### PR TITLE
Update water frequency display logic

### DIFF
--- a/plant-swipe/src/components/plant/PlantDetails.tsx
+++ b/plant-swipe/src/components/plant/PlantDetails.tsx
@@ -8,6 +8,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { SunMedium, Droplets, Leaf } from "lucide-react";
 import type { Plant } from "@/types/plant";
 import { rarityTone, seasonBadge } from "@/constants/badges";
+import { deriveWaterLevelFromFrequency } from "@/lib/utils";
 
 export const PlantDetails: React.FC<{ plant: Plant; onClose: () => void }> = ({ plant, onClose }) => {
   const navigate = useNavigate()
@@ -20,6 +21,7 @@ export const PlantDetails: React.FC<{ plant: Plant; onClose: () => void }> = ({ 
   const freqAmountRaw = plant.waterFreqAmount ?? plant.waterFreqValue
   const freqAmount = typeof freqAmountRaw === 'number' ? freqAmountRaw : Number(freqAmountRaw || 0)
   const freqPeriod = (plant.waterFreqPeriod || plant.waterFreqUnit) as 'day' | 'week' | 'month' | 'year' | undefined
+  const derivedWater = deriveWaterLevelFromFrequency(freqPeriod, freqAmount) || (plant.care.water as any) || 'Low'
   const freqLabel = freqPeriod
     ? `${freqAmount > 0 ? `${freqAmount} ${freqAmount === 1 ? 'time' : 'times'} ` : ''}per ${freqPeriod}`
     : null
@@ -36,7 +38,7 @@ export const PlantDetails: React.FC<{ plant: Plant; onClose: () => void }> = ({ 
 
       <div className="grid md:grid-cols-3 gap-3">
         <Fact icon={<SunMedium className="h-4 w-4" />} label="Sunlight" value={plant.care.sunlight} />
-        <Fact icon={<Droplets className="h-4 w-4" />} label="Water" value={plant.care.water} />
+        <Fact icon={<Droplets className="h-4 w-4" />} label="Water" value={derivedWater} />
         <Fact icon={<Leaf className="h-4 w-4" />} label="Difficulty" value={plant.care.difficulty} />
       </div>
 
@@ -71,7 +73,7 @@ export const PlantDetails: React.FC<{ plant: Plant; onClose: () => void }> = ({ 
         </CardHeader>
         <CardContent className="space-y-2 text-sm">
           <div><span className="font-medium">Sunlight:</span> {plant.care.sunlight}</div>
-            <div><span className="font-medium">Water:</span> {plant.care.water}</div>
+            <div><span className="font-medium">Water:</span> {derivedWater}</div>
             {freqLabel && (
               <div>
                 <span className="font-medium">Water frequency:</span>

--- a/plant-swipe/src/lib/utils.ts
+++ b/plant-swipe/src/lib/utils.ts
@@ -20,3 +20,19 @@ export function getEnvAny(names: string[], fallback?: string): string {
   if (fallback !== undefined) return fallback
   throw new Error(`Missing environment variable. Tried: ${names.join(', ')}`)
 }
+
+export function deriveWaterLevelFromFrequency(
+  period?: 'day' | 'week' | 'month' | 'year',
+  amountRaw?: number | null
+): 'Low' | 'Medium' | 'High' | null {
+  if (!period) return null
+  const amount = Number(amountRaw || 0)
+  if (period === 'day') return 'High'
+  if (period === 'week') {
+    if (amount >= 3) return 'High'
+    if (amount === 2) return 'Medium'
+    if (amount <= 1) return 'Low'
+  }
+  if (period === 'month' || period === 'year') return 'Low'
+  return null
+}

--- a/plant-swipe/src/pages/CreatePlantPage.tsx
+++ b/plant-swipe/src/pages/CreatePlantPage.tsx
@@ -43,7 +43,6 @@ export const CreatePlantPage: React.FC<CreatePlantPageProps> = ({ onCancel, onSa
   const [description, setDescription] = React.useState("")
   const [imageUrl, setImageUrl] = React.useState("")
   const [careSunlight, setCareSunlight] = React.useState<Plant["care"]["sunlight"]>("Low")
-  const [careWater, setCareWater] = React.useState<Plant["care"]["water"]>("Low")
   const [careSoil, setCareSoil] = React.useState("")
   const [careDifficulty, setCareDifficulty] = React.useState<Plant["care"]["difficulty"]>("Easy")
   const [seedsAvailable, setSeedsAvailable] = React.useState(false)
@@ -99,7 +98,6 @@ export const CreatePlantPage: React.FC<CreatePlantPageProps> = ({ onCancel, onSa
         description: description || null,
         image_url: imageUrl || null,
         care_sunlight: careSunlight,
-        care_water: careWater,
         care_soil: careSoil,
         care_difficulty: careDifficulty,
         seeds_available: seedsAvailable,
@@ -172,14 +170,7 @@ export const CreatePlantPage: React.FC<CreatePlantPageProps> = ({ onCancel, onSa
               ))}
             </select>
           </div>
-          <div className="grid gap-2">
-            <Label htmlFor="plant-water">Care: Water</Label>
-            <select id="plant-water" className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm" value={careWater} onChange={(e: React.ChangeEvent<HTMLSelectElement>) => setCareWater(e.target.value as Plant["care"]["water"]) }>
-              {(["Low", "Medium", "High"] as const).map((v) => (
-                <option key={v} value={v}>{v}</option>
-              ))}
-            </select>
-          </div>
+          {/* Water care is derived from frequency; no manual input */}
           <div className="grid gap-2">
             <Label htmlFor="plant-soil">Care: Soil</Label>
             <Input id="plant-soil" value={careSoil} onChange={(e: React.ChangeEvent<HTMLInputElement>) => setCareSoil(e.target.value)} />

--- a/plant-swipe/src/pages/EditPlantPage.tsx
+++ b/plant-swipe/src/pages/EditPlantPage.tsx
@@ -28,7 +28,6 @@ export const EditPlantPage: React.FC<EditPlantPageProps> = ({ onCancel, onSaved 
   const [description, setDescription] = React.useState("")
   const [imageUrl, setImageUrl] = React.useState("")
   const [careSunlight, setCareSunlight] = React.useState<Plant["care"]["sunlight"]>("Low")
-  const [careWater, setCareWater] = React.useState<Plant["care"]["water"]>("Low")
   const [careSoil, setCareSoil] = React.useState("")
   const [careDifficulty, setCareDifficulty] = React.useState<Plant["care"]["difficulty"]>("Easy")
   const [seedsAvailable, setSeedsAvailable] = React.useState(false)
@@ -49,7 +48,7 @@ export const EditPlantPage: React.FC<EditPlantPageProps> = ({ onCancel, onSaved 
       try {
         const { data, error: qerr } = await supabase
           .from('plants')
-          .select('id, name, scientific_name, colors, seasons, rarity, meaning, description, image_url, care_sunlight, care_water, care_soil, care_difficulty, seeds_available, water_freq_period, water_freq_amount, water_freq_unit, water_freq_value')
+          .select('id, name, scientific_name, colors, seasons, rarity, meaning, description, image_url, care_sunlight, care_soil, care_difficulty, seeds_available, water_freq_period, water_freq_amount, water_freq_unit, water_freq_value')
           .eq('id', id)
           .maybeSingle()
         if (qerr) throw new Error(qerr.message)
@@ -64,7 +63,6 @@ export const EditPlantPage: React.FC<EditPlantPageProps> = ({ onCancel, onSaved 
         setDescription(String(data.description || ''))
         setImageUrl(String(data.image_url || ''))
         setCareSunlight((data.care_sunlight || 'Low') as Plant['care']['sunlight'])
-        setCareWater((data.care_water || 'Low') as Plant['care']['water'])
         setCareSoil(String(data.care_soil || ''))
         setCareDifficulty((data.care_difficulty || 'Easy') as Plant['care']['difficulty'])
         setSeedsAvailable(Boolean(data.seeds_available ?? false))
@@ -107,7 +105,6 @@ export const EditPlantPage: React.FC<EditPlantPageProps> = ({ onCancel, onSaved 
           description: description || null,
           image_url: imageUrl || null,
           care_sunlight: careSunlight,
-          care_water: careWater,
           care_soil: careSoil,
           care_difficulty: careDifficulty,
           seeds_available: seedsAvailable,
@@ -183,14 +180,7 @@ export const EditPlantPage: React.FC<EditPlantPageProps> = ({ onCancel, onSaved 
                   ))}
                 </select>
               </div>
-              <div className="grid gap-2">
-                <Label htmlFor="plant-water">Care: Water</Label>
-                <select id="plant-water" className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm" value={careWater} onChange={(e: React.ChangeEvent<HTMLSelectElement>) => setCareWater(e.target.value as Plant["care"]["water"]) }>
-                  {(["Low", "Medium", "High"] as const).map((v) => (
-                    <option key={v} value={v}>{v}</option>
-                  ))}
-                </select>
-              </div>
+              {/* Water care is derived from frequency; no manual input */}
               <div className="grid gap-2">
                 <Label htmlFor="plant-soil">Care: Soil</Label>
                 <Input id="plant-soil" value={careSoil} onChange={(e: React.ChangeEvent<HTMLInputElement>) => setCareSoil(e.target.value)} />


### PR DESCRIPTION
Remove user-set `care_water` from plant forms and display derived water evaluation based on watering frequency.

This change automates the `care_water` field calculation via a database trigger and frontend utility, ensuring consistency with the plant's watering schedule and simplifying the user experience by removing manual input.

---
<a href="https://cursor.com/background-agent?bcId=bc-9d0177c1-d924-4827-9281-273017619c91">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9d0177c1-d924-4827-9281-273017619c91">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

