### PR TITLE
Fix image cropping on encyclopedia and search pages

### DIFF
--- a/plant-swipe/src/pages/GardenDashboardPage.tsx
+++ b/plant-swipe/src/pages/GardenDashboardPage.tsx
@@ -634,12 +634,13 @@ export const GardenDashboardPage: React.FC = () => {
                           </button>
                         </div>
                         <div className="grid grid-cols-3 items-stretch gap-0">
-                          <div className="col-span-1 h-full min-h-[148px] rounded-l-2xl overflow-hidden bg-stone-100">
+                          <div className="col-span-1 relative h-full min-h-[148px] rounded-l-2xl overflow-hidden bg-stone-100">
                             {gp.plant?.image ? (
                               <img
                                 src={gp.plant.image}
                                 alt={gp.nickname || gp.plant?.name || 'Plant'}
-                                className="h-full w-full object-cover object-center select-none"
+                                decoding="async"
+                                className="absolute inset-0 h-full w-full object-cover object-center select-none"
                                 draggable={false}
                               />
                             ) : null}

--- a/plant-swipe/src/pages/SearchPage.tsx
+++ b/plant-swipe/src/pages/SearchPage.tsx
@@ -24,14 +24,15 @@ export const SearchPage: React.FC<SearchPageProps> = ({ plants, openInfo, likedI
           onKeyDown={(e: React.KeyboardEvent<HTMLDivElement>) => { if (e.key === 'Enter') openInfo(p) }}
         >
           <div className="grid grid-cols-3 items-stretch gap-0">
-            <div className="col-span-1 h-full min-h-[148px] rounded-l-2xl overflow-hidden bg-stone-100">
+            <div className="col-span-1 relative h-full min-h-[148px] rounded-l-2xl overflow-hidden bg-stone-100">
               {p.image ? (
                 <img
                   src={p.image}
                   alt={p.name}
                   loading="lazy"
                   draggable={false}
-                  className="block h-full w-full object-cover object-center select-none"
+                  decoding="async"
+                  className="absolute inset-0 h-full w-full object-cover object-center select-none"
                 />
               ) : null}
             </div>


### PR DESCRIPTION
Ensure images in search and garden dashboard pages fill their containers vertically to prevent cropping and gaps.

---
<a href="https://cursor.com/background-agent?bcId=bc-9666afda-ef49-400d-80d7-56623b6e28c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9666afda-ef49-400d-80d7-56623b6e28c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

