### PR TITLE
Fix online user count display in admin

### DIFF
--- a/plant-swipe/src/pages/AdminPage.tsx
+++ b/plant-swipe/src/pages/AdminPage.tsx
@@ -453,7 +453,8 @@ export const AdminPage: React.FC = () => {
     if (isInitial) setOnlineLoading(true)
     else setOnlineRefreshing(true)
     try {
-      const resp = await fetch('/api/admin/online-users', {
+      // Use visitors-stats endpoint to reflect "currently online" via recent uniques
+      const resp = await fetch('/api/admin/visitors-stats', {
         headers: { 'Accept': 'application/json' },
         credentials: 'same-origin',
       })
@@ -461,7 +462,12 @@ export const AdminPage: React.FC = () => {
       if (!resp.ok) {
         throw new Error(data?.error || `Request failed (${resp.status})`)
       }
-      const num = Number(data?.onlineUsers)
+      const num = Number(
+        (data?.currentUniqueVisitors10m ??
+        data?.uniqueIpsLast30m ??
+        data?.uniqueIpsLast60m ??
+        data?.onlineUsers)
+      )
       setOnlineUsers(Number.isFinite(num) ? num : 0)
       setOnlineUpdatedAt(Date.now())
     } catch {


### PR DESCRIPTION
Update the Admin page to use the new visitor stats endpoint for a more accurate 'Currently online' count.

---
<a href="https://cursor.com/background-agent?bcId=bc-ceb90e63-709e-4e59-bdab-21adb3f6ba57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ceb90e63-709e-4e59-bdab-21adb3f6ba57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

