### PR TITLE
Fix user visit graph hover card theme

### DIFF
--- a/plant-swipe/src/pages/AdminPage.tsx
+++ b/plant-swipe/src/pages/AdminPage.tsx
@@ -2693,8 +2693,8 @@ export const AdminPage: React.FC = () => {
                             if (!active || !payload || payload.length === 0) return null
                             const current = payload[0]?.value as number
                             return (
-                              <div className="rounded-xl border bg-white/90 backdrop-blur p-3 shadow-lg">
-                                <div className="text-xs opacity-60">{formatFull(label)}</div>
+                              <div className="rounded-xl border bg-white/90 dark:bg-[#252526] dark:border-[#3e3e42] backdrop-blur p-3 shadow-lg">
+                                <div className="text-xs opacity-60 dark:opacity-70">{formatFull(label)}</div>
                                 <div className="mt-1 text-base font-semibold tabular-nums">{current}</div>
                               </div>
                             )


### PR DESCRIPTION
Correct the theme of the user visits graph hover card on the admin page to support dark mode.

---
<a href="https://cursor.com/background-agent?bcId=bc-ca478a99-6501-4a3d-8bc4-a0153cefdd66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ca478a99-6501-4a3d-8bc4-a0153cefdd66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

