### PR TITLE
Fix broken website loading script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "workspace",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/plant-swipe/index.html
+++ b/plant-swipe/index.html
@@ -5,8 +5,8 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>PLANT SWIPE</title>
-    <!-- Inject runtime environment before the app bundle -->
-    <script src="/env.js"></script>
+    <!-- Inject runtime environment via API (proxied by Nginx) before the app bundle -->
+    <script src="/api/env.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/plant-swipe/public/env.js
+++ b/plant-swipe/public/env.js
@@ -1,0 +1,5 @@
+window.__ENV__ = {
+  VITE_SUPABASE_URL: globalThis.VITE_SUPABASE_URL || '',
+  VITE_SUPABASE_ANON_KEY: globalThis.VITE_SUPABASE_ANON_KEY || '',
+  VITE_API_BASE: globalThis.VITE_API_BASE || ''
+};

--- a/plant-swipe/server.js
+++ b/plant-swipe/server.js
@@ -236,7 +236,8 @@ app.get('/api/health', (_req, res) => {
 })
 
 // Runtime environment injector for client (exposes safe VITE_* only)
-// Serve on both /api/env.js and /env.js to be resilient to proxy rules
+// Serve on both /api/env.js and /env.js to be resilient to proxy rules.
+// Some static hosts might hijack /env.js and serve index.html; prefer /api/env.js in index.html.
 app.get(['/api/env.js', '/env.js'], (_req, res) => {
   try {
     const env = {


### PR DESCRIPTION
Switch `env.js` loading to `/api/env.js` to prevent static server hijacking and ensure correct environment variable injection.

The `/env.js` path was being served as `text/html` by the static server's SPA fallback rule, leading to a `SyntaxError` and preventing the application from accessing critical environment variables. This change ensures the Express server handles the request with the correct `application/javascript` MIME type, resolving the runtime errors. A static fallback `public/env.js` is also added.

---
<a href="https://cursor.com/background-agent?bcId=bc-dad6d6f4-a955-41b3-940a-7dcba80a3d1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dad6d6f4-a955-41b3-940a-7dcba80a3d1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

