### PR TITLE
Fix plant task error and sync

### DIFF
--- a/plant-swipe/supabase/000_sync_schema.sql
+++ b/plant-swipe/supabase/000_sync_schema.sql
@@ -270,6 +270,13 @@ alter table if exists public.garden_plant_tasks add column if not exists monthly
 alter table if exists public.garden_plant_tasks add column if not exists yearly_days text[];
 alter table if exists public.garden_plant_tasks add column if not exists monthly_nth_weekdays text[];
 
+-- Ensure schedule_kind check constraint is correct on existing deployments
+alter table if exists public.garden_plant_tasks
+  drop constraint if exists garden_plant_tasks_schedule_kind_check;
+alter table if exists public.garden_plant_tasks
+  add constraint garden_plant_tasks_schedule_kind_check
+  check (schedule_kind in ('one_time_date','one_time_duration','repeat_duration','repeat_pattern'));
+
 create table if not exists public.garden_plant_task_occurrences (
   id uuid primary key default gen_random_uuid(),
   task_id uuid not null references public.garden_plant_tasks(id) on delete cascade,


### PR DESCRIPTION
Update `garden_plant_tasks.schedule_kind` check constraint to include 'repeat_pattern' to fix task creation errors.

The previous `CHECK` constraint on `garden_plant_tasks.schedule_kind` did not include the 'repeat_pattern' value, leading to an error when attempting to insert tasks with this schedule kind. This PR updates the constraint in both `gardens_schema.sql` and `000_sync_schema.sql` to allow 'repeat_pattern'.

---
<a href="https://cursor.com/background-agent?bcId=bc-39e0967e-869e-41e1-bae0-2f3692e5790d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-39e0967e-869e-41e1-bae0-2f3692e5790d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

