### PR TITLE
Handle git pull and build failures gracefully

### DIFF
--- a/admin_api/app.py
+++ b/admin_api/app.py
@@ -236,6 +236,9 @@ def _run_refresh(branch: Optional[str], stream: bool):
     env = os.environ.copy()
     env.setdefault("CI", os.environ.get("CI", "true"))
     env["PLANTSWIPE_REPO_DIR"] = repo_root
+    # Prevent the refresh script from restarting services on its own.
+    # We will perform restarts explicitly after verifying build success.
+    env["SKIP_SERVICE_RESTARTS"] = "true"
     if branch:
         env["PLANTSWIPE_TARGET_BRANCH"] = branch
     if stream:


### PR DESCRIPTION
Add a non-blocking orange popup before service restarts and gate restarts on successful build completion to inform users of pending updates and prevent website downtime from failed deployments.

Previously, a failed build during the `GitPull and update` process could lead to the website becoming unresponsive, requiring manual intervention. This change ensures that if the build fails, the existing, working version of the site remains active, and services are only restarted after a verified successful build. The popup provides a clear, non-intrusive notification to the user that the page content may be deprecated and a reload is recommended.

---
<a href="https://cursor.com/background-agent?bcId=bc-423a35fc-7931-45ea-8b18-237cb95e6544"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-423a35fc-7931-45ea-8b18-237cb95e6544"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

