### PR TITLE
Fix admin api errors and update stats

### DIFF
--- a/plant-swipe/server.js
+++ b/plant-swipe/server.js
@@ -1804,8 +1804,26 @@ app.post('/api/track-visit', async (req, res) => {
 app.get('/api/admin/visitors-stats', async (req, res) => {
   const uid = "public"
   if (!uid) return
+  // Helper that always succeeds using in-memory analytics
+  const respondFromMemory = (extra = {}) => {
+    try {
+      const currentUniqueVisitors10m = memAnalytics.getUniqueIpCountInLastMinutes(10)
+      const uniqueIpsLast30m = memAnalytics.getUniqueIpCountInLastMinutes(30)
+      const uniqueIpsLast60m = memAnalytics.getUniqueIpCountInLastMinutes(60)
+      const visitsLast60m = memAnalytics.getVisitCountInLastMinutes(60)
+      const uniqueIps7d = memAnalytics.getUniqueIpCountInLastDays(7)
+      const series7d = memAnalytics.getDailySeries(7)
+      res.json({ ok: true, currentUniqueVisitors10m, uniqueIpsLast30m, uniqueIpsLast60m, visitsLast60m, uniqueIps7d, series7d, via: 'memory', ...extra })
+      return true
+    } catch {
+      return false
+    }
+  }
   try {
-    if (!sql) throw new Error('DB_NOT_CONFIGURED')
+    if (!sql) {
+      respondFromMemory()
+      return
+    }
 
     const [rows10m, rows30m, rows60mUnique, rows60mRaw, rows7dUnique] = await Promise.all([
       sql`select count(distinct v.ip_address)::int as c from public.web_visits v where v.ip_address is not null and v.occurred_at >= now() - interval '10 minutes'`,
@@ -1839,9 +1857,12 @@ app.get('/api/admin/visitors-stats', async (req, res) => {
     `
     const series7d = (rows7 || []).map(r => ({ date: new Date(r.day).toISOString().slice(0,10), uniqueVisitors: Number(r.unique_visitors || 0) }))
 
-    res.json({ ok: true, currentUniqueVisitors10m, uniqueIpsLast30m, uniqueIpsLast60m, visitsLast60m, uniqueIps7d, series7d })
+    res.json({ ok: true, currentUniqueVisitors10m, uniqueIpsLast30m, uniqueIpsLast60m, visitsLast60m, uniqueIps7d, series7d, via: 'database' })
   } catch (e) {
-    res.status(500).json({ ok: false, error: e?.message || 'DB query failed' })
+    // On DB failure, fall back to in-memory analytics instead of 500s
+    if (!respondFromMemory({ error: e?.message || 'DB query failed' })) {
+      res.status(500).json({ ok: false, error: e?.message || 'DB query failed' })
+    }
   }
 })
 
@@ -1849,15 +1870,29 @@ app.get('/api/admin/visitors-stats', async (req, res) => {
 app.get('/api/admin/online-users', async (req, res) => {
   const uid = "public"
   if (!uid) return
+  const respondFromMemory = (extra = {}) => {
+    try {
+      const ipCount = memAnalytics.getUniqueIpCountInLastMinutes(60)
+      res.json({ ok: true, onlineUsers: ipCount, via: 'memory', ...extra })
+      return true
+    } catch {
+      return false
+    }
+  }
   try {
-    if (!sql) throw new Error('DB_NOT_CONFIGURED')
+    if (!sql) {
+      respondFromMemory()
+      return
+    }
     const [ipRows] = await Promise.all([
       sql`select count(distinct v.ip_address)::int as c from public.web_visits v where v.ip_address is not null and v.occurred_at >= now() - interval '60 minutes'`,
     ])
     const ipCount = ipRows?.[0]?.c ?? 0
-    res.json({ onlineUsers: ipCount })
+    res.json({ ok: true, onlineUsers: ipCount, via: 'database' })
   } catch (e) {
-    res.status(500).json({ error: e?.message || 'DB query failed' })
+    if (!respondFromMemory({ error: e?.message || 'DB query failed' })) {
+      res.status(500).json({ ok: false, error: e?.message || 'DB query failed' })
+    }
   }
 })
 


### PR DESCRIPTION
Implement in-memory analytics fallback for admin API endpoints to prevent 500 errors when the database is unavailable.

The previous implementation would return a 500 Internal Server Error if the database connection failed or was not configured. This change ensures that the `/api/admin/online-users` and `/api/admin/visitors-stats` endpoints always return a 200 OK response, providing data from an in-memory analytics counter if the database is not accessible. This allows the Admin page to function and display metrics consistently.

---
<a href="https://cursor.com/background-agent?bcId=bc-20fef125-b024-4570-b929-f9e4e472da76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-20fef125-b024-4570-b929-f9e4e472da76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

