### PR TITLE
Show recent visits on admin page

### DIFF
--- a/plant-swipe/server.js
+++ b/plant-swipe/server.js
@@ -739,6 +739,8 @@ app.get('/api/admin/visitors-stats', async (req, res) => {
   try {
     const rows10m = await sql`select count(distinct session_id)::int as c from public.web_visits where occurred_at >= now() - interval '10 minutes'`
     const currentUniqueVisitors10m = rows10m?.[0]?.c ?? 0
+    const rows60m = await sql`select count(*)::int as c from public.web_visits where occurred_at >= now() - interval '60 minutes'`
+    const visitsLast60m = rows60m?.[0]?.c ?? 0
     const rows7 = await sql`
       with days as (
         select generate_series((now()::date - 6), now()::date, interval '1 day')::date as d
@@ -751,7 +753,7 @@ app.get('/api/admin/visitors-stats', async (req, res) => {
       order by d asc
     `
     const series7d = (rows7 || []).map(r => ({ date: new Date(r.day).toISOString().slice(0,10), uniqueVisitors: Number(r.unique_visitors || 0) }))
-    res.json({ ok: true, currentUniqueVisitors10m, series7d })
+    res.json({ ok: true, currentUniqueVisitors10m, visitsLast60m, series7d })
   } catch (e) {
     res.status(500).json({ error: e?.message || 'Failed to load visitors stats' })
   }

--- a/plant-swipe/src/pages/AdminPage.tsx
+++ b/plant-swipe/src/pages/AdminPage.tsx
@@ -104,6 +104,7 @@ export const AdminPage: React.FC = () => {
   const [visitorsSeries, setVisitorsSeries] = React.useState<Array<{ date: string; uniqueVisitors: number }>>([])
   const [visitorsLoading, setVisitorsLoading] = React.useState<boolean>(true)
   const [visitorsError, setVisitorsError] = React.useState<string | null>(null)
+  const [visitsLast60m, setVisitsLast60m] = React.useState<number | null>(null)
 
   const pullLatest = async () => {
     if (pulling) return
@@ -256,6 +257,8 @@ export const AdminPage: React.FC = () => {
         }
         const series: Array<{ date: string; uniqueVisitors: number }> = Array.isArray(data?.series7d) ? data.series7d : []
         if (!cancelled) setVisitorsSeries(series)
+        const v60: number = Number.isFinite(Number(data?.visitsLast60m)) ? Number(data.visitsLast60m) : 0
+        if (!cancelled) setVisitsLast60m(v60)
       } catch (e: unknown) {
         const msg = e instanceof Error ? e.message : String(e)
         if (!cancelled) setVisitorsError(msg || 'Failed to load visitors stats')
@@ -436,6 +439,7 @@ export const AdminPage: React.FC = () => {
                 <CardContent className="p-4">
                   <div className="text-sm opacity-60">Currently online</div>
                   <div className="text-2xl font-semibold">{onlineCount}</div>
+                  <div className="text-xs opacity-60 mt-1">Visits last 60 mins: <span className="font-medium opacity-80">{visitsLast60m ?? 0}</span></div>
                 </CardContent>
               </Card>
               <Card className="rounded-2xl">


### PR DESCRIPTION
Add a "Visits last 60 mins" count to the Admin page under "Currently online" to fulfill the user's request.

---
<a href="https://cursor.com/background-agent?bcId=bc-2f2a250f-e50d-4bf5-88ff-dd0bfd730d0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2f2a250f-e50d-4bf5-88ff-dd0bfd730d0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

