### PR TITLE
Fix garden creation recursion bug

### DIFF
--- a/plant-swipe/supabase/gardens_schema.sql
+++ b/plant-swipe/supabase/gardens_schema.sql
@@ -416,10 +416,17 @@ $$;
 -- Policies
 -- Gardens: members can select; owners can update/delete; authenticated can insert own garden
 do $$ begin
-  if not exists (select 1 from pg_policies where schemaname = 'public' and tablename = 'gardens' and policyname = 'gardens_select') then
-    create policy gardens_select on public.gardens for select
-      using (exists (select 1 from public.garden_members gm where gm.garden_id = id and gm.user_id = auth.uid()));
+  if exists (select 1 from pg_policies where schemaname = 'public' and tablename = 'gardens' and policyname = 'gardens_select') then
+    drop policy gardens_select on public.gardens;
   end if;
+  create policy gardens_select on public.gardens for select
+    using (
+      created_by = auth.uid()
+      or exists (
+        select 1 from public.garden_members gm
+        where gm.garden_id = id and gm.user_id = auth.uid()
+      )
+    );
 end $$;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname = 'public' and tablename = 'gardens' and policyname = 'gardens_insert') then
@@ -453,7 +460,16 @@ do $$ begin
     drop policy gm_insert on public.garden_members;
   end if;
   create policy gm_insert on public.garden_members for insert to authenticated
-    with check (public.is_garden_owner_bypass(garden_id, auth.uid()) and user_id is not null);
+    with check (
+      (
+        user_id = auth.uid()
+        and exists (
+          select 1 from public.gardens g
+          where g.id = garden_id and g.created_by = auth.uid()
+        )
+      )
+      or public.is_garden_owner_bypass(garden_id, auth.uid())
+    ) and user_id is not null;
 end $$;
 do $$ begin
   if exists (select 1 from pg_policies where schemaname = 'public' and tablename = 'garden_members' and policyname = 'gm_delete') then


### PR DESCRIPTION
Update RLS policies for `gardens` and `garden_members` to prevent infinite recursion during new garden creation.

The previous RLS policies created a deadlock: a user couldn't read their newly created garden (due to RLS requiring membership) to then insert themselves as a member (which also had RLS checks). This PR allows the creator to read their own garden immediately after creation and to self-insert as the initial owner, breaking the recursion.

---
<a href="https://cursor.com/background-agent?bcId=bc-21bbdc57-4b86-41d7-9e5e-2786f7b42ad7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-21bbdc57-4b86-41d7-9e5e-2786f7b42ad7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

