### PR TITLE
Troubleshoot server restart 405 error

### DIFF
--- a/plant-swipe/server.js
+++ b/plant-swipe/server.js
@@ -144,7 +144,7 @@ app.get('/api/health', (_req, res) => {
 })
 
 // Admin: restart server (detached self-reexec)
-app.post('/api/admin/restart-server', async (req, res) => {
+async function handleRestartServer(req, res) {
   try {
     const uid = await ensureAdmin(req, res)
     if (!uid) return
@@ -163,6 +163,14 @@ app.post('/api/admin/restart-server', async (req, res) => {
   } catch (e) {
     res.status(500).json({ error: e?.message || 'Failed to restart server' })
   }
+}
+
+app.post('/api/admin/restart-server', handleRestartServer)
+app.get('/api/admin/restart-server', handleRestartServer)
+app.options('/api/admin/restart-server', (_req, res) => {
+  res.setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS')
+  res.setHeader('Access-Control-Allow-Headers', 'Authorization, Content-Type')
+  res.status(204).end()
 })
 
 // Support both POST and GET (some environments may block POST from admin UI)


### PR DESCRIPTION
Add GET and OPTIONS support for the `/api/admin/restart-server` endpoint.

This resolves 405 (Not Allowed) errors when attempting to restart the server, allowing for more flexible client-side requests (e.g., falling back to GET) and mirroring the approach used for `sync-schema` to support environments that may block POST from the admin UI.

---
<a href="https://cursor.com/background-agent?bcId=bc-ca9d2a36-f0bc-4726-9ce7-b812a1230bb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ca9d2a36-f0bc-4726-9ce7-b812a1230bb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

