### PR TITLE
Fix garden creation success calculation

### DIFF
--- a/plant-swipe/src/pages/GardenDashboardPage.tsx
+++ b/plant-swipe/src/pages/GardenDashboardPage.tsx
@@ -294,7 +294,10 @@ export const GardenDashboardPage: React.FC = () => {
         d.setDate(d.getDate() - i)
         const ds = d.toISOString().slice(0,10)
         const entry = dayAgg[ds] || { due: 0, completed: 0 }
-        const success = entry.due > 0 ? (entry.completed >= entry.due) : true
+        // Do not count days before the garden was created as successful
+        const createdDayIso = (() => { try { return new Date((g as any).createdAt).toISOString().slice(0,10) } catch { return null } })()
+        const beforeCreation = createdDayIso ? (ds < createdDayIso) : false
+        const success = beforeCreation ? false : (entry.due > 0 ? (entry.completed >= entry.due) : true)
         days.push({ date: ds, due: entry.due, completed: entry.completed, success })
       }
       setDailyStats(days)


### PR DESCRIPTION
Prevent days before garden creation from being marked as successful in the dashboard grid.

---
<a href="https://cursor.com/background-agent?bcId=bc-666328b0-3621-4149-9e21-bc27c4835f90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-666328b0-3621-4149-9e21-bc27c4835f90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

