### PR TITLE
Allow public access to plant data

### DIFF
--- a/plant-swipe/supabase/000_sync_schema.sql
+++ b/plant-swipe/supabase/000_sync_schema.sql
@@ -92,7 +92,8 @@ do $$ begin
   if exists (select 1 from pg_policies where schemaname='public' and tablename='plants' and policyname='plants_select_all') then
     drop policy plants_select_all on public.plants;
   end if;
-  create policy plants_select_all on public.plants for select to authenticated using (true);
+  -- Allow anyone (including anon) to read plants
+  create policy plants_select_all on public.plants for select to authenticated, anon using (true);
 end $$;
 do $$ begin
   if exists (select 1 from pg_policies where schemaname='public' and tablename='plants' and policyname='plants_iud_all') then


### PR DESCRIPTION
Update Supabase RLS policy for `public.plants` to allow anonymous users to view plant data.

---
<a href="https://cursor.com/background-agent?bcId=bc-7d7a83ee-ebb7-4c9f-ad89-033b1121447d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7d7a83ee-ebb7-4c9f-ad89-033b1121447d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

