### PR TITLE
Fix git repository and server restart

### DIFF
--- a/scripts/refresh-plant-swipe.sh
+++ b/scripts/refresh-plant-swipe.sh
@@ -6,7 +6,8 @@ set -euo pipefail
 trap 'echo "[ERROR] Command failed at line $LINENO" >&2' ERR
 
 # Determine working directories based on where the command is RUN (caller cwd)
-WORK_DIR="$(pwd -P)"
+# Allow explicit override via PLANTSWIPE_REPO_DIR when provided by the caller
+WORK_DIR="${PLANTSWIPE_REPO_DIR:-$(pwd -P)}"
 # Prefer nested plant-swipe app if present; otherwise use current dir as Node app
 if [[ -f "$WORK_DIR/plant-swipe/package.json" ]]; then
   NODE_DIR="$WORK_DIR/plant-swipe"


### PR DESCRIPTION
Resolve real Git repository root to fix "not inside a git repository" errors when the app is deployed via a symlink.

The previous `path.resolve(__dirname, '..')` logic incorrectly determined the Git repository root when the Node app was a symlinked subdirectory (e.g., `/var/www/PlantSwipe/plant-swipe` pointing to a repo at `/var/www/PlantSwipe`). This change uses `fs.realpath` and `git rev-parse --show-toplevel` to find the actual repo root and passes it to the refresh script, ensuring Git commands execute in the correct context.

---
<a href="https://cursor.com/background-agent?bcId=bc-197a3bcd-1095-4e5f-9b06-abf6cc22cd90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-197a3bcd-1095-4e5f-9b06-abf6cc22cd90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

