### PR TITLE
Reload page on plant and task changes

### DIFF
--- a/plant-swipe/src/components/plant/TaskEditorDialog.tsx
+++ b/plant-swipe/src/components/plant/TaskEditorDialog.tsx
@@ -7,7 +7,7 @@ import { listPlantTasks, deletePlantTask, updatePatternTask } from '@/lib/garden
 import { SchedulePickerDialog } from '@/components/plant/SchedulePickerDialog'
 import { TaskCreateDialog } from '@/components/plant/TaskCreateDialog'
 
-export function TaskEditorDialog({ open, onOpenChange, gardenId, gardenPlantId }: { open: boolean; onOpenChange: (o: boolean) => void; gardenId: string; gardenPlantId: string }) {
+export function TaskEditorDialog({ open, onOpenChange, gardenId, gardenPlantId, onChanged }: { open: boolean; onOpenChange: (o: boolean) => void; gardenId: string; gardenPlantId: string; onChanged?: () => Promise<void> | void }) {
   const [tasks, setTasks] = React.useState<GardenPlantTask[]>([])
   const [loading, setLoading] = React.useState(false)
   const [error, setError] = React.useState<string | null>(null)
@@ -70,6 +70,7 @@ export function TaskEditorDialog({ open, onOpenChange, gardenId, gardenPlantId }
     try {
       await deletePlantTask(taskId)
       await load()
+      if (onChanged) await onChanged()
     } catch (e: any) {
       setError(e?.message || 'Failed to delete task')
     }
@@ -151,6 +152,7 @@ export function TaskEditorDialog({ open, onOpenChange, gardenId, gardenPlantId }
               })
               setEditingTask(null)
               await load()
+              if (onChanged) await onChanged()
             } catch (e: any) {
               setError(e?.message || 'Failed to update task')
             }
@@ -165,7 +167,7 @@ export function TaskEditorDialog({ open, onOpenChange, gardenId, gardenPlantId }
         onOpenChange={(o) => setCreateOpen(o)}
         gardenId={gardenId}
         gardenPlantId={gardenPlantId}
-        onCreated={async () => { await load() }}
+        onCreated={async () => { await load(); if (onChanged) await onChanged() }}
       />
     </Dialog>
   )

--- a/plant-swipe/src/pages/CreatePlantPage.tsx
+++ b/plant-swipe/src/pages/CreatePlantPage.tsx
@@ -111,6 +111,8 @@ export const CreatePlantPage: React.FC<CreatePlantPageProps> = ({ onCancel, onSa
       if (insErr) { setError(insErr.message); return }
       setOk('Saved')
       onSaved && onSaved(id)
+      // Ensure list views pick up the new plant immediately
+      try { if (typeof window !== 'undefined') window.location.reload() } catch {}
     } finally {
       setSaving(false)
     }

--- a/plant-swipe/src/pages/GardenDashboardPage.tsx
+++ b/plant-swipe/src/pages/GardenDashboardPage.tsx
@@ -757,7 +757,16 @@ export const GardenDashboardPage: React.FC = () => {
           />
 
           {/* Task Editor Dialog */}
-          <TaskEditorDialog open={taskOpen} onOpenChange={(o) => { setTaskOpen(o); if (!o) setPendingGardenPlantId(null) }} gardenId={id!} gardenPlantId={pendingGardenPlantId || ''} />
+          <TaskEditorDialog
+            open={taskOpen}
+            onOpenChange={(o) => { setTaskOpen(o); if (!o) setPendingGardenPlantId(null) }}
+            gardenId={id!}
+            gardenPlantId={pendingGardenPlantId || ''}
+            onChanged={async () => {
+              // Ensure page reflects latest tasks after create/update/delete
+              await load()
+            }}
+          />
 
           {/* Invite Dialog */}
           <Dialog open={inviteOpen} onOpenChange={setInviteOpen}>


### PR DESCRIPTION
Reload page after adding a new plant and refetch data after task changes to ensure the UI updates with the latest information.

---
<a href="https://cursor.com/background-agent?bcId=bc-6059f1fa-ba7d-4d8f-af35-9fa652b8afe3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6059f1fa-ba7d-4d8f-af35-9fa652b8afe3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

