### PR TITLE
Investigate failed watering task with no plants

### DIFF
--- a/plant-swipe/src/pages/GardenDashboardPage.tsx
+++ b/plant-swipe/src/pages/GardenDashboardPage.tsx
@@ -206,7 +206,7 @@ export const GardenDashboardPage: React.FC = () => {
         const idxTodayForStats = isToday ? weekDaysIso.indexOf(today) : -1
         const dueOverride = isToday && idxTodayForStats >= 0 ? (Object.values(perPlant).reduce((acc: number, arr: any) => acc + ((arr as number[]).includes(idxTodayForStats) ? 1 : 0), 0)) : undefined
         const dueVal = dueOverride !== undefined ? dueOverride : entry.due
-        const success = dueVal > 0 ? (entry.completed >= dueVal) : Boolean(trow?.success)
+        const success = dueVal > 0 ? (entry.completed >= dueVal) : true
         days.push({ date: ds, due: dueVal, completed: entry.completed, success })
       }
       // Keep dueToday from schedule definitions (already set)


### PR DESCRIPTION
Mark watering tasks with no plants as successful in both UI and database to reflect "nothing to do" as a positive outcome.

The previous implementation incorrectly set `success=false` for watering tasks that had an empty `garden_plant_ids` array, both during initial seeding and task creation. The UI then displayed these days as unsuccessful. This change ensures that if no plants are due for watering, the task is considered successful, providing a more accurate representation of task completion. It also includes a backfill for existing empty tasks for the day being processed.

---
<a href="https://cursor.com/background-agent?bcId=bc-9448561d-2945-4a45-bf89-836a2eeb01fc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9448561d-2945-4a45-bf89-836a2eeb01fc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

