### PR TITLE
Fix visitor tracking database access for guests

### DIFF
--- a/plant-swipe/supabase/000_sync_schema.sql
+++ b/plant-swipe/supabase/000_sync_schema.sql
@@ -92,7 +92,8 @@ do $$ begin
   if exists (select 1 from pg_policies where schemaname='public' and tablename='plants' and policyname='plants_select_all') then
     drop policy plants_select_all on public.plants;
   end if;
-  create policy plants_select_all on public.plants for select to authenticated using (true);
+  -- Allow select for both authenticated users and anonymous visitors
+  create policy plants_select_all on public.plants for select using (true);
 end $$;
 do $$ begin
   if exists (select 1 from pg_policies where schemaname='public' and tablename='plants' and policyname='plants_iud_all') then


### PR DESCRIPTION
Enable unauthenticated users to view plant data by relaxing Supabase RLS and adding a client-side API fallback.

Previously, non-logged-in users were unable to load plant data due to Supabase Row Level Security (RLS) policies restricting `public.plants` SELECTs to authenticated users. This change allows anonymous users to access the plant catalog.

---
<a href="https://cursor.com/background-agent?bcId=bc-092bfaab-6800-45a0-b2c8-254ce7ab394e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-092bfaab-6800-45a0-b2c8-254ce7ab394e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

