### PR TITLE
Restart server button execution

### DIFF
--- a/admin_api/nginx-snippet.conf
+++ b/admin_api/nginx-snippet.conf
@@ -1,17 +1,23 @@
 location = /admin/restart-app {
     limit_except POST { deny all; }
+    allow 127.0.0.1;
+    deny all;
     proxy_pass http://127.0.0.1:5001/admin/restart-app;
     proxy_set_header X-Real-IP $remote_addr;
 }
 
 location = /admin/reload-nginx {
     limit_except POST { deny all; }
+    allow 127.0.0.1;
+    deny all;
     proxy_pass http://127.0.0.1:5001/admin/reload-nginx;
     proxy_set_header X-Real-IP $remote_addr;
 }
 
 location = /admin/reboot {
     limit_except POST { deny all; }
+    allow 127.0.0.1;
+    deny all;
     proxy_pass http://127.0.0.1:5001/admin/reboot;
     proxy_set_header X-Real-IP $remote_addr;
 }


### PR DESCRIPTION
Wire the 'Restart Server' button to securely trigger a full host reboot via the Python admin API.

The previous implementation only restarted the Node.js application. This change enables a complete server reboot by delegating the action to a Python service, protected by Nginx access restrictions and HMAC/static token authentication.

---
<a href="https://cursor.com/background-agent?bcId=bc-39ac4c41-08e0-4dd2-8472-dc233f33ebbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-39ac4c41-08e0-4dd2-8472-dc233f33ebbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

