### PR TITLE
Remove discovery tag and optimize card layout

### DIFF
--- a/plant-swipe/src/pages/SwipePage.tsx
+++ b/plant-swipe/src/pages/SwipePage.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { motion, AnimatePresence, type MotionValue } from "framer-motion"
-import { ChevronLeft, ChevronRight, ChevronUp, Heart, Sparkles, PartyPopper, Palette, Wand2, Flame } from "lucide-react"
+import { ChevronLeft, ChevronRight, ChevronUp, Heart, Sparkles, PartyPopper, Palette, Flame } from "lucide-react"
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"


### PR DESCRIPTION
Remove the "Discovery" tag and tighten mobile spacing on the Discovery page.

This change cleans up the header by removing redundant tagging and improves the mobile layout by making the swipe card use the maximum available width, hugging the wrapper.

---
<a href="https://cursor.com/background-agent?bcId=bc-27d1e150-b8a9-4321-9fc7-d6d48dda1097"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-27d1e150-b8a9-4321-9fc7-d6d48dda1097"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

