### PR TITLE
Fix garden button layout and mobile nav

### DIFF
--- a/plant-swipe/src/PlantSwipe.tsx
+++ b/plant-swipe/src/PlantSwipe.tsx
@@ -469,8 +469,8 @@ export default function PlantSwipe() {
     onLogout={async () => { await signOut(); navigate('/') }}
   />
 
-      {/* Mobile bottom nav */}
-      <MobileNavBar canCreate={Boolean(user)} />
+      {/* Mobile bottom nav (hide Create on phones) */}
+      <MobileNavBar canCreate={false} />
 
       {/* Layout: grid only when search view (to avoid narrow column in other views) */}
       <div className={`max-w-6xl mx-auto mt-6 ${currentView === 'search' ? 'lg:grid lg:grid-cols-[260px_1fr] lg:gap-10' : ''}`}>

--- a/plant-swipe/src/components/layout/BottomBar.tsx
+++ b/plant-swipe/src/components/layout/BottomBar.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 
 export const BottomBar: React.FC = () => (
-  <footer className="max-w-5xl mx-auto mt-10 text-center text-xs opacity-60 px-2 overflow-x-hidden hidden md:block">
+  <footer className="max-w-6xl mx-auto mt-10 text-center text-xs opacity-60 px-2 overflow-x-hidden hidden md:block">
     © {new Date().getFullYear()} PlantSwipe. All rights reserved.
   </footer>
 )

--- a/plant-swipe/src/components/layout/MobileNavBar.tsx
+++ b/plant-swipe/src/components/layout/MobileNavBar.tsx
@@ -40,7 +40,7 @@ export const MobileNavBar: React.FC<MobileNavBarProps> = ({ canCreate }) => {
       role="navigation"
       aria-label="Primary"
     >
-      <div className="relative mx-auto max-w-5xl px-6 pt-3 pb-3">
+      <div className="relative mx-auto max-w-6xl px-6 pt-3 pb-3">
         {/* Center floating create button */}
         {canCreate && (
           <div className="pointer-events-none absolute -top-6 left-1/2 -translate-x-1/2">

--- a/plant-swipe/src/components/layout/TopBar.tsx
+++ b/plant-swipe/src/components/layout/TopBar.tsx
@@ -77,7 +77,7 @@ export const TopBar: React.FC<TopBarProps> = ({ openLogin, openSignup, user, dis
   }, [user?.id])
   const label = displayName && displayName.trim().length > 0 ? displayName : 'Profile'
   return (
-    <header className="max-w-5xl mx-auto w-full flex items-center gap-3 px-2 overflow-x-hidden">
+    <header className="max-w-6xl mx-auto w-full flex items-center gap-3 px-2 overflow-x-hidden">
       <div className="h-10 w-10 rounded-2xl bg-green-200 flex items-center justify-center shadow">
         <Leaf className="h-5 w-5" />
       </div>

--- a/plant-swipe/src/pages/GardenDashboardPage.tsx
+++ b/plant-swipe/src/pages/GardenDashboardPage.tsx
@@ -566,16 +566,16 @@ export const GardenDashboardPage: React.FC = () => {
       {error && <div className="p-6 text-sm text-red-600">{error}</div>}
       {!loading && garden && (
         <>
-          <aside className="space-y-2 lg:sticky lg:top-4 self-start">
+          <aside className="space-y-2 md:sticky md:top-4 self-start">
             <div className="text-xl font-semibold">{garden.name}</div>
-            <nav className="flex lg:flex-col gap-2">
+            <nav className="flex flex-wrap md:flex-col gap-2">
               {([
                 ['overview','Overview'],
                 ['plants','Plants'],
                 ['routine','Routine'],
                 ['settings','Settings'],
               ] as Array<[TabKey, string]>).map(([k, label]) => (
-                <Button key={k} asChild variant={tab === k ? 'default' : 'secondary'} className="rounded-2xl">
+                <Button key={k} asChild variant={tab === k ? 'default' : 'secondary'} className="rounded-2xl md:w-full">
                   <NavLink to={`/garden/${id}/${k}`} className="no-underline">{label}</NavLink>
                 </Button>
               ))}


### PR DESCRIPTION
Improve responsive layout and remove the mobile bottom 'Create' button.

This PR addresses layout inconsistencies at various screen resolutions by unifying container widths and enhancing the garden dashboard sidebar's responsiveness. Additionally, the 'Create' button is removed from the mobile bottom navigation to streamline phone navigation, as it remains available in the top bar.

---
<a href="https://cursor.com/background-agent?bcId=bc-181f4a9d-f5d3-4a65-9807-33d924d51b2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-181f4a9d-f5d3-4a65-9807-33d924d51b2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

