### PR TITLE
Restore 000 sync schema to working version

### DIFF
--- a/plant-swipe/supabase/001_sync_schema.sql
+++ b/plant-swipe/supabase/001_sync_schema.sql
@@ -3128,13 +3128,21 @@ BEGIN
 END;
 $$;
 
--- Schedule daily cleanup job to run at 2 AM UTC every day
--- This prevents cache accumulation and keeps database clean
-SELECT cron.schedule(
-  'cleanup-old-task-cache',
-  '0 2 * * *', -- 2 AM UTC daily
-  $$SELECT cleanup_old_garden_task_cache();$$
-) ON CONFLICT (jobname) DO UPDATE SET schedule = '0 2 * * *', command = $$SELECT cleanup_old_garden_task_cache();$$;
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM cron.job WHERE jobname = 'cleanup-old-task-cache'
+  ) THEN
+    PERFORM cron.unschedule('cleanup-old-task-cache');
+  END IF;
+
+  PERFORM cron.schedule(
+    'cleanup-old-task-cache',
+    '0 2 * * *', -- 2 AM UTC daily
+    $$SELECT cleanup_old_garden_task_cache();$$
+  );
+END;
+$$;
 
 -- Function: Initialize cache for all gardens AND users (run on startup/periodically)
 CREATE OR REPLACE FUNCTION initialize_all_task_cache()


### PR DESCRIPTION
## Summary
- replace the contents of `000_sync_schema.sql` with the working schema from `001_sync_schema.sql`
- ensure cron scheduling and garden feature tables align with the previous working definition

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911c00a43d883268e7ce9a97f9254ab)