### PR TITLE
Restrict admin page access to admins

### DIFF
--- a/plant-swipe/src/PlantSwipe.tsx
+++ b/plant-swipe/src/PlantSwipe.tsx
@@ -23,6 +23,7 @@ import PlantInfoPage from "@/pages/PlantInfoPage";
 import { useAuth } from "@/context/AuthContext";
 import { ProfilePage } from "@/pages/ProfilePage";
 import { AdminPage } from "@/pages/AdminPage";
+import RequireAdmin from "@/pages/RequireAdmin";
 import { supabase } from "@/lib/supabaseClient";
 
 // --- Main Component ---
@@ -639,7 +640,7 @@ export default function PlantSwipe() {
                   }
                 />
                 <Route path="/profile" element={user ? <ProfilePage /> : <Navigate to="/" replace />} />
-                <Route path="/admin" element={<AdminPage />} />
+                <Route path="/admin" element={<RequireAdmin><AdminPage /></RequireAdmin>} />
                 <Route path="/create" element={user ? (
                   <CreatePlantPage
                     onCancel={() => navigate('/')}

--- a/plant-swipe/src/context/AuthContext.tsx
+++ b/plant-swipe/src/context/AuthContext.tsx
@@ -21,7 +21,14 @@ const AuthContext = React.createContext<AuthContextValue | undefined>(undefined)
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [user, setUser] = React.useState<AuthUser | null>(null)
-  const [profile, setProfile] = React.useState<ProfileRow | null>(null)
+  const [profile, setProfile] = React.useState<ProfileRow | null>(() => {
+    try {
+      const cached = localStorage.getItem('plantswipe.profile')
+      return cached ? (JSON.parse(cached) as ProfileRow) : null
+    } catch {
+      return null
+    }
+  })
   const [loading, setLoading] = React.useState(true)
 
   const loadSession = React.useCallback(async () => {

--- a/plant-swipe/src/pages/RequireAdmin.tsx
+++ b/plant-swipe/src/pages/RequireAdmin.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import { Navigate } from 'react-router-dom'
+import { useAuth } from '@/context/AuthContext'
+
+const getCachedIsAdmin = (): boolean | null => {
+  try {
+    const s = localStorage.getItem('plantswipe.profile')
+    if (!s) return null
+    const obj = JSON.parse(s)
+    return obj && typeof obj.is_admin === 'boolean' ? obj.is_admin : null
+  } catch {
+    return null
+  }
+}
+
+export const RequireAdmin: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { user, profile, loading } = useAuth()
+
+  const cachedIsAdmin = React.useMemo(() => getCachedIsAdmin(), [])
+  const isAdmin = !!profile?.is_admin || cachedIsAdmin === true
+
+  // Cached negative: fail fast
+  if (cachedIsAdmin === false || profile?.is_admin === false) {
+    return <Navigate to="/" replace />
+  }
+
+  // If admin via cache, allow immediately (prevents flicker on reload)
+  if (cachedIsAdmin === true) return <>{children}</>
+
+  // If we don't have a user yet, wait while auth is resolving
+  if (!user) {
+    return loading ? null : <Navigate to="/" replace />
+  }
+
+  // User known but profile not yet resolved: hold to avoid rendering content early
+  if (user && !profile) return null
+
+  // Final check
+  if (!isAdmin) return <Navigate to="/" replace />
+
+  return <>{children}</>
+}
+
+export default RequireAdmin


### PR DESCRIPTION
Restrict access to the Admin page, redirecting non-admin users to the main page before content renders.

The `RequireAdmin` component now wraps the `/admin` route, performing an immediate redirect based on `profile.is_admin`. Profile data is hydrated from `localStorage` on startup to prevent flicker and ensure a swift redirect for non-admins.

---
<a href="https://cursor.com/background-agent?bcId=bc-9f04c554-5d72-42bc-859b-1c01c9cec52a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9f04c554-5d72-42bc-859b-1c01c9cec52a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

