### PR TITLE
Fix schema sync from admin page

### DIFF
--- a/plant-swipe/server.js
+++ b/plant-swipe/server.js
@@ -165,7 +165,8 @@ app.post('/api/admin/restart-server', async (req, res) => {
   }
 })
 
-app.post('/api/admin/sync-schema', async (req, res) => {
+// Support both POST and GET (some environments may block POST from admin UI)
+async function handleSyncSchema(req, res) {
   if (!sql) {
     res.status(500).json({ error: 'Database not configured' })
     return
@@ -220,6 +221,15 @@ app.post('/api/admin/sync-schema', async (req, res) => {
   } catch (e) {
     res.status(500).json({ error: e?.message || 'Failed to sync schema' })
   }
+}
+
+app.post('/api/admin/sync-schema', handleSyncSchema)
+app.get('/api/admin/sync-schema', handleSyncSchema)
+app.options('/api/admin/sync-schema', (_req, res) => {
+  // Allow standard headers for admin calls
+  res.setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS')
+  res.setHeader('Access-Control-Allow-Headers', 'Authorization, Content-Type')
+  res.status(204).end()
 })
 
 app.get('/api/plants', async (_req, res) => {

--- a/plant-swipe/src/pages/AdminPage.tsx
+++ b/plant-swipe/src/pages/AdminPage.tsx
@@ -23,13 +23,22 @@ export const AdminPage: React.FC = () => {
         alert('You must be signed in to run schema sync')
         return
       }
-      const resp = await fetch('/api/admin/sync-schema', {
+      let resp = await fetch('/api/admin/sync-schema', {
         method: 'POST',
         headers: {
           'Authorization': `Bearer ${token}`,
           'Content-Type': 'application/json',
         },
       })
+      if (resp.status === 405) {
+        // Fallback to GET in environments where POST may be blocked
+        resp = await fetch('/api/admin/sync-schema', {
+          method: 'GET',
+          headers: {
+            'Authorization': `Bearer ${token}`,
+          },
+        })
+      }
       const body = await resp.json().catch(() => ({}))
       if (!resp.ok) {
         throw new Error(body?.error || `Request failed (${resp.status})`)


### PR DESCRIPTION
Add GET/OPTIONS support to `/api/admin/sync-schema` and a frontend GET fallback to resolve 405 errors in some environments.

---
<a href="https://cursor.com/background-agent?bcId=bc-7169a3d9-e4bc-4b7c-a3d3-0ad825826276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7169a3d9-e4bc-4b7c-a3d3-0ad825826276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

