### PR TITLE
Drop and recreate get_user_profile_public_stats function

### DIFF
--- a/plant-swipe/supabase/000_sync_schema.sql
+++ b/plant-swipe/supabase/000_sync_schema.sql
@@ -1048,6 +1048,7 @@ $$;
 grant execute on function public.get_profile_public_by_display_name(text) to anon, authenticated;
 
 -- Aggregate public stats for a user's gardens/membership
+drop function if exists public.get_user_profile_public_stats(uuid) cascade;
 create or replace function public.get_user_profile_public_stats(_user_id uuid)
 returns table(plants_total integer, best_streak integer)
 language plpgsql


### PR DESCRIPTION
Add `DROP FUNCTION CASCADE` for `get_user_profile_public_stats` to resolve migration error when changing its return type.

---
<a href="https://cursor.com/background-agent?bcId=bc-43585e53-aa15-47bd-89a6-8ad4e32bc25f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-43585e53-aa15-47bd-89a6-8ad4e32bc25f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

