### PR TITLE
Investigate user count discrepancy

### DIFF
--- a/plant-swipe/server.js
+++ b/plant-swipe/server.js
@@ -222,6 +222,28 @@ app.post('/api/admin/sync-schema', async (req, res) => {
   }
 })
 
+// Admin: global stats (bypass RLS via server connection)
+app.get('/api/admin/stats', async (req, res) => {
+  const uid = await ensureAdmin(req, res)
+  if (!uid) return
+  if (!sql) {
+    res.status(500).json({ error: 'Database not configured' })
+    return
+  }
+  try {
+    const profilesRows = await sql`select count(*)::int as count from public.profiles`
+    const profilesCount = Array.isArray(profilesRows) && profilesRows[0] ? Number(profilesRows[0].count) : 0
+    let authUsersCount = null
+    try {
+      const authRows = await sql`select count(*)::int as count from auth.users`
+      authUsersCount = Array.isArray(authRows) && authRows[0] ? Number(authRows[0].count) : null
+    } catch {}
+    res.json({ ok: true, profilesCount, authUsersCount })
+  } catch (e) {
+    res.status(500).json({ error: e?.message || 'Failed to load stats' })
+  }
+})
+
 app.get('/api/plants', async (_req, res) => {
   if (!sql) {
     res.status(500).json({ error: 'Database not configured' })


### PR DESCRIPTION
Add an admin-only API endpoint to return a global profile count and update the Admin page to use it.

The "Registered accounts" metric on the Admin page was incorrect due to Row Level Security (RLS) on the `profiles` table, which limited the client-side count to only the authenticated user's own profile. This PR introduces a server-side endpoint that bypasses RLS to fetch the true total count of profiles, ensuring the Admin page displays accurate statistics.

---
<a href="https://cursor.com/background-agent?bcId=bc-dce2be46-6be2-4209-b058-d4e876544a88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dce2be46-6be2-4209-b058-d4e876544a88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

