### PR TITLE
Style plant cards and search images

### DIFF
--- a/plant-swipe/src/pages/GardenDashboardPage.tsx
+++ b/plant-swipe/src/pages/GardenDashboardPage.tsx
@@ -624,8 +624,8 @@ export const GardenDashboardPage: React.FC = () => {
                             <Info className="h-4 w-4" />
                           </button>
                         </div>
-                        <div className="grid grid-cols-3 gap-0">
-                          <div className="col-span-1 h-36 rounded-l-2xl overflow-hidden bg-stone-100">
+                        <div className="grid grid-cols-3 items-stretch gap-0">
+                          <div className="col-span-1 h-full min-h-[148px] rounded-l-2xl overflow-hidden bg-stone-100">
                             {gp.plant?.image ? (
                               <img
                                 src={gp.plant.image}

--- a/plant-swipe/src/pages/SearchPage.tsx
+++ b/plant-swipe/src/pages/SearchPage.tsx
@@ -23,8 +23,8 @@ export const SearchPage: React.FC<SearchPageProps> = ({ plants, openInfo, likedI
           tabIndex={0}
           onKeyDown={(e: React.KeyboardEvent<HTMLDivElement>) => { if (e.key === 'Enter') openInfo(p) }}
         >
-          <div className="grid grid-cols-3 gap-0">
-            <div className="col-span-1 h-36 rounded-l-2xl overflow-hidden bg-stone-100">
+          <div className="grid grid-cols-3 items-stretch gap-0">
+            <div className="col-span-1 h-full min-h-[148px] rounded-l-2xl overflow-hidden bg-stone-100">
               {p.image ? (
                 <img
                   src={p.image}


### PR DESCRIPTION
Adjust plant card image containers to fill the left column vertically without gaps, improving visual consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-ae221298-495b-4c14-984f-c73fa5f12a8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ae221298-495b-4c14-984f-c73fa5f12a8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

