### PR TITLE
Fix and test online card functionality

### DIFF
--- a/plant-swipe/src/pages/AdminPage.tsx
+++ b/plant-swipe/src/pages/AdminPage.tsx
@@ -351,6 +351,14 @@ export const AdminPage: React.FC = () => {
     loadOnlineUsers({ initial: true })
   }, [loadOnlineUsers])
 
+  // Auto-refresh the "Currently online" count every minute
+  React.useEffect(() => {
+    const intervalId = setInterval(() => {
+      loadOnlineUsers({ initial: false })
+    }, 60_000)
+    return () => clearInterval(intervalId)
+  }, [loadOnlineUsers])
+
   // Load visitors stats (last 7 days)
   const loadVisitorsStats = React.useCallback(async (opts?: { initial?: boolean }) => {
     const isInitial = !!opts?.initial


### PR DESCRIPTION
Add a 60-second auto-refresh to the "Currently online" card to ensure the count stays current.

---
<a href="https://cursor.com/background-agent?bcId=bc-d2354da7-7d90-4e69-ba0b-02ce83016857"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d2354da7-7d90-4e69-ba0b-02ce83016857"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

