### PR TITLE
Changes from background agent bc-8490b3d4-6730-4319-8139-341e94f6bde2

### DIFF
--- a/plant-swipe/supabase/000_sync_schema.sql
+++ b/plant-swipe/supabase/000_sync_schema.sql
@@ -915,7 +915,7 @@ do $$ begin
   perform cron.schedule(
     'compute_daily_garden_tasks',
     '5 0 * * *',
-    $$ call public.compute_daily_tasks_for_all_gardens((now() at time zone 'utc')::date); $$
+    $cron$select public.compute_daily_tasks_for_all_gardens((now() at time zone 'utc')::date)$cron$
   );
 end $$;
 


### PR DESCRIPTION
Update pg_cron schedule command syntax to resolve a syntax error and nested dollar-quoting conflict.

---
<a href="https://cursor.com/background-agent?bcId=bc-8490b3d4-6730-4319-8139-341e94f6bde2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8490b3d4-6730-4319-8139-341e94f6bde2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

