### PR TITLE
Fix duplicate identifiers in admin page

### DIFF
--- a/plant-swipe/src/pages/AdminPage.tsx
+++ b/plant-swipe/src/pages/AdminPage.tsx
@@ -35,6 +35,7 @@ import {
   Users,
   FileText,
   ScrollText,
+  CloudUpload,
 } from "lucide-react";
 import { supabase } from "@/lib/supabaseClient";
 import { CreatePlantPage } from "@/pages/CreatePlantPage";
@@ -61,20 +62,7 @@ const {
   PieChart,
   Pie,
   Cell,
-} = LazyCharts
-import { RefreshCw, Server, Database, Github, ExternalLink, ShieldCheck, ShieldX, UserSearch, AlertTriangle, Gavel, Search, ChevronDown, GitBranch, Trash2, EyeOff, Copy, ArrowUpRight, Info, Plus, LayoutDashboard, Users, FileText, ScrollText, CloudUpload } from "lucide-react"
-import { supabase } from '@/lib/supabaseClient'
-import { CreatePlantPage } from '@/pages/CreatePlantPage'
-import {
-  Dialog,
-  DialogTrigger,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-  DialogFooter,
-  DialogClose,
-} from '@/components/ui/dialog'
+} = LazyCharts;
 type AdminTab = "overview" | "members" | "requests" | "admin_logs";
 
 export const AdminPage: React.FC = () => {
@@ -220,10 +208,8 @@ export const AdminPage: React.FC = () => {
   }, []);
 
   const [syncing, setSyncing] = React.useState(false);
+  const [deployingEdge, setDeployingEdge] = React.useState(false);
 
-  const [syncing, setSyncing] = React.useState(false)
-  const [deployingEdge, setDeployingEdge] = React.useState(false)
-  
   // Backup disabled for now
 
   const [restarting, setRestarting] = React.useState(false);


### PR DESCRIPTION
Deduplicate imports and state declarations in `AdminPage.tsx` to resolve TypeScript duplicate identifier errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-6a2b19af-1833-45da-a2c3-46d0cdb4db4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6a2b19af-1833-45da-a2c3-46d0cdb4db4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

