### PR TITLE
Fix build header type error

### DIFF
--- a/plant-swipe/src/PlantSwipe.tsx
+++ b/plant-swipe/src/PlantSwipe.tsx
@@ -136,7 +136,8 @@ export default function PlantSwipe() {
       try {
         const session = (await supabase.auth.getSession()).data.session
         const token = session?.access_token
-        const authHeader = token ? { Authorization: `Bearer ${token}` } : {}
+        const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+        if (token) headers.Authorization = `Bearer ${token}`
         const ref = document.referrer || ''
         const extra = {
           viewport: { w: window.innerWidth, h: window.innerHeight, dpr: window.devicePixelRatio || 1 },
@@ -150,7 +151,7 @@ export default function PlantSwipe() {
         }
         await fetch('/api/track-visit', {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json', ...authHeader },
+          headers,
           body: JSON.stringify({
             pagePath: path,
             referrer: ref,


### PR DESCRIPTION
Fix TypeScript error TS2769 by explicitly constructing the `headers` object as `Record<string, string>` to satisfy `HeadersInit`.

---
<a href="https://cursor.com/background-agent?bcId=bc-53b10dbf-fa14-43e6-833c-ef33d4d7b083"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-53b10dbf-fa14-43e6-833c-ef33d4d7b083"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

