### PR TITLE
Make name field mandatory only

### DIFF
--- a/plant-swipe/src/pages/EditPlantPage.tsx
+++ b/plant-swipe/src/pages/EditPlantPage.tsx
@@ -84,8 +84,6 @@ export const EditPlantPage: React.FC<EditPlantPageProps> = ({ onCancel, onSaved 
     setError(null)
     setOk(null)
     if (!name.trim()) { setError("Name is required"); return }
-    if (!scientificName.trim()) { setError("Scientific name is required"); return }
-    if (!careSoil.trim()) { setError("Soil is required"); return }
     // Validate frequency constraints
     const periodMax: Record<'week'|'month'|'year', number> = { week: 7, month: 4, year: 12 }
     const maxAllowed = periodMax[waterFreqPeriod]
@@ -97,7 +95,7 @@ export const EditPlantPage: React.FC<EditPlantPageProps> = ({ onCancel, onSaved 
         .from('plants')
         .update({
           name: name.trim(),
-          scientific_name: scientificName.trim(),
+          scientific_name: scientificName.trim() || null,
           colors: colorArray,
           seasons,
           rarity,
@@ -105,7 +103,7 @@ export const EditPlantPage: React.FC<EditPlantPageProps> = ({ onCancel, onSaved 
           description: description || null,
           image_url: imageUrl || null,
           care_sunlight: careSunlight,
-          care_soil: careSoil,
+          care_soil: careSoil.trim() || null,
           care_difficulty: careDifficulty,
           seeds_available: seedsAvailable,
           water_freq_period: waterFreqPeriod,


### PR DESCRIPTION
Make scientific name and soil optional fields on the edit plant page.

The previous client-side validation prevented saving if these fields were empty. This change removes that validation and ensures empty optional fields are saved as `null` to the database.

---
<a href="https://cursor.com/background-agent?bcId=bc-a21920a0-e119-41b1-82c5-55b3b6a59ed6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a21920a0-e119-41b1-82c5-55b3b6a59ed6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

