### PR TITLE
Drop and recreate get_profiles_for_garden function

### DIFF
--- a/plant-swipe/supabase/000_sync_schema.sql
+++ b/plant-swipe/supabase/000_sync_schema.sql
@@ -1163,9 +1163,9 @@ as $$
   select count(*)::int from auth.users;
 $$;
 
--- Ensure we can change the return table shape if it evolved
-drop function if exists public.get_profiles_for_garden(uuid);
-create or replace function public.get_profiles_for_garden(_garden_id uuid)
+-- Drop and recreate to allow return type changes
+drop function if exists public.get_profiles_for_garden(uuid) cascade;
+create function public.get_profiles_for_garden(_garden_id uuid)
 returns table(user_id uuid, display_name text, email text)
 language sql
 security definer

--- a/plant-swipe/supabase/gardens_schema.sql
+++ b/plant-swipe/supabase/gardens_schema.sql
@@ -544,9 +544,9 @@ as $$
   select id from auth.users where email ilike _email limit 1;
 $$;
 
--- Ensure we can change the return table shape if it evolved
-drop function if exists public.get_profiles_for_garden(uuid);
-create or replace function public.get_profiles_for_garden(_garden_id uuid)
+-- Drop and recreate to allow return type changes
+drop function if exists public.get_profiles_for_garden(uuid) cascade;
+create function public.get_profiles_for_garden(_garden_id uuid)
 returns table(user_id uuid, display_name text, email text)
 language sql
 security definer


### PR DESCRIPTION
Update `get_profiles_for_garden` function definition to explicitly `DROP ... CASCADE` then `CREATE` to resolve `cannot change return type` errors during schema sync.

The `CREATE OR REPLACE FUNCTION` statement, even when preceded by a `DROP FUNCTION IF EXISTS`, can still fail if the return type of the function changes significantly (e.g., changing the number or type of columns in a `RETURNS TABLE` definition). Explicitly dropping with `CASCADE` and then creating ensures a clean recreation, allowing for such schema evolution without the `42P13` error.

---
<a href="https://cursor.com/background-agent?bcId=bc-f98d5404-fd1f-4827-b289-12c67c9366f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f98d5404-fd1f-4827-b289-12c67c9366f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

