### PR TITLE
Fix 000_sync syntax error

### DIFF
--- a/plant-swipe/supabase/000_sync_schema.sql
+++ b/plant-swipe/supabase/000_sync_schema.sql
@@ -367,14 +367,17 @@ do $$ begin
   create policy gm_insert on public.garden_members for insert to authenticated
     with check (
       (
-        user_id = (select auth.uid())
-        and exists (
-          select 1 from public.gardens g
-          where g.id = garden_id and g.created_by = (select auth.uid())
+        (
+          user_id = (select auth.uid())
+          and exists (
+            select 1 from public.gardens g
+            where g.id = garden_id and g.created_by = (select auth.uid())
+          )
         )
+        or public.is_garden_owner_bypass(garden_id, (select auth.uid()))
       )
-      or public.is_garden_owner_bypass(garden_id, (select auth.uid()))
-    ) and user_id is not null;
+      and user_id is not null
+    );
 end $$;
 do $$ begin
   if exists (select 1 from pg_policies where schemaname='public' and tablename='garden_members' and policyname='gm_delete') then

--- a/plant-swipe/supabase/gardens_schema.sql
+++ b/plant-swipe/supabase/gardens_schema.sql
@@ -462,14 +462,17 @@ do $$ begin
   create policy gm_insert on public.garden_members for insert to authenticated
     with check (
       (
-        user_id = auth.uid()
-        and exists (
-          select 1 from public.gardens g
-          where g.id = garden_id and g.created_by = auth.uid()
+        (
+          user_id = auth.uid()
+          and exists (
+            select 1 from public.gardens g
+            where g.id = garden_id and g.created_by = auth.uid()
+          )
         )
+        or public.is_garden_owner_bypass(garden_id, auth.uid())
       )
-      or public.is_garden_owner_bypass(garden_id, auth.uid())
-    ) and user_id is not null;
+      and user_id is not null
+    );
 end $$;
 do $$ begin
   if exists (select 1 from pg_policies where schemaname = 'public' and tablename = 'garden_members' and policyname = 'gm_delete') then


### PR DESCRIPTION
Fix syntax error in `gm_insert` policy by moving `and user_id is not null` inside the `with check` clause.

---
<a href="https://cursor.com/background-agent?bcId=bc-0d8fa8a2-821f-4256-8e4e-ccc442b1aa13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0d8fa8a2-821f-4256-8e4e-ccc442b1aa13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

