### PR TITLE
Fix navigation bar scrollbar overflow

### DIFF
--- a/plant-swipe/src/index.css
+++ b/plant-swipe/src/index.css
@@ -27,6 +27,7 @@
     margin: 0;
     min-width: 320px;
     overflow-y: auto;
+    overflow-x: hidden;
     overscroll-behavior-y: auto;
     -webkit-user-select: none;
     -ms-user-select: none;
@@ -38,7 +39,6 @@
     min-height: 100vh;
     min-height: 100dvh;
     width: 100%;
-    overflow-x: hidden;
   }
 
   a {


### PR DESCRIPTION
Move `overflow-x: hidden` from `#root` to `body` to fix duplicate scrollbars and enable pull-to-refresh on mobile.

---
<a href="https://cursor.com/background-agent?bcId=bc-6e6d45c0-9a3c-44c1-8e5a-faf0a2b01c27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6e6d45c0-9a3c-44c1-8e5a-faf0a2b01c27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

