### PR TITLE
Shorten deploy edge functions button text

### DIFF
--- a/plant-swipe/src/pages/AdminPage.tsx
+++ b/plant-swipe/src/pages/AdminPage.tsx
@@ -3560,11 +3560,11 @@ export const AdminPage: React.FC = () => {
                               disabled={deployingEdge}
                             >
                               <CloudUpload className="h-4 w-4" />
-                              <span>
-                                {deployingEdge
-                                  ? "Deploying..."
-                                  : "Deploy Edge Functions"}
-                              </span>
+                                <span>
+                                  {deployingEdge
+                                    ? "Deploying..."
+                                    : "Deploy Edge"}
+                                </span>
                             </Button>
                             <Button
                             className="rounded-2xl w-full"


### PR DESCRIPTION
Shorten the "Deploy Edge Functions" button label in the Admin page to prevent text overflow.

---
<a href="https://cursor.com/background-agent?bcId=bc-ee445bf6-6f00-460c-913c-97fb8c71e994"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ee445bf6-6f00-460c-913c-97fb8c71e994"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

