### PR TITLE
Fetch unique dashboard visits past week

### DIFF
--- a/plant-swipe/src/pages/AdminPage.tsx
+++ b/plant-swipe/src/pages/AdminPage.tsx
@@ -572,8 +572,18 @@ export const AdminPage: React.FC = () => {
         ? data.series7d.map((d: any) => ({ date: String(d.date), uniqueVisitors: Number(d.uniqueVisitors ?? d.unique_visitors ?? 0) }))
         : []
       setVisitorsSeries(series)
-      const total7d = Number(data?.uniqueIps7d ?? data?.weeklyUniqueIps7d ?? 0)
-      setVisitorsTotalUnique7d(Number.isFinite(total7d) ? total7d : 0)
+      // Fetch weekly unique total from dedicated endpoint to keep requests separate
+      try {
+        const totalResp = await fetch('/api/admin/visitors-unique-7d', {
+          headers: { 'Accept': 'application/json' },
+          credentials: 'same-origin',
+        })
+        const totalData = await safeJson(totalResp)
+        if (totalResp.ok) {
+          const total7d = Number(totalData?.uniqueIps7d ?? totalData?.weeklyUniqueIps7d ?? 0)
+          setVisitorsTotalUnique7d(Number.isFinite(total7d) ? total7d : 0)
+        }
+      } catch {}
       setVisitorsUpdatedAt(Date.now())
     } catch {
       // keep last known


### PR DESCRIPTION
Separate the unique IP total for the past 7 days into its own API endpoint and frontend request, as per user requirement.

---
<a href="https://cursor.com/background-agent?bcId=bc-1a475cdb-35ee-4ba5-abe9-e445bed62ed2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1a475cdb-35ee-4ba5-abe9-e445bed62ed2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

