### PR TITLE
Fix plant adding due to db fields

### DIFF
--- a/plant-swipe/src/pages/CreatePlantPage.tsx
+++ b/plant-swipe/src/pages/CreatePlantPage.tsx
@@ -97,6 +97,8 @@ export const CreatePlantPage: React.FC<CreatePlantPageProps> = ({ onCancel, onSa
         description: description || null,
         image_url: imageUrl || null,
         care_sunlight: careSunlight,
+        // Ensure DB gets a value even when omitted in simplified flow
+        care_water: 'Low',
         care_soil: includeAdvanced ? (careSoil || null) : null,
         care_difficulty: careDifficulty,
         seeds_available: seedsAvailable,

--- a/plant-swipe/supabase/000_sync_schema.sql
+++ b/plant-swipe/supabase/000_sync_schema.sql
@@ -135,6 +135,9 @@ alter table if exists public.plants add column if not exists updated_at timestam
 -- Relax NOT NULL constraints to support Simplified Add Plant flow
 alter table if exists public.plants alter column scientific_name drop not null;
 alter table if exists public.plants alter column care_soil drop not null;
+-- Allow omitting care_water from inserts; keep sane default
+alter table if exists public.plants alter column care_water drop not null;
+alter table if exists public.plants alter column care_water set default 'Low';
 alter table public.plants enable row level security;
 -- Clean up legacy duplicate read policies if present
 do $$ begin


### PR DESCRIPTION
Make `care_water` optional for simplified plant creation by updating DB schema and client-side insert.

The simplified plant creation flow failed because the `care_water` field was still required by the database. This PR relaxes the `NOT NULL` constraint on `plants.care_water` and sets a default value of 'Low' in the schema, while also ensuring the client always sends 'Low' if `care_water` is not explicitly provided.

---
<a href="https://cursor.com/background-agent?bcId=bc-a41773d0-67bd-4f63-af3d-a834cfb2669b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a41773d0-67bd-4f63-af3d-a834cfb2669b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

