### PR TITLE
Normalize online data time zone

### DIFF
--- a/plant-swipe/server.js
+++ b/plant-swipe/server.js
@@ -773,10 +773,10 @@ app.get('/api/admin/visitors-stats', async (req, res) => {
   try {
     // Unique IPs in recent windows
     const [rows10m, rows30m, rows60mUnique, rows60mRaw] = await Promise.all([
-      sql`select count(distinct v.ip_address::text)::int as c from public.web_visits v where v.ip_address is not null and v.occurred_at >= now() - interval '10 minutes'`,
-      sql`select count(distinct v.ip_address::text)::int as c from public.web_visits v where v.ip_address is not null and v.occurred_at >= now() - interval '30 minutes'`,
-      sql`select count(distinct v.ip_address::text)::int as c from public.web_visits v where v.ip_address is not null and v.occurred_at >= now() - interval '60 minutes'`,
-      sql`select count(*)::int as c from public.web_visits where occurred_at >= now() - interval '60 minutes'`,
+      sql`select count(distinct v.ip_address::text)::int as c from public.web_visits v where v.ip_address is not null and (v.occurred_at at time zone 'utc') >= (now() at time zone 'utc') - interval '10 minutes'`,
+      sql`select count(distinct v.ip_address::text)::int as c from public.web_visits v where v.ip_address is not null and (v.occurred_at at time zone 'utc') >= (now() at time zone 'utc') - interval '30 minutes'`,
+      sql`select count(distinct v.ip_address::text)::int as c from public.web_visits v where v.ip_address is not null and (v.occurred_at at time zone 'utc') >= (now() at time zone 'utc') - interval '60 minutes'`,
+      sql`select count(*)::int as c from public.web_visits where (occurred_at at time zone 'utc') >= (now() at time zone 'utc') - interval '60 minutes'`,
     ])
     const currentUniqueVisitors10m = rows10m?.[0]?.c ?? 0
     const uniqueIpsLast30m = rows30m?.[0]?.c ?? 0


### PR DESCRIPTION
Normalize "currently online" queries to UTC to ensure consistent visitor statistics regardless of the viewer's local timezone.

---
<a href="https://cursor.com/background-agent?bcId=bc-a5fb2cd6-0201-4b85-829a-318f09714104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a5fb2cd6-0201-4b85-829a-318f09714104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

