### PR TITLE
Debug and repair broken garden feature

### DIFF
--- a/plant-swipe/src/pages/GardenDashboardPage.tsx
+++ b/plant-swipe/src/pages/GardenDashboardPage.tsx
@@ -788,7 +788,7 @@ function RoutineSection({ plants, duePlantIds, onLogWater, weekDays, weekCounts,
 }
 
 
-function OverviewSection({ plants, membersCount, serverToday, dailyStats, totalOnHand, speciesOnHand }: { plants: any[]; membersCount: number; serverToday: string | null; dailyStats: Array<{ date: string; due: number; completed: number; success: boolean }>; totalOnHand: number; speciesOnHand: number }) {
+function OverviewSection({ plants, membersCount, serverToday, dailyStats, totalOnHand, speciesOnHand, baseStreak }: { plants: any[]; membersCount: number; serverToday: string | null; dailyStats: Array<{ date: string; due: number; completed: number; success: boolean }>; totalOnHand: number; speciesOnHand: number; baseStreak: number }) {
   const totalToDoToday = dailyStats.find(d => d.date === (serverToday || ''))?.due ?? 0
   const completedToday = dailyStats.find(d => d.date === (serverToday || ''))?.completed ?? 0
   const progressPct = totalToDoToday === 0 ? 100 : Math.min(100, Math.round((completedToday / totalToDoToday) * 100))


### PR DESCRIPTION
Add missing database schema and frontend prop to fix garden dashboard loading errors.

The `ReferenceError: baseStreak is not defined` was resolved by passing the `baseStreak` prop to the `OverviewSection` component. The `400` errors from Supabase queries were due to the frontend attempting to query columns (`override_water_freq_unit`, `override_water_freq_value`, `sort_index`) and use tables/RPCs (`garden_plant_schedule`, `garden_watering_schedule`, `get_server_now`, `reseed_watering_schedule`, `mark_garden_plant_watered`, `compute_garden_task_for_day`) that were not defined in the database schema. This PR adds these missing elements.

---
<a href="https://cursor.com/background-agent?bcId=bc-6eafd33e-3bc5-4885-b28f-da8b877a6949"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6eafd33e-3bc5-4885-b28f-da8b877a6949"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

