### PR TITLE
Update discovery card labels

### DIFF
--- a/plant-swipe/src/pages/SwipePage.tsx
+++ b/plant-swipe/src/pages/SwipePage.tsx
@@ -73,7 +73,6 @@ export const SwipePage: React.FC<SwipePageProps> = ({ current, index, setIndex, 
                     <Button variant="secondary" className="rounded-2xl" onClick={handlePass}>
                       <ChevronLeft className="h-4 w-4 mr-1" /> Pass
                     </Button>
-                    <div className="text-xs opacity-60 select-none">Swipe: left = pass, right = info</div>
                     <Button className="rounded-2xl" onClick={handleInfo}>
                       More info <ChevronRight className="h-4 w-4 ml-1" />
                     </Button>


### PR DESCRIPTION
Remove the in-card swipe hint text from the discovery cards because it was deemed useless by the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-14d58f1e-9a08-4bfb-b383-e11004b24ea8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-14d58f1e-9a08-4bfb-b383-e11004b24ea8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

