### PR TITLE
Update footer copyright year dynamically

### DIFF
--- a/plant-swipe/src/components/layout/Footer.tsx
+++ b/plant-swipe/src/components/layout/Footer.tsx
@@ -12,6 +12,7 @@ const footerLinks = [
 
 export const Footer: React.FC = () => {
   const { t } = useTranslation('common')
+  const currentYear = new Date().getFullYear()
 
   return (
     <footer className="max-w-6xl mx-auto mt-10 pt-8 pb-6 px-2 border-t border-stone-300 dark:border-[#3e3e42]">
@@ -62,7 +63,7 @@ export const Footer: React.FC = () => {
 
         {/* Copyright */}
         <div className="text-xs text-stone-500 dark:text-stone-500 text-center md:text-right">
-          © {new Date().getFullYear()} {t('common.appName')}. {t('common.allRightsReserved')}.
+          © {currentYear} {t('common.appName')}. {t('common.allRightsReserved')}.
         </div>
       </div>
     </footer>


### PR DESCRIPTION
Refactor the footer copyright year calculation to use a variable for clarity, ensuring it always displays the current year.

---
<a href="https://cursor.com/background-agent?bcId=bc-9a9d3bc8-7496-409a-9fe8-b75dd15ad3a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9a9d3bc8-7496-409a-9fe8-b75dd15ad3a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

