### PR TITLE
Fix broken website due to missing env var

### DIFF
--- a/plant-swipe/index.html
+++ b/plant-swipe/index.html
@@ -5,6 +5,8 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>PLANT SWIPE</title>
+    <!-- Inject runtime environment before the app bundle -->
+    <script src="/api/env.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/plant-swipe/server.js
+++ b/plant-swipe/server.js
@@ -233,6 +233,25 @@ app.get('/api/health', (_req, res) => {
   res.json({ ok: true })
 })
 
+// Runtime environment injector for client (exposes safe VITE_* only)
+app.get('/api/env.js', (_req, res) => {
+  try {
+    const env = {
+      VITE_SUPABASE_URL: process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL || '',
+      VITE_SUPABASE_ANON_KEY: process.env.VITE_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY || '',
+      VITE_API_BASE: process.env.VITE_API_BASE || '',
+    }
+    const js = `window.__ENV__ = ${JSON.stringify(env).replace(/</g, '\\u003c')};\n`
+    res.setHeader('Content-Type', 'application/javascript; charset=utf-8')
+    res.setHeader('Cache-Control', 'no-store')
+    res.send(js)
+  } catch (e) {
+    res.setHeader('Content-Type', 'application/javascript; charset=utf-8')
+    res.setHeader('Cache-Control', 'no-store')
+    res.send('window.__ENV__ = {}')
+  }
+})
+
 // ==== Helpers: cookie/session/ip/geo ====
 function parseCookies(headerValue) {
   const cookies = {}

--- a/plant-swipe/src/lib/utils.ts
+++ b/plant-swipe/src/lib/utils.ts
@@ -6,7 +6,8 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 export function getEnv(name: string, fallback?: string): string {
-  const v = (import.meta as any).env?.[name]
+  // Prefer build-time Vite env; fallback to runtime window.__ENV__ injected by server
+  const v = (import.meta as any).env?.[name] ?? (globalThis as any)?.__ENV__?.[name]
   if (typeof v === 'string' && v.length > 0) return v
   if (fallback !== undefined) return fallback
   throw new Error(`Missing environment variable: ${name}`)
@@ -14,7 +15,7 @@ export function getEnv(name: string, fallback?: string): string {
 
 export function getEnvAny(names: string[], fallback?: string): string {
   for (const n of names) {
-    const v = (import.meta as any).env?.[n]
+    const v = (import.meta as any).env?.[n] ?? (globalThis as any)?.__ENV__?.[n]
     if (typeof v === 'string' && v.length > 0) return v
   }
   if (fallback !== undefined) return fallback


### PR DESCRIPTION
Implement runtime environment variable injection to resolve missing `VITE_SUPABASE_URL` error in production.

The client-side application was failing to find `VITE_SUPABASE_URL` because `import.meta.env` was not correctly populated in the production build or was not picking up server-side environment variables. This change introduces a server-side endpoint (`/api/env.js`) to dynamically inject necessary `VITE_*` environment variables into the client's `window.__ENV__` object at runtime, allowing the application to function correctly without requiring a full client-side rebuild for environment variable changes.

---
<a href="https://cursor.com/background-agent?bcId=bc-5b4f32cd-0907-4e62-9e47-2f7faa06c2ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5b4f32cd-0907-4e62-9e47-2f7faa06c2ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

