### PR TITLE
Center search bar card images

### DIFF
--- a/plant-swipe/src/pages/SearchPage.tsx
+++ b/plant-swipe/src/pages/SearchPage.tsx
@@ -26,11 +26,11 @@ export const SearchPage: React.FC<SearchPageProps> = ({ plants, openInfo, likedI
           <div className="grid grid-cols-3 gap-0">
             <div className="col-span-1 h-36 rounded-l-2xl overflow-hidden bg-stone-100">
               {p.image ? (
-                <img
+              <img
                   src={p.image}
                   alt={p.name}
                   loading="lazy"
-                  className="h-full w-full object-cover"
+                  className="h-full w-full object-cover object-center"
                 />
               ) : null}
             </div>


### PR DESCRIPTION
Center images in search cards by adding the `object-center` Tailwind class.

---
<a href="https://cursor.com/background-agent?bcId=bc-353f1d50-4849-4668-ba78-f29ede7e6649"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-353f1d50-4849-4668-ba78-f29ede7e6649"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

