### PR TITLE
Fix database connection and health check

### DIFF
--- a/plant-swipe/src/lib/supabaseClient.ts
+++ b/plant-swipe/src/lib/supabaseClient.ts
@@ -1,9 +1,17 @@
 import { createClient } from '@supabase/supabase-js'
 import { getEnvAny } from '@/lib/utils'
 
-// Frontend should only consume VITE_ variables (never server secrets)
-const supabaseUrl = getEnvAny(['VITE_SUPABASE_URL'])
-const supabaseAnonKey = getEnvAny(['VITE_SUPABASE_ANON_KEY'])
+// Frontend should only consume public env vars. Accept common prefixes for portability.
+const supabaseUrl = getEnvAny([
+  'VITE_SUPABASE_URL',
+  'REACT_APP_SUPABASE_URL',
+  'NEXT_PUBLIC_SUPABASE_URL',
+])
+const supabaseAnonKey = getEnvAny([
+  'VITE_SUPABASE_ANON_KEY',
+  'REACT_APP_SUPABASE_ANON_KEY',
+  'NEXT_PUBLIC_SUPABASE_ANON_KEY',
+])
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
   auth: {


### PR DESCRIPTION
Standardize Supabase environment variable parsing and enhance database health check.

The Admin page's database connection status was red because the health check relied on a direct Postgres connection, which was not always configured, while the Supabase client was still functional. This PR adds support for common `REACT_APP_*` and `NEXT_PUBLIC_*` Supabase environment variable prefixes and implements a fallback health check using the Supabase anonymous client to accurately reflect connectivity.

---
<a href="https://cursor.com/background-agent?bcId=bc-8f4d7bb6-0719-459d-826c-6e5685a2c1c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8f4d7bb6-0719-459d-826c-6e5685a2c1c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

