### PR TITLE
Fix pull to refresh on mobile

### DIFF
--- a/plant-swipe/src/index.css
+++ b/plant-swipe/src/index.css
@@ -8,9 +8,9 @@
 
 @layer base {
   html {
-    height: 100%;
     min-height: 100%;
-    overflow: hidden;
+    overflow-y: auto;
+    overscroll-behavior-y: auto;
     font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
     line-height: 1.5;
     font-weight: 400;
@@ -22,11 +22,12 @@
   }
 
   body {
-    height: 100%;
-    min-height: 100%;
+    min-height: 100vh;
+    min-height: 100dvh;
     margin: 0;
     min-width: 320px;
-    overflow: hidden;
+    overflow-y: auto;
+    overscroll-behavior-y: auto;
     -webkit-user-select: none;
     -ms-user-select: none;
     user-select: none;
@@ -34,11 +35,9 @@
   }
 
   #root {
-    height: 100%;
     min-height: 100vh;
     min-height: 100dvh;
     width: 100%;
-    overflow-y: auto;
     overflow-x: hidden;
   }
 


### PR DESCRIPTION
Enable native pull-to-refresh on mobile by allowing the document to be the scroll container.

The `html` and `body` elements were previously set to `overflow: hidden`, which prevented the system WebView from detecting the document's scroll position and thus disabled the native pull-to-refresh gesture. This change reconfigures `html`, `body`, and `#root` to allow the document to overscroll at the top edge.

---
<a href="https://cursor.com/background-agent?bcId=bc-4bf3bc08-4e70-41c4-bad2-3904fdc0d8b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4bf3bc08-4e70-41c4-bad2-3904fdc0d8b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

