### PR TITLE
Fix admin IP list dark theme display

### DIFF
--- a/plant-swipe/src/pages/AdminPage.tsx
+++ b/plant-swipe/src/pages/AdminPage.tsx
@@ -2222,7 +2222,7 @@ export const AdminPage: React.FC = () => {
                     </div>
                     {ipsOpen && (
                       <div className="mt-2" id="connected-ips">
-                        <div className="rounded-xl border bg-white p-3 max-h-48 overflow-auto">
+                        <div className="rounded-xl border bg-white dark:bg-[#2d2d30] dark:border-[#3e3e42] p-3 max-h-48 overflow-auto">
                           {ipsLoading ? (
                             <div className="text-sm opacity-60">Loading...</div>
                           ) : ips.length === 0 ? (
@@ -2239,7 +2239,7 @@ export const AdminPage: React.FC = () => {
                                   title={`Lookup members for ? ${ip}`}
                                   aria-label={`Lookup members for ? ${ip}`}
                                   variant="outline"
-                                  className="rounded-full px-2 py-1 text-xs cursor-pointer hover:bg-stone-50 focus:outline-none focus:ring-2 focus:ring-ring"
+                                  className="rounded-full px-2 py-1 text-xs cursor-pointer hover:bg-stone-50 dark:hover:bg-[#3e3e42] focus:outline-none focus:ring-2 focus:ring-ring"
                                 >
                                   {ip}
                                 </Badge>


### PR DESCRIPTION
Correct styling for the 'Currently Online' IP list on the Admin page to ensure readability in Dark Theme.

---
<a href="https://cursor.com/background-agent?bcId=bc-665dac76-187b-43b2-8f60-52aca835511e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-665dac76-187b-43b2-8f60-52aca835511e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

