### PR TITLE
Fix sql function return type error

### DIFF
--- a/plant-swipe/supabase/000_sync_schema.sql
+++ b/plant-swipe/supabase/000_sync_schema.sql
@@ -894,6 +894,8 @@ security definer
 set search_path = public
 as $$ select id from auth.users where email ilike _email limit 1; $$;
 
+-- Ensure we can change the return table shape if it evolved
+drop function if exists public.get_profiles_for_garden(uuid);
 create or replace function public.get_profiles_for_garden(_garden_id uuid)
 returns table(user_id uuid, display_name text, email text)
 language sql

--- a/plant-swipe/supabase/gardens_schema.sql
+++ b/plant-swipe/supabase/gardens_schema.sql
@@ -544,7 +544,8 @@ as $$
   select id from auth.users where email ilike _email limit 1;
 $$;
 
--- Return profiles (id, display_name) for all members of a garden
+-- Ensure we can change the return table shape if it evolved
+drop function if exists public.get_profiles_for_garden(uuid);
 create or replace function public.get_profiles_for_garden(_garden_id uuid)
 returns table(user_id uuid, display_name text, email text)
 language sql


### PR DESCRIPTION
Add `DROP FUNCTION IF EXISTS` before `CREATE OR REPLACE FUNCTION` for `get_profiles_for_garden` to resolve the `cannot change return type of existing function` error during schema sync.

---
<a href="https://cursor.com/background-agent?bcId=bc-a8f996f5-1631-4fe6-af63-da548f00eca9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a8f996f5-1631-4fe6-af63-da548f00eca9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

