### PR TITLE
Remove required amount field from task creation

### DIFF
--- a/plant-swipe/src/components/plant/TaskCreateDialog.tsx
+++ b/plant-swipe/src/components/plant/TaskCreateDialog.tsx
@@ -25,7 +25,6 @@ export function TaskCreateDialog({
   const [customName, setCustomName] = React.useState('')
   const [period, setPeriod] = React.useState<Period>('week')
   const [amount, setAmount] = React.useState<number>(1)
-  const [requiredCount, setRequiredCount] = React.useState<number>(1)
 
   // Inline schedule selection state
   const [weeklyDays, setWeeklyDays] = React.useState<number[]>([])
@@ -42,7 +41,6 @@ export function TaskCreateDialog({
       setCustomName('')
       setPeriod('week')
       setAmount(1)
-      setRequiredCount(1)
       setWeeklyDays([])
       setMonthlyNthWeekdays([])
       setYearlyDays([])
@@ -87,7 +85,6 @@ export function TaskCreateDialog({
         monthlyDays: period === 'month' ? [] : null,
         yearlyDays: period === 'year' ? [...yearlyDays].sort() : null,
         monthlyNthWeekdays: period === 'month' ? [...monthlyNthWeekdays].sort() : null,
-        requiredCount,
       })
       if (onCreated) await onCreated()
       onOpenChange(false)
@@ -151,16 +148,7 @@ export function TaskCreateDialog({
             </div>
           )}
 
-          <div className="grid gap-2">
-            <label className="text-sm font-medium">Required count</label>
-            <Input
-              type="number"
-              min={1}
-              value={String(requiredCount)}
-              onChange={(e: any) => setRequiredCount(Math.max(1, Number(e.target.value || '1')))}
-            />
-            <div className="text-xs opacity-60">Progress and completion use this count.</div>
-          </div>
+          
 
           <div className="text-sm opacity-60">
             {period === 'week' && 'Pick days Monday–Sunday'}


### PR DESCRIPTION
Remove the "Required count" field from the task creation dialog because it is no longer needed, and the backend now defaults this value to 1.

---
<a href="https://cursor.com/background-agent?bcId=bc-b1135e11-fb85-431d-8e86-ee300545ba3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b1135e11-fb85-431d-8e86-ee300545ba3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

