### PR TITLE
Ensure api and services auto-restart

### DIFF
--- a/admin_api/admin-api.service
+++ b/admin_api/admin-api.service
@@ -8,7 +8,11 @@ Group=www-data
 EnvironmentFile=/etc/admin-api/env
 WorkingDirectory=/opt/admin
 ExecStart=/opt/admin/venv/bin/gunicorn -b 127.0.0.1:5001 app:app --workers 2 --timeout 30 --access-logfile - --error-logfile -
-Restart=on-failure
+Restart=always
+RestartSec=3s
+StartLimitIntervalSec=60
+StartLimitBurst=10
+TimeoutStopSec=15s
 KillMode=mixed
 
 [Install]

--- a/scripts/restart-services.sh
+++ b/scripts/restart-services.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Restart PlantSwipe services (admin-api, node API, nginx) out-of-band.
+# Usable even if APIs are down. Requires the sudoers entries set by setup.sh.
+
+SERVICE_NODE="plant-swipe-node"
+SERVICE_ADMIN="admin-api"
+SERVICE_NGINX="nginx"
+
+usage() {
+  cat <<EOF
+Usage: plantswipe-restart [all|node|admin|nginx]
+ - all: restart node and admin, then reload nginx (default)
+ - node: restart only Node API service
+ - admin: restart only Admin API service
+ - nginx: reload nginx
+EOF
+}
+
+cmd="${1:-all}"
+case "$cmd" in
+  -h|--help|help) usage; exit 0;;
+  all) ;;
+  node|admin|nginx) ;;
+  *) echo "Unknown argument: $cmd" >&2; usage; exit 1;;
+
+esac
+
+# Prefer non-interactive sudo; if it fails, fallback to interactive sudo
+SUDO="sudo -n"
+if ! $SUDO true >/dev/null 2>&1; then
+  SUDO="sudo"
+fi
+
+if [[ "$cmd" == "node" || "$cmd" == "all" ]]; then
+  echo "[+] Restarting $SERVICE_NODE…"
+  $SUDO systemctl restart "$SERVICE_NODE"
+fi
+
+if [[ "$cmd" == "admin" || "$cmd" == "all" ]]; then
+  echo "[+] Restarting $SERVICE_ADMIN…"
+  $SUDO systemctl restart "$SERVICE_ADMIN"
+fi
+
+if [[ "$cmd" == "nginx" || "$cmd" == "all" ]]; then
+  echo "[+] Reloading $SERVICE_NGINX…"
+  $SUDO nginx -t
+  $SUDO systemctl reload "$SERVICE_NGINX"
+fi
+
+echo "[✓] Done."


### PR DESCRIPTION
Harden systemd services with `Restart=always` and add an out-of-band `plantswipe-restart` script to ensure APIs auto-recover and can be restarted independently.

This PR addresses the need for APIs to constantly run and relaunch automatically by configuring systemd units with `Restart=always`. It also provides a new `plantswipe-restart` script, installed by `setup.sh`, which allows restarting services (Node API, Admin API, Nginx) via `systemctl` directly, enabling recovery even if the APIs themselves are down.

---
<a href="https://cursor.com/background-agent?bcId=bc-0ada0b23-a2dc-401f-a805-167481b30bf9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0ada0b23-a2dc-401f-a805-167481b30bf9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

