### PR TITLE
Debug online status display error

### DIFF
--- a/plant-swipe/server.js
+++ b/plant-swipe/server.js
@@ -767,7 +767,7 @@ app.get('/api/admin/visitors-stats', async (req, res) => {
         select generate_series((now()::date - 6), now()::date, interval '1 day')::date as d
       )
       select d as day,
-             coalesce((select count(distinct ip_address)
+             coalesce((select count(distinct coalesce(v.ip_address::text, v.session_id))
                        from public.web_visits v
                        where (v.occurred_at at time zone 'utc')::date = d), 0)::int as unique_visitors
       from days


### PR DESCRIPTION
Update visitor counting logic, add client-side visit heartbeats, and enable auto-refresh for the admin online count.

This fixes the "Currently online" metric always showing 0 by making server-side counting more robust (coalescing IP or session ID), ensuring continuous client-side visit tracking, and automatically updating the admin dashboard.

---
<a href="https://cursor.com/background-agent?bcId=bc-38470f51-4986-4ba7-a35f-1502f752566b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-38470f51-4986-4ba7-a35f-1502f752566b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

