### PR TITLE
Fix donut graph layout and spacing

### DIFF
--- a/plant-swipe/src/pages/AdminPage.tsx
+++ b/plant-swipe/src/pages/AdminPage.tsx
@@ -1572,14 +1572,15 @@ export const AdminPage: React.FC = () => {
                   </Badge>
                 </div>
               </div>
-              <div className="mt-3 flex items-center gap-2">
-                <select
-                  className="rounded-xl border px-3 py-2 text-sm bg-white"
-                  value={selectedBranch}
-                  onChange={(e) => setSelectedBranch(e.target.value)}
-                  disabled={branchesLoading || branchesRefreshing}
-                  aria-label="Select branch"
-                >
+              <div className="mt-3 flex flex-col sm:flex-row items-stretch sm:items-center gap-2">
+                <div className="flex-1 min-w-0">
+                  <select
+                    className="w-full rounded-xl border px-3 py-2 text-sm bg-white"
+                    value={selectedBranch}
+                    onChange={(e) => setSelectedBranch(e.target.value)}
+                    disabled={branchesLoading || branchesRefreshing}
+                    aria-label="Select branch"
+                  >
                   {branchesLoading ? (
                     <option value="">Loading…</option>
                   ) : branchOptions.length === 0 ? (
@@ -1589,15 +1590,18 @@ export const AdminPage: React.FC = () => {
                       <option key={b} value={b} title={b}>{shortenMiddle(b, branchMaxChars)}</option>
                     ))
                   )}
-                </select>
+                  </select>
+                </div>
                 <Button
                   variant="outline"
-                  className="rounded-xl"
+                  className="rounded-xl w-full sm:w-auto px-2 sm:px-3"
                   onClick={() => loadBranches({ initial: false })}
                   disabled={branchesLoading || branchesRefreshing}
+                  aria-label="Refresh branches"
                 >
                   <RefreshCw className={`h-4 w-4 ${branchesRefreshing ? 'animate-spin' : ''}`} />
-                  Refresh branches
+                  <span className="hidden sm:inline">Refresh branches</span>
+                  <span className="sm:hidden inline">Refresh</span>
                 </Button>
               </div>
               <div className="text-xs opacity-60 mt-2">


### PR DESCRIPTION
Adjust chart layouts to utilize full horizontal space and improve readability on mobile.

---
<a href="https://cursor.com/background-agent?bcId=bc-a295a68e-cf9a-4174-982b-1e54725f63ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a295a68e-cf9a-4174-982b-1e54725f63ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

