### PR TITLE
Enforce user login for database access

### DIFF
--- a/plant-swipe/src/components/plant/PlantDetails.tsx
+++ b/plant-swipe/src/components/plant/PlantDetails.tsx
@@ -10,9 +10,11 @@ import type { Plant } from "@/types/plant";
 import { rarityTone, seasonBadge } from "@/constants/badges";
 import { deriveWaterLevelFromFrequency } from "@/lib/utils";
 import { supabase } from "@/lib/supabaseClient";
+import { useAuth } from "@/context/AuthContext";
 
 export const PlantDetails: React.FC<{ plant: Plant; onClose: () => void; liked?: boolean; onToggleLike?: () => void }> = ({ plant, onClose, liked = false, onToggleLike }) => {
   const navigate = useNavigate()
+  const { user } = useAuth()
   const y = useMotionValue(0)
   const threshold = 120
   const onDragEnd = (_: unknown, info: { offset: { y: number }; velocity: { y: number } }) => {
@@ -98,16 +100,20 @@ export const PlantDetails: React.FC<{ plant: Plant; onClose: () => void; liked?:
       </Card>
 
       <div className="flex justify-between gap-2">
-        <Button variant="destructive" className="rounded-2xl" onClick={async () => {
-          const yes = window.confirm('Delete this plant? This will fail if it is used in any garden.')
-          if (!yes) return
-          const { error } = await supabase.from('plants').delete().eq('id', plant.id)
-          if (error) { alert(error.message); return }
-          onClose()
-          window.location.reload()
-        }}>Delete</Button>
-        <div className="flex gap-2">
-          <Button variant="secondary" className="rounded-2xl" onClick={() => { navigate(`/plants/${plant.id}/edit`); onClose() }}>Edit</Button>
+        {user && (
+          <Button variant="destructive" className="rounded-2xl" onClick={async () => {
+            const yes = window.confirm('Delete this plant? This will fail if it is used in any garden.')
+            if (!yes) return
+            const { error } = await supabase.from('plants').delete().eq('id', plant.id)
+            if (error) { alert(error.message); return }
+            onClose()
+            window.location.reload()
+          }}>Delete</Button>
+        )}
+        <div className="flex gap-2 ml-auto">
+          {user && (
+            <Button variant="secondary" className="rounded-2xl" onClick={() => { navigate(`/plants/${plant.id}/edit`); onClose() }}>Edit</Button>
+          )}
           <Button className="rounded-2xl" onClick={onClose}>Close</Button>
         </div>
       </div>


### PR DESCRIPTION
Enable public browsing of plants by adding a server-side fallback for data fetching and restricting edit/delete actions to logged-in users.

Unauthenticated users were previously unable to view plant listings. This change introduces a fallback mechanism in `PlantSwipe.tsx` to fetch plant data from `/api/plants` if the direct Supabase query fails, ensuring guests can browse. Additionally, "Edit" and "Delete" buttons in `PlantDetails.tsx` are now only visible to authenticated users, maintaining data integrity and security for protected actions.

---
<a href="https://cursor.com/background-agent?bcId=bc-8cff766d-41e3-44db-8c3b-210dd54297c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8cff766d-41e3-44db-8c3b-210dd54297c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

