### PR TITLE
Recenter admin graph display

### DIFF
--- a/plant-swipe/src/pages/AdminPage.tsx
+++ b/plant-swipe/src/pages/AdminPage.tsx
@@ -733,7 +733,7 @@ export const AdminPage: React.FC = () => {
                           <ResponsiveContainer width="100%" height="100%">
                             <ComposedChart
                               data={visitorsSeries}
-                              margin={{ top: 10, right: 8, bottom: 8, left: 0 }}
+                              margin={{ top: 10, right: 16, bottom: 14, left: 16 }}
                             >
                               <defs>
                                 <linearGradient id="visitsLineGrad" x1="0" y1="0" x2="1" y2="0">
@@ -754,6 +754,7 @@ export const AdminPage: React.FC = () => {
                                 axisLine={false}
                                 tickLine={false}
                                 interval={0}
+                                padding={{ left: 12, right: 12 }}
                               />
                               <YAxis
                                 allowDecimals={false}
@@ -763,7 +764,13 @@ export const AdminPage: React.FC = () => {
                                 tickLine={false}
                               />
                               <Tooltip content={<TooltipContent />} cursor={{ stroke: 'rgba(0,0,0,0.1)' }} />
-                              <ReferenceLine y={avgVal} stroke="#a3a3a3" strokeDasharray="4 4" ifOverflow="extendDomain" label={{ value: 'avg', position: 'right', fill: '#737373', fontSize: 11 }} />
+                              <ReferenceLine
+                                y={avgVal}
+                                stroke="#a3a3a3"
+                                strokeDasharray="4 4"
+                                ifOverflow="extendDomain"
+                                label={{ value: 'avg', position: 'insideRight', fill: '#737373', fontSize: 11, dx: -6 }}
+                              />
 
                               <Area type="monotone" dataKey="uniqueVisitors" fill="url(#visitsAreaGrad)" stroke="none" animationDuration={600} />
                               <Line


### PR DESCRIPTION
Recenter the Admin page graph and prevent the average reference line label from being cut off.

---
<a href="https://cursor.com/background-agent?bcId=bc-a0484bb0-da65-411b-828a-3f0bbd3a69dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a0484bb0-da65-411b-828a-3f0bbd3a69dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

