### PR TITLE
Show all members in the same garden

### DIFF
--- a/plant-swipe/supabase/000_sync_schema.sql
+++ b/plant-swipe/supabase/000_sync_schema.sql
@@ -405,7 +405,8 @@ drop policy if exists "__gm_temp_all" on public.garden_members;
 drop policy if exists gm_select on public.garden_members;
 create policy gm_select on public.garden_members for select to authenticated
   using (
-    user_id = (select auth.uid())
+    -- Any member of the garden can read all memberships for that garden
+    public.is_garden_member_bypass(garden_id, (select auth.uid()))
     or public.is_garden_creator_bypass(garden_id, (select auth.uid()))
   );
 

--- a/plant-swipe/supabase/gardens_schema.sql
+++ b/plant-swipe/supabase/gardens_schema.sql
@@ -457,8 +457,10 @@ do $$ begin
   if exists (select 1 from pg_policies where schemaname = 'public' and tablename = 'garden_members' and policyname = 'gm_select') then
     drop policy gm_select on public.garden_members;
   end if;
+  -- Allow any member of a garden to read all its members.
+  -- Uses security-definer helper to avoid RLS self-recursion.
   create policy gm_select on public.garden_members for select to authenticated
-    using (user_id = auth.uid());
+    using (public.is_garden_member_bypass(garden_id, auth.uid()));
 end $$;
 do $$ begin
   if exists (select 1 from pg_policies where schemaname = 'public' and tablename = 'garden_members' and policyname = 'gm_insert') then


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Update Supabase RLS policy to allow garden members to view all other garden members.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous RLS policy for `garden_members` only allowed users to see their own entry, preventing them from viewing other members or the garden owner. This change enables members to see all members of the same garden, addressing the user's request.

---
<a href="https://cursor.com/background-agent?bcId=bc-3ea87f47-f492-46ab-b809-18e16b90838e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3ea87f47-f492-46ab-b809-18e16b90838e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

