### PR TITLE
Prevent refresh script from pulling deleted branch

### DIFF
--- a/scripts/refresh-plant-swipe.sh
+++ b/scripts/refresh-plant-swipe.sh
@@ -320,6 +320,78 @@ if [[ -n "$TARGET_BRANCH" && "$TARGET_BRANCH" != "$BRANCH_NAME" ]]; then
   log "Switched to branch: $BRANCH_NAME"
 fi
 
+# Ensure current branch has a valid upstream; if missing or deleted on remote, switch
+# to a sane default (origin/HEAD, PLANTSWIPE_DEFAULT_BRANCH, main or master)
+log "Validating upstream for current branch…"
+UPSTREAM_REF="$(${GIT_LOCAL_CMD[@]} rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || true)"
+UPSTREAM_OK=true
+if [[ -z "$UPSTREAM_REF" ]]; then
+  UPSTREAM_OK=false
+else
+  if ! ${GIT_LOCAL_CMD[@]} show-ref --verify --quiet "refs/remotes/${UPSTREAM_REF}"; then
+    UPSTREAM_OK=false
+  fi
+fi
+
+if [[ "$UPSTREAM_OK" != "true" ]]; then
+  DEFAULT_BRANCH="${PLANTSWIPE_DEFAULT_BRANCH:-}"
+  if [[ -z "$DEFAULT_BRANCH" ]]; then
+    # Prefer origin/HEAD if available
+    remote_head_short="$(${GIT_LOCAL_CMD[@]} symbolic-ref -q --short refs/remotes/origin/HEAD 2>/dev/null || ${GIT_CMD[@]} symbolic-ref -q --short refs/remotes/origin/HEAD 2>/dev/null || true)"
+    if [[ -n "$remote_head_short" ]]; then
+      DEFAULT_BRANCH="${remote_head_short#origin/}"
+    else
+      # Try common defaults
+      if ${GIT_LOCAL_CMD[@]} ls-remote --exit-code --heads origin main >/dev/null 2>&1; then
+        DEFAULT_BRANCH="main"
+      elif ${GIT_LOCAL_CMD[@]} ls-remote --exit-code --heads origin master >/dev/null 2>&1; then
+        DEFAULT_BRANCH="master"
+      fi
+    fi
+  fi
+
+  if [[ -z "$DEFAULT_BRANCH" ]]; then
+    echo "[ERROR] Current branch '$BRANCH_NAME' has no valid upstream and no default branch could be determined. Set PLANTSWIPE_DEFAULT_BRANCH or supply a target branch." >&2
+    exit 1
+  fi
+
+  if [[ "$DEFAULT_BRANCH" == "$BRANCH_NAME" ]]; then
+    # Already on the default branch; clear any stale upstream silently
+    ${GIT_LOCAL_CMD[@]} branch --unset-upstream >/dev/null 2>&1 || true
+  else
+    log "Upstream missing for '$BRANCH_NAME'. Switching to default branch '$DEFAULT_BRANCH'…"
+    if ${GIT_LOCAL_CMD[@]} show-ref --verify --quiet "refs/heads/$DEFAULT_BRANCH"; then
+      if ! ${GIT_LOCAL_CMD[@]} checkout "$DEFAULT_BRANCH"; then
+        if [[ ${#RUN_AS_PREFIX[@]} -gt 0 && "$CAN_SUDO" == "true" ]]; then
+          if ! ${GIT_CMD[@]} checkout "$DEFAULT_BRANCH"; then
+            echo "[ERROR] Failed to checkout $DEFAULT_BRANCH" >&2
+            exit 1
+          fi
+        else
+          echo "[ERROR] Failed to checkout $DEFAULT_BRANCH (no sudo)" >&2
+          exit 1
+        fi
+      fi
+    else
+      if ! ${GIT_LOCAL_CMD[@]} checkout -B "$DEFAULT_BRANCH" "origin/$DEFAULT_BRANCH"; then
+        if [[ ${#RUN_AS_PREFIX[@]} -gt 0 && "$CAN_SUDO" == "true" ]]; then
+          if ! ${GIT_CMD[@]} checkout -B "$DEFAULT_BRANCH" "origin/$DEFAULT_BRANCH"; then
+            echo "[ERROR] Failed to create local $DEFAULT_BRANCH from origin/$DEFAULT_BRANCH" >&2
+            exit 1
+          fi
+        else
+          echo "[ERROR] Failed to create local $DEFAULT_BRANCH from origin/$DEFAULT_BRANCH (no sudo)" >&2
+          exit 1
+        fi
+      fi
+    fi
+    # Best-effort: set upstream to origin/DEFAULT_BRANCH for future pulls
+    ${GIT_LOCAL_CMD[@]} branch --set-upstream-to="origin/$DEFAULT_BRANCH" "$DEFAULT_BRANCH" >/dev/null 2>&1 || true
+    BRANCH_NAME="$DEFAULT_BRANCH"
+    log "Switched to branch: $BRANCH_NAME"
+  fi
+fi
+
 log "Pulling latest (fast-forward only) on current branch…"
 # Try pull as current user first
 if ! "${GIT_LOCAL_CMD[@]}" pull --ff-only; then


### PR DESCRIPTION
Add logic to `refresh-plant-swipe.sh` to automatically switch to a default branch if the current branch's upstream is missing, preventing repeated failed pulls.

Previously, if a branch was merged and its remote counterpart deleted, the `refresh` script would repeatedly attempt `git pull` on the non-existent upstream, leading to errors and preventing the script from proceeding or switching branches effectively. This change ensures the script can recover gracefully by finding a valid branch to pull from.

---
<a href="https://cursor.com/background-agent?bcId=bc-7803d4bc-b54a-4fc0-8023-ff44e4818e13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7803d4bc-b54a-4fc0-8023-ff44e4818e13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

