### PR TITLE
Fix admin server restart and git pull

### DIFF
--- a/plant-swipe/src/pages/AdminPage.tsx
+++ b/plant-swipe/src/pages/AdminPage.tsx
@@ -63,20 +63,21 @@ export const AdminPage: React.FC = () => {
         alert('You must be signed in to restart the server')
         return
       }
-      // Try GET first to avoid 405s from proxies that block POST
+      // Try POST first to ensure Authorization header is preserved across proxies
       let resp = await fetch('/api/admin/restart-server', {
-        method: 'GET',
+        method: 'POST',
         headers: {
           'Authorization': `Bearer ${token}`,
+          'Content-Type': 'application/json',
         },
+        body: '{}',
       })
       if (resp.status === 405) {
-        // Fallback to POST if GET is blocked
+        // Fallback to GET if POST is blocked
         resp = await fetch('/api/admin/restart-server', {
-          method: 'POST',
+          method: 'GET',
           headers: {
             'Authorization': `Bearer ${token}`,
-            'Content-Type': 'application/json',
           },
         })
       }
@@ -105,15 +106,16 @@ export const AdminPage: React.FC = () => {
     setPulling(true)
     try {
       const token = (await supabase.auth.getSession()).data.session?.access_token
-      // Try GET first to avoid 405s from proxies that block POST
+      // Try POST first to ensure Authorization header is preserved across proxies
       let res = await fetch('/api/admin/pull-code', {
-        method: 'GET',
-        headers: token ? { 'Authorization': `Bearer ${token}` } : undefined,
+        method: 'POST',
+        headers: token ? { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' } : undefined,
+        body: token ? '{}' : undefined,
       })
       if (res.status === 405) {
-        // Fallback to POST if GET is blocked
+        // Fallback to GET if POST is blocked
         res = await fetch('/api/admin/pull-code', {
-          method: 'POST',
+          method: 'GET',
           headers: token ? { 'Authorization': `Bearer ${token}` } : undefined,
         })
       }


### PR DESCRIPTION
Refactor `ensureAdmin` for robust admin verification and switch admin UI actions to POST-first to fix non-functional 'Restart Server' and 'Gitpull' buttons.

The previous implementation of `ensureAdmin` could fail to properly identify admin users, and proxies often strip `Authorization` headers from GET requests, leading to authentication failures for the admin API endpoints. This change makes admin verification more resilient and ensures authorization headers are preserved for critical actions.

---
<a href="https://cursor.com/background-agent?bcId=bc-f2cf8054-2728-403a-9493-ce83bb83dc36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f2cf8054-2728-403a-9493-ce83bb83dc36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

