### PR TITLE
Update 000_sync sql for plant upload

### DIFF
--- a/plant-swipe/supabase/000_sync_schema.sql
+++ b/plant-swipe/supabase/000_sync_schema.sql
@@ -104,7 +104,7 @@ end $$;
 create table if not exists public.plants (
   id text primary key,
   name text not null,
-  scientific_name text not null,
+  scientific_name text,
   colors text[] not null default '{}',
   seasons text[] not null default '{}',
   rarity text not null default 'Common' check (rarity in ('Common','Uncommon','Rare','Legendary')),
@@ -113,7 +113,7 @@ create table if not exists public.plants (
   image_url text,
   care_sunlight text not null default 'Low' check (care_sunlight in ('Low','Medium','High')),
   care_water text not null default 'Low' check (care_water in ('Low','Medium','High')),
-  care_soil text not null,
+  care_soil text,
   care_difficulty text not null default 'Easy' check (care_difficulty in ('Easy','Moderate','Hard')),
   seeds_available boolean not null default false,
   created_at timestamptz not null default now(),
@@ -132,6 +132,9 @@ alter table if exists public.plants add column if not exists water_freq_amount i
 alter table if exists public.plants add column if not exists water_freq_unit text;
 alter table if exists public.plants add column if not exists water_freq_value integer;
 alter table if exists public.plants add column if not exists updated_at timestamptz not null default now();
+-- Relax NOT NULL constraints to support Simplified Add Plant flow
+alter table if exists public.plants alter column scientific_name drop not null;
+alter table if exists public.plants alter column care_soil drop not null;
 alter table public.plants enable row level security;
 -- Clean up legacy duplicate read policies if present
 do $$ begin


### PR DESCRIPTION
Relax `NOT NULL` constraints for `scientific_name` and `care_soil` in the `plants` table to allow the Simplified Add Plant flow to upload plants without these fields.

The current schema configuration prevented the Simplified Add Plant feature from successfully creating new plant entries when `scientific_name` or `care_soil` were not provided, leading to upload failures. This change makes these fields optional, aligning with the simplified input requirements.

---
<a href="https://cursor.com/background-agent?bcId=bc-6ac457be-8971-4733-ac50-593d376bbc6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6ac457be-8971-4733-ac50-593d376bbc6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

