### PR TITLE
Fix admin page access for administrators

### DIFF
--- a/plant-swipe/server.js
+++ b/plant-swipe/server.js
@@ -968,6 +968,16 @@ app.get('/api/admin/member', async (req, res) => {
   }
 })
 
+// Admin: whoami — lightweight check if current request has admin privileges
+app.get('/api/admin/whoami', async (req, res) => {
+  try {
+    const isAdmin = await isAdminFromRequest(req)
+    res.json({ ok: true, isAdmin })
+  } catch (e) {
+    res.status(500).json({ ok: false, error: e?.message || 'whoami failed' })
+  }
+})
+
 // Admin: suggest emails by prefix for autocomplete (top 3)
 app.get('/api/admin/member-suggest', async (req, res) => {
   try {

--- a/plant-swipe/src/PlantSwipe.tsx
+++ b/plant-swipe/src/PlantSwipe.tsx
@@ -27,7 +27,7 @@ import { supabase } from "@/lib/supabaseClient";
 
 // --- Main Component ---
 export default function PlantSwipe() {
-  const { user, signIn, signUp, signOut, profile, refreshProfile } = useAuth()
+  const { user, signIn, signUp, signOut, profile, refreshProfile, loading } = useAuth()
   const [query, setQuery] = useState("")
   const [seasonFilter, setSeasonFilter] = useState<string | null>(null)
   const [colorFilter, setColorFilter] = useState<string | null>(null)
@@ -639,7 +639,18 @@ export default function PlantSwipe() {
                   }
                 />
                 <Route path="/profile" element={user ? <ProfilePage /> : <Navigate to="/" replace />} />
-                <Route path="/admin" element={profile?.is_admin ? <AdminPage /> : <Navigate to="/" replace />} />
+                <Route
+                  path="/admin"
+                  element={
+                    loading
+                      ? (
+                        <div className="p-8 text-center text-sm opacity-60">Checking admin access…</div>
+                      )
+                      : profile?.is_admin
+                        ? <AdminPage />
+                        : <Navigate to="/" replace />
+                  }
+                />
                 <Route path="/create" element={user ? (
                   <CreatePlantPage
                     onCancel={() => navigate('/')}

--- a/plant-swipe/src/context/AuthContext.tsx
+++ b/plant-swipe/src/context/AuthContext.tsx
@@ -53,6 +53,21 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     ;(async () => {
       // Before first paint: load session then profile (if any) and only then render
       await loadSession()
+      // Hydrate profile from localStorage immediately if it matches current user
+      try {
+        const uid = (await supabase.auth.getUser()).data.user?.id
+        if (uid) {
+          const raw = localStorage.getItem('plantswipe.profile')
+          if (raw) {
+            try {
+              const cached = JSON.parse(raw)
+              if (cached && typeof cached === 'object' && cached.id === uid) {
+                setProfile(cached as any)
+              }
+            } catch {}
+          }
+        }
+      } catch {}
       // Profile in background to reduce chances of startup stalls
       refreshProfile().catch(() => {})
       setLoading(false)


### PR DESCRIPTION
Fix admin page access by ensuring the user profile is loaded before authorization checks.

The admin page was inaccessible because the `profile` (containing `is_admin`) was not always loaded before the route guard evaluated, leading to a redirect even for legitimate admins. This PR hydrates the profile from local storage on startup and introduces a loading state for the admin route to prevent premature redirects. Additionally, a new `/api/admin/whoami` endpoint is added for lightweight admin status checks.

---
<a href="https://cursor.com/background-agent?bcId=bc-ada60b70-be1f-430d-9f88-e647d9a91131"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ada60b70-be1f-430d-9f88-e647d9a91131"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

