### PR TITLE
Fix garden page refresh error

### DIFF
--- a/plant-swipe/src/PlantSwipe.tsx
+++ b/plant-swipe/src/PlantSwipe.tsx
@@ -454,7 +454,7 @@ export default function PlantSwipe() {
                   )}
                 />
                 <Route path="/gardens" element={<GardenListPage />} />
-                <Route path="/garden/:id" element={<GardenDashboardPage />} />
+                <Route path="/garden/:id/*" element={<GardenDashboardPage />} />
                 <Route
                   path="/search"
                   element={

--- a/plant-swipe/vite.config.ts
+++ b/plant-swipe/vite.config.ts
@@ -13,7 +13,7 @@ import { fileURLToPath } from 'url'
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 export default defineConfig({
-  base: './',
+  base: '/',
   plugins: [react()],
   envPrefix: ['VITE_', 'SUPABASE_'],
   resolve: { alias: { '@': path.resolve(__dirname, 'src') } },


### PR DESCRIPTION
Update Vite's base path to '/' to resolve module script loading errors on page reload for nested routes.

The previous relative base path (`./`) caused built assets to be incorrectly requested as HTML on subsequent reloads of nested routes (e.g., `/gardens`), leading to a white page and `Failed to load module script` errors. Changing `base` to `'/'` ensures absolute asset URLs, allowing the server to correctly serve JavaScript modules.

---
<a href="https://cursor.com/background-agent?bcId=bc-d0875953-2d2a-4934-a9d8-f03fb6f79750">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d0875953-2d2a-4934-a9d8-f03fb6f79750">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

