### PR TITLE
Center garden management images

### DIFF
--- a/plant-swipe/src/pages/GardenDashboardPage.tsx
+++ b/plant-swipe/src/pages/GardenDashboardPage.tsx
@@ -625,7 +625,16 @@ export const GardenDashboardPage: React.FC = () => {
                           </button>
                         </div>
                         <div className="grid grid-cols-3 gap-0">
-                          <div className="col-span-1 h-36 bg-cover bg-center rounded-l-2xl" style={{ backgroundImage: `url(${gp.plant?.image || ''})` }} />
+                          <div className="col-span-1 h-36 rounded-l-2xl overflow-hidden bg-stone-100">
+                            {gp.plant?.image ? (
+                              <img
+                                src={gp.plant.image}
+                                alt={gp.nickname || gp.plant?.name || 'Plant'}
+                                className="h-full w-full object-cover object-center select-none"
+                                draggable={false}
+                              />
+                            ) : null}
+                          </div>
                           <div className="col-span-2 p-3">
                             <div className="font-medium">{gp.nickname || gp.plant?.name}</div>
                             {gp.nickname && <div className="text-xs opacity-60">{gp.plant?.name}</div>}

--- a/plant-swipe/src/pages/SearchPage.tsx
+++ b/plant-swipe/src/pages/SearchPage.tsx
@@ -26,11 +26,12 @@ export const SearchPage: React.FC<SearchPageProps> = ({ plants, openInfo, likedI
           <div className="grid grid-cols-3 gap-0">
             <div className="col-span-1 h-36 rounded-l-2xl overflow-hidden bg-stone-100">
               {p.image ? (
-              <img
+                <img
                   src={p.image}
                   alt={p.name}
                   loading="lazy"
-                  className="h-full w-full object-cover object-center"
+                  draggable={false}
+                  className="block h-full w-full object-cover object-center select-none"
                 />
               ) : null}
             </div>


### PR DESCRIPTION
Refactor plant card images in the Garden Dashboard to use `<img>` tags with `object-cover object-center` for consistent centering and cropping.

---
<a href="https://cursor.com/background-agent?bcId=bc-b3cbeaca-018f-4f36-9fae-8d3f7bfc923e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b3cbeaca-018f-4f36-9fae-8d3f7bfc923e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

