### PR TITLE
Fix garden picture link update bug

### DIFF
--- a/plant-swipe/supabase/000_sync_schema.sql
+++ b/plant-swipe/supabase/000_sync_schema.sql
@@ -360,10 +360,14 @@ do $$ begin
   end if;
 end $$;
 do $$ begin
-  if not exists (select 1 from pg_policies where schemaname='public' and tablename='gardens' and policyname='gardens_update') then
-    create policy gardens_update on public.gardens for update to authenticated
-      using (created_by = (select auth.uid()));
+  if exists (select 1 from pg_policies where schemaname='public' and tablename='gardens' and policyname='gardens_update') then
+    drop policy gardens_update on public.gardens;
   end if;
+  create policy gardens_update on public.gardens for update to authenticated
+    using (
+      created_by = (select auth.uid())
+      or public.is_garden_owner_bypass(id, (select auth.uid()))
+    );
 end $$;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='gardens' and policyname='gardens_delete') then


### PR DESCRIPTION
Enable garden owners to update garden details, including the cover image URL, and display save errors in the UI.

---
<a href="https://cursor.com/background-agent?bcId=bc-dd5066b3-1d1f-45c3-a651-9bf52d4e9455"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dd5066b3-1d1f-45c3-a651-9bf52d4e9455"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

