### PR TITLE
Fix image height on search plant cards

### DIFF
--- a/plant-swipe/src/pages/SearchPage.tsx
+++ b/plant-swipe/src/pages/SearchPage.tsx
@@ -27,7 +27,7 @@ export const SearchPage: React.FC<SearchPageProps> = ({ plants, openInfo, likedI
           onKeyDown={(e: React.KeyboardEvent<HTMLDivElement>) => { if (e.key === 'Enter') openInfo(p) }}
         >
           <div className="grid grid-cols-3 items-stretch gap-0">
-            <div className="col-span-1 relative rounded-l-2xl overflow-hidden bg-stone-100">
+            <div className="col-span-1 relative rounded-l-2xl overflow-hidden bg-stone-100 flex items-stretch">
               {p.image ? (
                 <img
                   src={p.image}
@@ -35,7 +35,7 @@ export const SearchPage: React.FC<SearchPageProps> = ({ plants, openInfo, likedI
                   loading="lazy"
                   draggable={false}
                   decoding="async"
-                  className="absolute inset-0 w-full h-full object-cover object-center select-none"
+                  className="w-full h-full object-cover object-center select-none self-stretch"
                   style={{ transform: 'scale(1.5)' }}
                 />
               ) : null}


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-5f7433d4-5013-4bb6-9486-9641395c13e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5f7433d4-5013-4bb6-9486-9641395c13e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

