### PR TITLE
Fix setup script command not found error

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -103,7 +103,12 @@ else
 fi
 if $need_node_install; then
   log "Installing/upgrading Node.js to 22.x…"
-  curl -fsSL https://deb.nodesource.com/setup_22.x | $SUDO -E bash -
+  # When running as root, $SUDO is empty; avoid emitting a leading "-E" token
+  if [[ -n "$SUDO" ]]; then
+    curl -fsSL https://deb.nodesource.com/setup_22.x | $SUDO -E bash -
+  else
+    curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
+  fi
   $PM_INSTALL nodejs
 else
   log "Node.js is sufficiently new ($(node -v))."


### PR DESCRIPTION
Conditionally use `-E` with `sudo` in `setup.sh` to prevent "`-E: command not found`" when run as root.

The original script would pass `-E` to `bash` even when `$SUDO` was empty (i.e., when running as root), causing the shell to interpret `-E` as a command. This change ensures `-E` is only used when `sudo` is actually present and being invoked.

---
<a href="https://cursor.com/background-agent?bcId=bc-b8d99868-b8ad-458d-9065-117bce4ab1f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b8d99868-b8ad-458d-9065-117bce4ab1f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

