### PR TITLE
Round images in cards

### DIFF
--- a/plant-swipe/src/components/plant/PlantDetails.tsx
+++ b/plant-swipe/src/components/plant/PlantDetails.tsx
@@ -36,7 +36,7 @@ export const PlantDetails: React.FC<{ plant: Plant; onClose: () => void; liked?:
       </SheetHeader>
 
       <div className="rounded-2xl overflow-hidden shadow relative">
-        <div className="h-56 bg-cover bg-center select-none" style={{ backgroundImage: `url(${plant.image})`, userSelect: 'none' as any }} />
+        <div className="h-56 bg-cover bg-center select-none rounded-2xl" style={{ backgroundImage: `url(${plant.image})`, userSelect: 'none' as any }} />
         <div className="absolute bottom-3 right-3">
           <button
             onClick={() => onToggleLike && onToggleLike()}

--- a/plant-swipe/src/pages/GalleryPage.tsx
+++ b/plant-swipe/src/pages/GalleryPage.tsx
@@ -13,7 +13,7 @@ export const GalleryPage: React.FC<GalleryPageProps> = ({ plants, onOpen }) => (
       {plants.map((p) => (
         <button key={p.id} onClick={() => onOpen(p)} className="text-left">
           <Card className="rounded-2xl overflow-hidden hover:shadow-lg transition-shadow">
-            <div className="h-36 bg-cover bg-center" style={{ backgroundImage: `url(${p.image})` }} />
+            <div className="h-36 bg-cover bg-center rounded-t-2xl" style={{ backgroundImage: `url(${p.image})` }} />
             <CardContent className="p-3">
               <div className="flex items-center gap-2 mb-1">
                 <Badge className={`${rarityTone[p.rarity]} rounded-xl`}>{p.rarity}</Badge>

--- a/plant-swipe/src/pages/GardenDashboardPage.tsx
+++ b/plant-swipe/src/pages/GardenDashboardPage.tsx
@@ -625,7 +625,7 @@ export const GardenDashboardPage: React.FC = () => {
                           </button>
                         </div>
                         <div className="grid grid-cols-3 gap-0">
-                          <div className="col-span-1 h-36 bg-cover bg-center" style={{ backgroundImage: `url(${gp.plant?.image || ''})` }} />
+                          <div className="col-span-1 h-36 bg-cover bg-center rounded-l-2xl" style={{ backgroundImage: `url(${gp.plant?.image || ''})` }} />
                           <div className="col-span-2 p-3">
                             <div className="font-medium">{gp.nickname || gp.plant?.name}</div>
                             {gp.nickname && <div className="text-xs opacity-60">{gp.plant?.name}</div>}

--- a/plant-swipe/src/pages/GardenListPage.tsx
+++ b/plant-swipe/src/pages/GardenListPage.tsx
@@ -108,7 +108,7 @@ export const GardenListPage: React.FC = () => {
                 })()
               )}
               <button onClick={() => navigate(`/garden/${g.id}`)} className="grid grid-cols-3 gap-0 w-full text-left">
-                <div className="col-span-1 h-36 bg-cover bg-center" style={{ backgroundImage: `url(${g.coverImageUrl || ''})` }} />
+                <div className="col-span-1 h-36 bg-cover bg-center rounded-l-2xl" style={{ backgroundImage: `url(${g.coverImageUrl || ''})` }} />
                 <div className="col-span-2 p-4">
                   <div className="font-medium">{g.name}</div>
                   <div className="text-xs opacity-60">Created {new Date(g.createdAt).toLocaleDateString()}</div>

--- a/plant-swipe/src/pages/SearchPage.tsx
+++ b/plant-swipe/src/pages/SearchPage.tsx
@@ -24,7 +24,7 @@ export const SearchPage: React.FC<SearchPageProps> = ({ plants, openInfo, likedI
           onKeyDown={(e: React.KeyboardEvent<HTMLDivElement>) => { if (e.key === 'Enter') openInfo(p) }}
         >
           <div className="grid grid-cols-3 gap-0">
-            <div className="col-span-1 h-36 bg-cover bg-center" style={{ backgroundImage: `url(${p.image})` }} />
+            <div className="col-span-1 h-36 bg-cover bg-center rounded-l-2xl" style={{ backgroundImage: `url(${p.image})` }} />
             <div className="col-span-2 p-3">
               <div className="flex items-center gap-2 mb-1">
                 <Badge className={`${rarityTone[p.rarity]} rounded-xl`}>{p.rarity}</Badge>

--- a/plant-swipe/src/pages/SwipePage.tsx
+++ b/plant-swipe/src/pages/SwipePage.tsx
@@ -39,8 +39,8 @@ export const SwipePage: React.FC<SwipePageProps> = ({ current, index, setIndex, 
             >
               <Card className="h-full rounded-3xl overflow-hidden shadow-xl">
                 <div className="h-2/3 relative">
-                  <div className="absolute inset-0 bg-cover bg-center" style={{ backgroundImage: `url(${current.image})` }} />
-                  <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-black/10 to-transparent" />
+                  <div className="absolute inset-0 bg-cover bg-center rounded-t-3xl" style={{ backgroundImage: `url(${current.image})` }} />
+                  <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-black/10 to-transparent rounded-t-3xl" />
                   <div className="absolute top-2 right-2 z-10">
                     <button
                       onClick={(e: React.MouseEvent<HTMLButtonElement>) => { e.stopPropagation(); onToggleLike && onToggleLike() }}


### PR DESCRIPTION
Add matching border-radius to image containers within rounded Cards to prevent visible corner cut-offs.

---
<a href="https://cursor.com/background-agent?bcId=bc-75c992e7-2f9b-4a6f-817b-f5b810d61980"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-75c992e7-2f9b-4a6f-817b-f5b810d61980"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

