### PR TITLE
Fix edit mode on plant info page

### DIFF
--- a/plant-swipe/src/components/plant/PlantDetails.tsx
+++ b/plant-swipe/src/components/plant/PlantDetails.tsx
@@ -106,7 +106,17 @@ export const PlantDetails: React.FC<{ plant: Plant; onClose: () => void; liked?:
         )}
         <div className="flex gap-2 ml-auto">
           {user && (
-            <Button variant="secondary" className="rounded-2xl" onClick={() => { navigate(`/plants/${plant.id}/edit`); onClose() }}>Edit</Button>
+            <Button
+              variant="secondary"
+              className="rounded-2xl"
+              onClick={() => {
+                // Navigate to the dedicated edit page; do not call onClose here
+                // so we don't immediately pop back to the overlay route.
+                navigate(`/plants/${plant.id}/edit`)
+              }}
+            >
+              Edit
+            </Button>
           )}
           <Button className="rounded-2xl" onClick={onClose}>Close</Button>
         </div>


### PR DESCRIPTION
Remove `onClose()` from the 'Edit' button's `onClick` handler to correctly navigate to the plant edit page.

---
<a href="https://cursor.com/background-agent?bcId=bc-b0f6499c-4610-4a84-b6df-90016e452dfa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b0f6499c-4610-4a84-b6df-90016e452dfa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

