### PR TITLE
Set Supabase environment variables

### DIFF
--- a/plant-swipe/public/env.js
+++ b/plant-swipe/public/env.js
@@ -1,5 +1,4 @@
 window.__ENV__ = {
   VITE_SUPABASE_URL: globalThis.VITE_SUPABASE_URL || '',
   VITE_SUPABASE_ANON_KEY: globalThis.VITE_SUPABASE_ANON_KEY || '',
-  VITE_API_BASE: globalThis.VITE_API_BASE || ''
 };

--- a/plant-swipe/src/PlantSwipe.tsx
+++ b/plant-swipe/src/PlantSwipe.tsx
@@ -134,18 +134,7 @@ export default function PlantSwipe() {
     // Track SPA route changes to server for visit analytics
     const sendVisit = async (path: string) => {
       try {
-        // Allow overriding API base via environment (build-time or runtime)
-        // Reads from import.meta.env first, then window.__ENV__ via getEnvAny
-        const apiBase: string = (() => {
-          try {
-            const v1 = (import.meta as any)?.env?.VITE_API_BASE
-            if (v1 && String(v1).length > 0) return String(v1)
-            const v2 = (globalThis as any)?.__ENV__?.VITE_API_BASE
-            if (v2 && String(v2).length > 0) return String(v2)
-          } catch {}
-          return ''
-        })()
-        const base = apiBase.replace(/\/$/, '')
+        const base: string = ''
         const session = (await supabase.auth.getSession()).data.session
         const token = session?.access_token
         const headers: Record<string, string> = { 'Content-Type': 'application/json' }


### PR DESCRIPTION
Restrict environment variable usage to only `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`, and `SUPABASE_ANON_KEY`, removing `VITE_API_BASE` and all Supabase service role keys.

---
<a href="https://cursor.com/background-agent?bcId=bc-1260e6c6-83ba-4b22-985a-35bb0dc06673"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1260e6c6-83ba-4b22-985a-35bb0dc06673"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

