### PR TITLE
Fix undefined token assignment in build

### DIFF
--- a/plant-swipe/src/pages/AdminPage.tsx
+++ b/plant-swipe/src/pages/AdminPage.tsx
@@ -172,7 +172,7 @@ export const AdminPage: React.FC = () => {
       if (!start.ok) {
         throw new Error(startBody?.error || `Backup failed (${start.status})`)
       }
-      const dlToken: string = startBody?.token
+      const dlToken = startBody?.token
       const filename: string = startBody?.filename || 'backup.sql.gz'
       if (!dlToken) throw new Error('Missing download token from server')
 


### PR DESCRIPTION
Remove explicit `string` type annotation for `dlToken` to resolve a TypeScript build error.

The previous code caused a `Type 'string | undefined' is not assignable to type 'string'` error because `startBody?.token` could be `undefined`. Removing the explicit type allows TypeScript to infer the correct type, and the subsequent `if (!dlToken)` guard correctly handles the `undefined` case.

---
<a href="https://cursor.com/background-agent?bcId=bc-01691e8d-091b-47bd-b281-c6d8e3de99c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-01691e8d-091b-47bd-b281-c6d8e3de99c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

