### PR TITLE
Fix magnifying glass overlap on search placeholder

### DIFF
--- a/plant-swipe/src/PlantSwipe.tsx
+++ b/plant-swipe/src/PlantSwipe.tsx
@@ -488,10 +488,10 @@ export default function PlantSwipe() {
             <div>
               <Label htmlFor="plant-search" className="sr-only">Search plants</Label>
               <div className="relative">
-                <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 opacity-60" />
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 opacity-60 pointer-events-none" />
                 <Input
                   id="plant-search"
-                  className="pl-9"
+                  className="pl-9 md:pl-9"
                   placeholder="Search name, meaning, color…"
                   value={query}
                   onChange={(e: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
Fix search icon overlapping placeholder text by adding `pointer-events-none` and ensuring consistent left padding on the search input.

---
<a href="https://cursor.com/background-agent?bcId=bc-ac0b70e1-b569-48bd-a610-14f2111a7986"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ac0b70e1-b569-48bd-a610-14f2111a7986"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

