### PR TITLE
Fix git repository detection for server refresh

### DIFF
--- a/admin_api/app.py
+++ b/admin_api/app.py
@@ -29,8 +29,9 @@ def _parse_allowed_services(env_value: str) -> Set[str]:
 
 APP_SECRET = _get_env_var("ADMIN_BUTTON_SECRET", "change-me")
 ADMIN_STATIC_TOKEN = _get_env_var("ADMIN_STATIC_TOKEN", "")
-ALLOWED_SERVICES_RAW = _get_env_var("ADMIN_ALLOWED_SERVICES", "nginx")
-DEFAULT_SERVICE = _get_env_var("ADMIN_DEFAULT_SERVICE", "nginx")
+# Allow nginx, node app, and admin api by default; can be overridden via env
+ALLOWED_SERVICES_RAW = _get_env_var("ADMIN_ALLOWED_SERVICES", "nginx,plant-swipe-node,admin-api")
+DEFAULT_SERVICE = _get_env_var("ADMIN_DEFAULT_SERVICE", "plant-swipe-node")
 
 ALLOWED_SERVICES = _parse_allowed_services(ALLOWED_SERVICES_RAW)
 


### PR DESCRIPTION
Harden Git repository detection and broaden default allowed services for Admin API.

This fixes "Current directory is not inside a git repository" errors during Git pull/build by handling Git ownership checks and inherited environment variables, and resolves 400 errors when restarting `plant-swipe-node` or `admin-api` by allowing these services by default.

---
<a href="https://cursor.com/background-agent?bcId=bc-92a3ef77-f03e-411d-b8bb-498787c3a907"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-92a3ef77-f03e-411d-b8bb-498787c3a907"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

