### PR TITLE
Fix plant more info modal display

### DIFF
--- a/plant-swipe/src/pages/GardenDashboardPage.tsx
+++ b/plant-swipe/src/pages/GardenDashboardPage.tsx
@@ -648,7 +648,7 @@ export const GardenDashboardPage: React.FC = () => {
                       >
                         <div className="absolute top-2 right-2 z-10">
                           <button
-                            onClick={(e: any) => { e.stopPropagation(); if (gp?.plant) navigate(`/plants/${gp.plant.id}`) }}
+                            onClick={(e: any) => { e.stopPropagation(); if (gp?.plant) navigate(`/plants/${gp.plant.id}`, { state: { backgroundLocation: location } }) }}
                             onMouseDown={(e: any) => e.stopPropagation()}
                             onTouchStart={(e: any) => e.stopPropagation()}
                             aria-label="More information"


### PR DESCRIPTION
Implement Plant More Info as a bottom sheet overlay with swipe-to-close to restore previous UX and fix `DialogTitle` error.

---
<a href="https://cursor.com/background-agent?bcId=bc-8f4c6b15-5f82-48f7-969b-44d980223d2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8f4c6b15-5f82-48f7-969b-44d980223d2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

