### PR TITLE
Investigate schema sync 405 error

### DIFF
--- a/plant-swipe/src/pages/AdminPage.tsx
+++ b/plant-swipe/src/pages/AdminPage.tsx
@@ -23,19 +23,20 @@ export const AdminPage: React.FC = () => {
         alert('You must be signed in to run schema sync')
         return
       }
+      // Try GET first to avoid 405s from proxies that block POST
       let resp = await fetch('/api/admin/sync-schema', {
-        method: 'POST',
+        method: 'GET',
         headers: {
           'Authorization': `Bearer ${token}`,
-          'Content-Type': 'application/json',
         },
       })
       if (resp.status === 405) {
-        // Fallback to GET in environments where POST may be blocked
+        // Fallback to POST if GET is blocked
         resp = await fetch('/api/admin/sync-schema', {
-          method: 'GET',
+          method: 'POST',
           headers: {
             'Authorization': `Bearer ${token}`,
+            'Content-Type': 'application/json',
           },
         })
       }


### PR DESCRIPTION
Prefer GET for `/api/admin/sync-schema` to avoid 405 errors from reverse proxies.

The server supports both GET and POST for the schema sync endpoint, but some reverse proxies might block POST requests by default, leading to a 405 error in the console even when the sync eventually succeeds (likely via a subsequent GET or other mechanism). This change makes the client more robust by attempting GET first.

---
<a href="https://cursor.com/background-agent?bcId=bc-15b6b07f-d909-4472-95c0-6aeffb37d05f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-15b6b07f-d909-4472-95c0-6aeffb37d05f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

