### PR TITLE
Disable swipe to close on more info page

### DIFF
--- a/plant-swipe/src/components/plant/PlantDetails.tsx
+++ b/plant-swipe/src/components/plant/PlantDetails.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { useNavigate } from "react-router-dom";
-import { motion, useMotionValue } from "framer-motion";
 import { SheetHeader, SheetTitle, SheetDescription } from "@/components/ui/sheet";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -15,12 +14,6 @@ import { useAuth } from "@/context/AuthContext";
 export const PlantDetails: React.FC<{ plant: Plant; onClose: () => void; liked?: boolean; onToggleLike?: () => void }> = ({ plant, onClose, liked = false, onToggleLike }) => {
   const navigate = useNavigate()
   const { user } = useAuth()
-  const y = useMotionValue(0)
-  const threshold = 120
-  const onDragEnd = (_: unknown, info: { offset: { y: number }; velocity: { y: number } }) => {
-    const dy = info.offset.y + info.velocity.y * 0.2
-    if (dy > threshold) onClose()
-  }
   const freqAmountRaw = plant.waterFreqAmount ?? plant.waterFreqValue
   const freqAmount = typeof freqAmountRaw === 'number' ? freqAmountRaw : Number(freqAmountRaw || 0)
   const freqPeriod = (plant.waterFreqPeriod || plant.waterFreqUnit) as 'day' | 'week' | 'month' | 'year' | undefined
@@ -29,7 +22,7 @@ export const PlantDetails: React.FC<{ plant: Plant; onClose: () => void; liked?:
     ? `${freqAmount > 0 ? `${freqAmount} ${freqAmount === 1 ? 'time' : 'times'} ` : ''}per ${freqPeriod}`
     : null
   return (
-    <motion.div className="space-y-4 select-none" drag="y" style={{ y }} dragConstraints={{ top: 0, bottom: 0 }} onDragEnd={onDragEnd}>
+    <div className="space-y-4 select-none">
       <div className="grid md:grid-cols-2 gap-4 items-center">
         <SheetHeader className="text-left">
           <SheetTitle className="text-3xl md:text-4xl font-bold leading-tight">{plant.name}</SheetTitle>
@@ -118,7 +111,7 @@ export const PlantDetails: React.FC<{ plant: Plant; onClose: () => void; liked?:
           <Button className="rounded-2xl" onClick={onClose}>Close</Button>
         </div>
       </div>
-    </motion.div>
+    </div>
   );
 };
 


### PR DESCRIPTION
Disable swipe-to-close on More Info page to allow mobile users to scroll content normally.

---
<a href="https://cursor.com/background-agent?bcId=bc-a4a4099d-bc3e-40b1-9e85-3b1fe9e799b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a4a4099d-bc3e-40b1-9e85-3b1fe9e799b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

