### PR TITLE
Fix admin server restart and git pull errors

### DIFF
--- a/plant-swipe/src/pages/AdminPage.tsx
+++ b/plant-swipe/src/pages/AdminPage.tsx
@@ -63,13 +63,23 @@ export const AdminPage: React.FC = () => {
         alert('You must be signed in to restart the server')
         return
       }
-      const resp = await fetch('/api/admin/restart-server', {
-        method: 'POST',
+      // Try GET first to avoid 405s from proxies that block POST
+      let resp = await fetch('/api/admin/restart-server', {
+        method: 'GET',
         headers: {
           'Authorization': `Bearer ${token}`,
-          'Content-Type': 'application/json',
         },
       })
+      if (resp.status === 405) {
+        // Fallback to POST if GET is blocked
+        resp = await fetch('/api/admin/restart-server', {
+          method: 'POST',
+          headers: {
+            'Authorization': `Bearer ${token}`,
+            'Content-Type': 'application/json',
+          },
+        })
+      }
       const body = await resp.json().catch(() => ({}))
       if (!resp.ok) {
         throw new Error(body?.error || `Request failed (${resp.status})`)
@@ -95,10 +105,18 @@ export const AdminPage: React.FC = () => {
     setPulling(true)
     try {
       const token = (await supabase.auth.getSession()).data.session?.access_token
-      const res = await fetch('/api/admin/pull-code', {
-        method: 'POST',
+      // Try GET first to avoid 405s from proxies that block POST
+      let res = await fetch('/api/admin/pull-code', {
+        method: 'GET',
         headers: token ? { 'Authorization': `Bearer ${token}` } : undefined,
       })
+      if (res.status === 405) {
+        // Fallback to POST if GET is blocked
+        res = await fetch('/api/admin/pull-code', {
+          method: 'POST',
+          headers: token ? { 'Authorization': `Bearer ${token}` } : undefined,
+        })
+      }
       if (!res.ok) {
         let body: any = {}
         try {


### PR DESCRIPTION
Update Admin page to use GET-first with POST fallback for restart and pull actions to avoid 405 errors from proxies.

---
<a href="https://cursor.com/background-agent?bcId=bc-9d5deee3-7620-4c84-81c3-9369f07d325e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9d5deee3-7620-4c84-81c3-9369f07d325e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

