### PR TITLE
Check and edit active broadcast message on admin page

### DIFF
--- a/plant-swipe/src/pages/AdminPage.tsx
+++ b/plant-swipe/src/pages/AdminPage.tsx
@@ -2853,7 +2853,7 @@ const BroadcastControls: React.FC<{ inline?: boolean; onExpired?: () => void; on
         method: 'POST',
         headers,
         credentials: 'same-origin',
-        body: JSON.stringify({ message: message.trim(), severity, durationMs: (() => { const v = duration; if (v === 'unlimited' || !v) return null; const m = v.match(/^(\d+)([smhd])$/); if (!m) return 5*60*1000; const n = Number(m[1]); const u = m[2]; const mult = u === 's' ? 1000 : u === 'm' ? 60000 : u === 'h' ? 3600000 : 86400000; return n*mult; })() }),
+        body: JSON.stringify({ message: message.trim(), severity, durationMs: (() => { const v = duration; if (v === 'unlimited' || !v) return null; const m = v.match(/^(\d+)([smhd])$/); if (!m) return null; const n = Number(m[1]); const u = m[2]; const mult = u === 's' ? 1000 : u === 'm' ? 60000 : u === 'h' ? 3600000 : 86400000; return n*mult; })() }),
       })
       const b = await resp.json().catch(() => ({}))
       if (!resp.ok) throw new Error(b?.error || `HTTP ${resp.status}`)
@@ -2865,7 +2865,7 @@ const BroadcastControls: React.FC<{ inline?: boolean; onExpired?: () => void; on
     } finally {
       setSubmitting(false)
     }
-  }, [message, submitting])
+  }, [message, submitting, duration, severity])
 
   const onRemove = React.useCallback(async () => {
     if (removing) return
@@ -2986,8 +2986,9 @@ const BroadcastControls: React.FC<{ inline?: boolean; onExpired?: () => void; on
               onChange={(e) => setDuration(e.target.value)}
               aria-label="Display time"
             >
-              <option value="5m">5 mins</option>
               <option value="1m">1 min</option>
+              <option value="5m">5 mins</option>
+              <option value="10m">10 mins</option>
               <option value="30m">30 mins</option>
               <option value="1h">1 hour</option>
               <option value="5h">5 hours</option>


### PR DESCRIPTION
Auto-open the Broadcast section on the Admin page and display the active message for editing, instead of always showing the create UI.

The previous behavior would always present the "create new broadcast" form, even when an active broadcast was live. This change ensures that administrators can immediately see and manage the currently active broadcast message upon navigating to the Admin page, improving the workflow for managing live communications. A loading state is also added to prevent a brief flash of the create UI before the active message status is determined.

---
<a href="https://cursor.com/background-agent?bcId=bc-297406f0-f873-4584-94b9-7c37e62f462f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-297406f0-f873-4584-94b9-7c37e62f462f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

