### PR TITLE
Fix online visitors count display

### DIFF
--- a/plant-swipe/src/pages/AdminPage.tsx
+++ b/plant-swipe/src/pages/AdminPage.tsx
@@ -201,8 +201,9 @@ export const AdminPage: React.FC = () => {
     const load = async () => {
       try {
         const token = (await supabase.auth.getSession()).data.session?.access_token
-        if (!token) return
-        const resp = await fetch('/api/admin/visitors-stats', { headers: { 'Authorization': `Bearer ${token}` } })
+        const headers: Record<string, string> = {}
+        if (token) headers['Authorization'] = `Bearer ${token}`
+        const resp = await fetch('/api/admin/visitors-stats', { headers })
         const data = await resp.json().catch(() => ({}))
         if (resp.ok && !cancelled) {
           const val: number = Number.isFinite(Number(data?.uniqueIpsLast60m)) ? Number(data.uniqueIpsLast60m) : 0
@@ -245,10 +246,9 @@ export const AdminPage: React.FC = () => {
       setVisitorsError(null)
       try {
         const token = (await supabase.auth.getSession()).data.session?.access_token
-        if (!token) {
-          throw new Error('Not authenticated')
-        }
-        const resp = await fetch('/api/admin/visitors-stats', { headers: { 'Authorization': `Bearer ${token}` } })
+        const headers: Record<string, string> = {}
+        if (token) headers['Authorization'] = `Bearer ${token}`
+        const resp = await fetch('/api/admin/visitors-stats', { headers })
         const data = await resp.json().catch(() => ({}))
         if (!resp.ok) {
           throw new Error(data?.error || `Request failed (${resp.status})`)


### PR DESCRIPTION
Fetch visitor statistics on `AdminPage.tsx` without requiring authentication.

The "Currently online" widget was not populating because the API call to `/api/admin/visitors-stats` was only made if an authentication token was present. This change ensures the call is always made, including the authorization header only if a session exists, allowing the widget to display unique IP visits for the last 60 minutes as intended.

---
<a href="https://cursor.com/background-agent?bcId=bc-817c8590-1e13-40b2-bdd1-4d34670ef2ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-817c8590-1e13-40b2-bdd1-4d34670ef2ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

