### PR TITLE
Fix setinventorycounts garden error

### DIFF
--- a/plant-swipe/src/pages/GardenDashboardPage.tsx
+++ b/plant-swipe/src/pages/GardenDashboardPage.tsx
@@ -236,7 +236,7 @@ export const GardenDashboardPage: React.FC = () => {
           species += 1
         }
       }
-      setInventoryCounts(perInstanceCounts)
+      setInstanceCounts(perInstanceCounts)
       setTotalOnHand(total)
       setSpeciesOnHand(species)
       // Build last-30-days stats from generic task occurrences instead of watering-only


### PR DESCRIPTION
Fix 'setInventoryCounts is not defined' error by replacing it with `setInstanceCounts` in `GardenDashboardPage.tsx`.

The error occurred because `setInventoryCounts` was called after a refactor renamed the state variable from `inventoryCounts` to `instanceCounts`, leaving `setInventoryCounts` undefined. The correct setter `setInstanceCounts` was already defined and should have been used.

---
<a href="https://cursor.com/background-agent?bcId=bc-c4ba013e-3f17-481c-89da-d3a2df90cdaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c4ba013e-3f17-481c-89da-d3a2df90cdaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

