### PR TITLE
Update edit page seasons to correct theme

### DIFF
--- a/plant-swipe/src/pages/EditPlantPage.tsx
+++ b/plant-swipe/src/pages/EditPlantPage.tsx
@@ -601,7 +601,7 @@ export const EditPlantPage: React.FC<EditPlantPageProps> = ({ onCancel, onSaved 
                 <Label>Seasons</Label>
                 <div className="flex flex-wrap gap-2">
                   {(["Spring", "Summer", "Autumn", "Winter"] as const).map((s) => (
-                    <button type="button" key={s} onClick={() => toggleSeason(s)} className={`px-3 py-1 rounded-2xl text-sm shadow-sm border transition ${seasons.includes(s) ? "bg-black text-white" : "bg-white hover:bg-stone-50"}`} aria-pressed={seasons.includes(s)}>
+                    <button type="button" key={s} onClick={() => toggleSeason(s)} className={`px-3 py-1 rounded-2xl text-sm shadow-sm border border-stone-300 dark:border-[#3e3e42] transition ${seasons.includes(s) ? "bg-black dark:bg-white text-white dark:text-black" : "bg-white dark:bg-[#2d2d30] text-black dark:text-white hover:bg-stone-50 dark:hover:bg-[#3e3e42]"}`} aria-pressed={seasons.includes(s)}>
                       {s}
                     </button>
                   ))}


### PR DESCRIPTION
Update the Seasons buttons on the Edit page to be theme-aware, ensuring consistent styling across light and dark modes.

---
<a href="https://cursor.com/background-agent?bcId=bc-a53dc86a-3b2a-4574-9508-c7aedad65901"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a53dc86a-3b2a-4574-9508-c7aedad65901"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

