### PR TITLE
Fix contact us page variable display

### DIFF
--- a/plant-swipe/public/locales/en/common.json
+++ b/plant-swipe/public/locales/en/common.json
@@ -42,6 +42,7 @@
     "emailLabel": "Email Address",
     "sendEmail": "Send Email",
     "copyEmail": "Copy",
+    "copySuccess": "Copied!",
     "responseTime": {
       "title": "Response Time",
       "description": "We typically respond within 24-48 hours during business days."
@@ -62,7 +63,12 @@
       "messageLabel": "Message",
       "messagePlaceholder": "Tell us a bit more about what you need...",
       "submitButton": "Send message",
-      "cancelButton": "Cancel"
+      "submitSending": "Sending...",
+      "cancelButton": "Cancel",
+      "successTitle": "Message sent",
+      "successDescription": "Thanks for reaching out! We'll get back to you soon.",
+      "errorMessage": "We couldn't send your message. Please try again in a moment.",
+      "rateLimitedMessage": "Please wait a little before sending another message."
     }
   },
   "auth": {

--- a/plant-swipe/public/locales/fr/common.json
+++ b/plant-swipe/public/locales/fr/common.json
@@ -42,6 +42,7 @@
     "emailLabel": "Adresse e-mail",
     "sendEmail": "Envoyer un e-mail",
     "copyEmail": "Copier",
+    "copySuccess": "Copié !",
     "responseTime": {
       "title": "Temps de réponse",
       "description": "Nous répondons généralement dans les 24 à 48 heures pendant les jours ouvrables."
@@ -62,7 +63,12 @@
       "messageLabel": "Message",
       "messagePlaceholder": "Dites-nous en un peu plus sur votre demande...",
       "submitButton": "Envoyer le message",
-      "cancelButton": "Annuler"
+      "submitSending": "Envoi...",
+      "cancelButton": "Annuler",
+      "successTitle": "Message envoyé",
+      "successDescription": "Merci pour votre message ! Nous vous répondrons rapidement.",
+      "errorMessage": "Impossible d'envoyer votre message. Veuillez réessayer dans un instant.",
+      "rateLimitedMessage": "Veuillez patienter un peu avant d'envoyer un nouveau message."
     }
   },
   "auth": {


### PR DESCRIPTION
Guard the Contact Us page with a loading skeleton and add default translation values to prevent placeholder keys from rendering.

---
<a href="https://cursor.com/background-agent?bcId=bc-4575e9e4-c5ff-44c4-9373-484839b773e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4575e9e4-c5ff-44c4-9373-484839b773e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

