### PR TITLE
Fix redeclared variable in edit plant page

### DIFF
--- a/plant-swipe/src/pages/EditPlantPage.tsx
+++ b/plant-swipe/src/pages/EditPlantPage.tsx
@@ -811,7 +811,6 @@ export const EditPlantPage: React.FC<EditPlantPageProps> = ({ onCancel, onSaved 
           const resolvedMeaning = String(translation?.meaning || data.meaning || translationMeta?.funFact || parsedMeta?.funFact || '')
         const resolvedDescription = String(translation?.description || data.description || '')
         const resolvedFunFact = String(translationMeta?.funFact || parsedMeta?.funFact || data.meaning || '')
-        const resolvedClassificationType = parsedClassification?.type ? String(parsedClassification.type) : ''
           const englishScientificName = String(data.scientific_name || parsedIdentifiers?.scientificName || '')
           const englishDescription = String(data.description || '')
           const resolvedColorsArray = Array.isArray(data.colors) ? (data.colors as string[]) : []


### PR DESCRIPTION
Remove duplicate declaration of `resolvedClassificationType` to resolve a `TS2451` redeclaration error.

---
<a href="https://cursor.com/background-agent?bcId=bc-3f3c51cf-023b-4310-a991-bfd44f5e1dc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3f3c51cf-023b-4310-a991-bfd44f5e1dc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

