### PR TITLE
Fix search card image display

### DIFF
--- a/plant-swipe/src/pages/SearchPage.tsx
+++ b/plant-swipe/src/pages/SearchPage.tsx
@@ -24,7 +24,16 @@ export const SearchPage: React.FC<SearchPageProps> = ({ plants, openInfo, likedI
           onKeyDown={(e: React.KeyboardEvent<HTMLDivElement>) => { if (e.key === 'Enter') openInfo(p) }}
         >
           <div className="grid grid-cols-3 gap-0">
-            <div className="col-span-1 h-36 bg-cover bg-center rounded-l-2xl" style={{ backgroundImage: `url(${p.image})` }} />
+            <div className="col-span-1 h-36 rounded-l-2xl overflow-hidden bg-stone-100">
+              {p.image ? (
+                <img
+                  src={p.image}
+                  alt={p.name}
+                  loading="lazy"
+                  className="h-full w-full object-cover"
+                />
+              ) : null}
+            </div>
             <div className="col-span-2 p-3">
               <div className="flex items-center gap-2 mb-1">
                 <Badge className={`${rarityTone[p.rarity]} rounded-xl`}>{p.rarity}</Badge>


### PR DESCRIPTION
Replace CSS `background-image` with `<img>` tag for plant images on search cards.

The previous CSS `background-image` approach could fail to render images with certain URL characters and lacked accessibility features like `alt` text. This change ensures reliable image display and better accessibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-1786dd69-86fe-4e75-8285-6ef62b90414a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1786dd69-86fe-4e75-8285-6ef62b90414a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

