### PR TITLE
Fix task loading after optimization

### DIFF
--- a/plant-swipe/src/pages/GardenListPage.tsx
+++ b/plant-swipe/src/pages/GardenListPage.tsx
@@ -34,6 +34,7 @@ export const GardenListPage: React.FC = () => {
   const lastSuccessfulLoadRef = React.useRef<number>(0)
   const [allPlants, setAllPlants] = React.useState<any[]>([])
   const [todayTaskOccurrences, setTodayTaskOccurrences] = React.useState<Array<{ id: string; taskId: string; gardenPlantId: string; dueAt: string; requiredCount: number; completedCount: number; completedAt: string | null; taskType?: 'water' | 'fertilize' | 'harvest' | 'cut' | 'custom'; taskEmoji?: string | null }>>([])
+  const [completionsByOcc, setCompletionsByOcc] = React.useState<Record<string, any[]>>({})
   const [progressingOccIds, setProgressingOccIds] = React.useState<Set<string>>(new Set())
   const [completingPlantIds, setCompletingPlantIds] = React.useState<Set<string>>(new Set())
   const [markingAllCompleted, setMarkingAllCompleted] = React.useState(false)
@@ -292,7 +293,7 @@ export const GardenListPage: React.FC = () => {
         } else {
           // Use cache but it's empty - mismatch detection will catch this
           setTodayTaskOccurrences(cached.data.occurrences)
-          setCompletionsByOcc(cached.data.completions)
+          setCompletionsByOcc(cached.data.completions || {})
           setAllPlants(cached.data.plants)
           setLoadingTasks(false)
           return
@@ -300,7 +301,7 @@ export const GardenListPage: React.FC = () => {
       } else {
         // Cache has tasks or skipResync is true - use it
         setTodayTaskOccurrences(cached.data.occurrences)
-        setCompletionsByOcc(cached.data.completions)
+        setCompletionsByOcc(cached.data.completions || {})
         setAllPlants(cached.data.plants)
         setLoadingTasks(false)
         return
@@ -422,7 +423,7 @@ export const GardenListPage: React.FC = () => {
       // Fetch completions for all occurrences
       const ids = occsAugmented.map(o => o.id)
       const compMap = ids.length > 0 ? await listCompletionsForOccurrences(ids) : {}
-      setCompletionsByOcc(compMap)
+      setCompletionsByOcc(compMap || {})
       // 4) Load plants for all gardens - use minimal version to reduce egress by ~80%
       const gardenIds = gardensList.map(g => g.id)
       const plantsMinimal = await getGardenPlantsMinimal(gardenIds)


### PR DESCRIPTION
Initialize `completionsByOcc` state and guard against empty cached completion data to ensure garden tasks render correctly after loading.

The `completionsByOcc` state was not declared, leading to a `ReferenceError` when the sidebar tried to render. Additionally, cached completion data could be `null` or `undefined`, causing issues when attempting to use it. These changes ensure the completions map is always defined, allowing tasks to display properly.

---
<a href="https://cursor.com/background-agent?bcId=bc-6155b5c5-7f88-4446-b773-69d7e0f8d707"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6155b5c5-7f88-4446-b773-69d7e0f8d707"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

