### PR TITLE
Debug online card display zero issue

### DIFF
--- a/plant-swipe/server.js
+++ b/plant-swipe/server.js
@@ -13,6 +13,7 @@ import { promisify } from 'util'
 import zlib from 'zlib'
 import crypto from 'crypto'
 import { pipeline as streamPipeline } from 'stream'
+import net from 'net'
 
 
 dotenv.config()
@@ -295,10 +296,11 @@ function normalizeIp(ip) {
     }
     // Handle IPv6-mapped IPv4 addresses like ::ffff:127.0.0.1
     const v4mapped = out.match(/::ffff:(\d{1,3}(?:\.\d{1,3}){3})/i)
-    if (v4mapped) return v4mapped[1]
-    return out.toLowerCase()
+    if (v4mapped) out = v4mapped[1]
+    const lower = out.toLowerCase()
+    return net.isIP(lower) ? lower : ''
   } catch {
-    return typeof ip === 'string' ? ip : ''
+    return ''
   }
 }
 
@@ -812,13 +814,13 @@ app.get('/api/admin/online-users', async (req, res) => {
     return
   }
   try {
-    const rows = await sql`
-      select count(distinct v.ip_address)::int as c
-      from public.web_visits v
-      where v.ip_address is not null
-        and v.occurred_at >= now() - interval '60 minutes'
-    `
-    const onlineUsers = rows?.[0]?.c ?? 0
+    const [ipRows, sessionRows] = await Promise.all([
+      sql`select count(distinct v.ip_address)::int as c from public.web_visits v where v.ip_address is not null and v.occurred_at >= now() - interval '60 minutes'`,
+      sql`select count(distinct v.session_id)::int as c from public.web_visits v where v.occurred_at >= now() - interval '60 minutes'`,
+    ])
+    const ipCount = ipRows?.[0]?.c ?? 0
+    const sessionCount = sessionRows?.[0]?.c ?? 0
+    const onlineUsers = ipCount > 0 ? ipCount : sessionCount
     res.json({ onlineUsers })
   } catch (e) {
     res.status(500).json({ error: e?.message || 'Failed to load online users' })


### PR DESCRIPTION
Improve online user count by robustly normalizing IPs and falling back to session IDs when IP counts are zero.

The "Currently online" card was consistently showing 0 because the `ip_address` values stored in the database were often invalid or malformed (e.g., due to proxy or IPv6 formats), causing the `count(distinct ip_address)` query to return zero. This PR ensures IPs are properly validated and normalized, and provides a fallback to count distinct `session_id`s for a more accurate online user count.

---
<a href="https://cursor.com/background-agent?bcId=bc-e2566ff3-10de-4329-bc10-1f206defef16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e2566ff3-10de-4329-bc10-1f206defef16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

