### PR TITLE
Align close button with fullscreen button

### DIFF
--- a/plant-swipe/src/components/plant/PlantDetails.tsx
+++ b/plant-swipe/src/components/plant/PlantDetails.tsx
@@ -1599,14 +1599,27 @@ export const PlantDetails: React.FC<{ plant: Plant; onClose: () => void; liked?:
                 }}
               />
 
-              {/* Close button - fixed position */}
-              <button
-                onClick={() => setIsImageFullScreen(false)}
-                className="fixed top-4 right-4 z-[100] h-12 w-12 rounded-full bg-black/80 hover:bg-black flex items-center justify-center transition-all shadow-lg hover:scale-110"
-                aria-label={t('common.close')}
-              >
-                <X className="h-6 w-6 text-white stroke-[2.5]" />
-              </button>
+              {/* Fullscreen and Close buttons - fixed position */}
+              <div className="fixed top-4 right-4 z-[100] flex items-center gap-2">
+                <button
+                  onClick={handleExpand}
+                  type="button"
+                  aria-label="Expand to full page"
+                  className="h-9 w-9 rounded-full flex items-center justify-center border bg-white/90 dark:bg-[#2d2d30] dark:border-[#3e3e42] text-black dark:text-white hover:bg-white dark:hover:bg-[#3e3e42] transition shadow-sm"
+                  title="Expand to full page"
+                >
+                  <Maximize2 className="h-4 w-4" />
+                </button>
+                <button
+                  onClick={() => setIsImageFullScreen(false)}
+                  type="button"
+                  aria-label={t('common.close')}
+                  className="h-9 w-9 rounded-full flex items-center justify-center border bg-white/90 dark:bg-[#2d2d30] dark:border-[#3e3e42] text-black dark:text-white hover:bg-white dark:hover:bg-[#3e3e42] transition shadow-sm"
+                  title={t('common.close')}
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              </div>
 
               {/* Background area - clickable to close */}
               <div


### PR DESCRIPTION
Moves the fullscreen image dialog's close button next to a new fullscreen button and unifies their styling.

---
<a href="https://cursor.com/background-agent?bcId=bc-83070805-8d1d-4c09-9b9c-935028d0789b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-83070805-8d1d-4c09-9b9c-935028d0789b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

