### PR TITLE
Update routine garden weekly task display

### DIFF
--- a/plant-swipe/src/pages/GardenDashboardPage.tsx
+++ b/plant-swipe/src/pages/GardenDashboardPage.tsx
@@ -182,6 +182,27 @@ export const GardenDashboardPage: React.FC = () => {
         const totals = weekDaysIso.map((_, i) => typeCounts.water[i] + typeCounts.fertilize[i] + typeCounts.harvest[i] + typeCounts.cut[i] + typeCounts.custom[i])
         setWeekCountsByType(typeCounts)
         setWeekCounts(totals)
+
+        // Build per-plant upcoming days (Mon=0..Sun=6) for "Due this week"
+        const dueMapSets: Record<string, Set<number>> = {}
+        for (const o of weekOccs) {
+          const dayIso = new Date(o.dueAt).toISOString().slice(0,10)
+          // Only consider remaining work and days from today forward (upcoming)
+          const remaining = Math.max(0, Number(o.requiredCount || 1) - Number(o.completedCount || 0))
+          if (remaining <= 0) continue
+          if (dayIso <= today) continue
+          const idx = weekDaysIso.indexOf(dayIso)
+          if (idx >= 0) {
+            const pid = String(o.gardenPlantId)
+            if (!dueMapSets[pid]) dueMapSets[pid] = new Set<number>()
+            dueMapSets[pid].add(idx)
+          }
+        }
+        const dueMap: Record<string, number[]> = {}
+        for (const pid of Object.keys(dueMapSets)) {
+          dueMap[pid] = Array.from(dueMapSets[pid]).sort((a, b) => a - b)
+        }
+        setDueThisWeekByPlant(dueMap)
       }
 
       // Determine due-today plants from task occurrences


### PR DESCRIPTION
Populate 'Due this week' list to reflect upcoming tasks shown in the weekly graph.

Previously, the 'Due this week' list was not populated. This change computes upcoming task days for each plant from the weekly task occurrences, filtering for remaining work and days strictly after today, ensuring consistency with the weekly graph.

---
<a href="https://cursor.com/background-agent?bcId=bc-06640a5a-6d7c-4a23-8e75-2b8c41def54d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-06640a5a-6d7c-4a23-8e75-2b8c41def54d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

