### PR TITLE
Fix visit tracking api call

### DIFF
--- a/plant-swipe.conf
+++ b/plant-swipe.conf
@@ -11,6 +11,19 @@ server {
         add_header Cache-Control "public, max-age=604800";
     }
 
+    # Proxy API requests to the Node server (Express)
+    location /api/ {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 30s;
+        proxy_connect_timeout 5s;
+        proxy_send_timeout 30s;
+    }
+
     location / {
         try_files $uri $uri/ /index.html;
     }

--- a/plant-swipe/src/PlantSwipe.tsx
+++ b/plant-swipe/src/PlantSwipe.tsx
@@ -134,6 +134,9 @@ export default function PlantSwipe() {
     // Track SPA route changes to server for visit analytics
     const sendVisit = async (path: string) => {
       try {
+        // Allow overriding API base via environment (e.g., VITE_API_BASE="http://172.237.109.227")
+        const apiBase: string = (import.meta as any)?.env?.VITE_API_BASE ? String((import.meta as any).env.VITE_API_BASE) : ''
+        const base = apiBase.replace(/\/$/, '')
         const session = (await supabase.auth.getSession()).data.session
         const token = session?.access_token
         const headers: Record<string, string> = { 'Content-Type': 'application/json' }
@@ -149,7 +152,7 @@ export default function PlantSwipe() {
           memoryGB: (navigator as any).deviceMemory || null,
           webgl: (() => { try { const c = document.createElement('canvas'); const gl = (c.getContext('webgl') || c.getContext('experimental-webgl')) as WebGLRenderingContext | null; const debug = gl && gl.getExtension('WEBGL_debug_renderer_info'); return debug && gl ? { vendor: gl.getParameter((debug as any).UNMASKED_VENDOR_WEBGL), renderer: gl.getParameter((debug as any).UNMASKED_RENDERER_WEBGL) } : null } catch { return null } })(),
         }
-        await fetch('/api/track-visit', {
+        await fetch(`${base}/api/track-visit`, {
           method: 'POST',
           headers,
           body: JSON.stringify({


### PR DESCRIPTION
Enable visit tracking by configuring Nginx to proxy `/api` requests and allowing the frontend to use an environment variable for the API base URL.

The `POST /api/track-visit` endpoint was returning a 405 "Not Allowed" error because Nginx was not configured to proxy requests to `/api` to the Node.js backend. This change adds the necessary Nginx proxy configuration and updates the frontend to correctly construct the API URL using an optional `VITE_API_BASE` environment variable, ensuring visit tracking requests are properly routed and processed.

---
<a href="https://cursor.com/background-agent?bcId=bc-54da1d8a-352d-4e44-912d-3e314e6017b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-54da1d8a-352d-4e44-912d-3e314e6017b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

