### PR TITLE
Simplify add plant form data submission

### DIFF
--- a/plant-swipe/src/pages/CreatePlantPage.tsx
+++ b/plant-swipe/src/pages/CreatePlantPage.tsx
@@ -86,6 +86,10 @@ export const CreatePlantPage: React.FC<CreatePlantPageProps> = ({ onCancel, onSa
       if (byName.error) { setError(byName.error.message); return }
       if (byName.data?.id) { setError('A plant with the same name already exists'); return }
 
+      // Provide safe defaults so simplified flow never violates NOT NULL constraints
+      const defaultPeriod: 'week' | 'month' | 'year' = 'week'
+      const defaultAmount: number = 1
+
       const { error: insErr } = await supabase.from('plants').insert({
         id,
         name: nameNorm,
@@ -102,12 +106,12 @@ export const CreatePlantPage: React.FC<CreatePlantPageProps> = ({ onCancel, onSa
         care_soil: includeAdvanced ? (careSoil || null) : null,
         care_difficulty: careDifficulty,
         seeds_available: seedsAvailable,
-        // Default watering frequency fields (advanced only)
-        water_freq_period: includeAdvanced ? waterFreqPeriod : null,
-        water_freq_amount: includeAdvanced ? normalizedAmount : null,
+        // Default watering frequency fields (optional in Advanced; always persisted safely)
+        water_freq_period: includeAdvanced ? waterFreqPeriod : defaultPeriod,
+        water_freq_amount: includeAdvanced ? normalizedAmount : defaultAmount,
         // Legacy/alternative field names for compatibility
-        water_freq_unit: includeAdvanced ? waterFreqPeriod : null,
-        water_freq_value: includeAdvanced ? normalizedAmount : null,
+        water_freq_unit: includeAdvanced ? waterFreqPeriod : defaultPeriod,
+        water_freq_value: includeAdvanced ? normalizedAmount : defaultAmount,
       })
       if (insErr) { setError(insErr.message); return }
       setOk('Saved')

--- a/plant-swipe/supabase/000_sync_schema.sql
+++ b/plant-swipe/supabase/000_sync_schema.sql
@@ -138,6 +138,21 @@ alter table if exists public.plants alter column care_soil drop not null;
 -- Allow omitting care_water from inserts; keep sane default
 alter table if exists public.plants alter column care_water drop not null;
 alter table if exists public.plants alter column care_water set default 'Low';
+-- Ensure watering frequency fields are optional (some DBs may still have NOT NULL)
+do $$ begin
+  begin
+    alter table if exists public.plants alter column water_freq_period drop not null;
+  exception when undefined_column then null; end;
+  begin
+    alter table if exists public.plants alter column water_freq_amount drop not null;
+  exception when undefined_column then null; end;
+  begin
+    alter table if exists public.plants alter column water_freq_unit drop not null;
+  exception when undefined_column then null; end;
+  begin
+    alter table if exists public.plants alter column water_freq_value drop not null;
+  exception when undefined_column then null; end;
+end $$;
 alter table public.plants enable row level security;
 -- Clean up legacy duplicate read policies if present
 do $$ begin


### PR DESCRIPTION
Make advanced plant fields optional and provide safe defaults for simplified plant creation.

Previously, the simplified plant creation flow would fail if advanced watering frequency fields were not provided, due to database `NOT NULL` constraints. This change ensures these fields are optional in the database and provides default values when using the simplified form, preventing insertion errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-9618b647-4f0c-43e4-8824-350b9d99a249"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9618b647-4f0c-43e4-8824-350b9d99a249"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

