### PR TITLE
Fix function return type error in 000_sync_sql

### DIFF
--- a/plant-swipe/supabase/000_sync_schema.sql
+++ b/plant-swipe/supabase/000_sync_schema.sql
@@ -1033,6 +1033,7 @@ end $$;
 -- ========== RPCs used by the app ==========
 -- Public profile fetch by display name (safe columns only) with admin flag, joined_at, and presence
 drop function if exists public.get_profile_public_by_username(text);
+drop function if exists public.get_profile_public_by_display_name(text);
 create or replace function public.get_profile_public_by_display_name(_name text)
 returns table(
   id uuid,


### PR DESCRIPTION
Add `DROP FUNCTION IF EXISTS` for `get_profile_public_by_display_name` to resolve the "cannot change return type of existing function" error during schema synchronization.

---
<a href="https://cursor.com/background-agent?bcId=bc-cce253a6-f39d-4457-a446-6399fb575ac0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cce253a6-f39d-4457-a446-6399fb575ac0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

