### PR TITLE
Generate website sitemap for SEO

### DIFF
--- a/plant-swipe/README.md
+++ b/plant-swipe/README.md
@@ -653,6 +653,15 @@ Ensure production environment variables are set:
 - **Local testing**: run `VITE_ENABLE_PWA=true npm run dev` to test the service worker in development. Use the “Application ▸ Manifest” panel in devtools to inspect install assets.
 - **Disable caching during QA**: add `VITE_DISABLE_PWA=true` to `plant-swipe/.env` (or the deployment env) before running `scripts/refresh-plant-swipe.sh`. The build will skip generating the service worker, and existing clients automatically unregister on next load, so a normal refresh always pulls the latest assets.
 
+### Automated Sitemap
+
+- `npm run generate:sitemap` (backed by `scripts/generate-sitemap.js`) writes `public/sitemap.xml`, combining hand-picked static routes and `/plants/:id` detail pages fetched from Supabase.
+- The command runs automatically at the start of `npm run build`, so every invocation of `scripts/refresh-plant-swipe.sh` (which already runs `npm run build`) refreshes the sitemap before assets are compiled.
+- **Required env**: set `PLANTSWIPE_SITE_URL` (or `SITE_URL`/`VITE_SITE_URL`) to the canonical origin, e.g. `https://aphylia.app`. Optional knobs include `SITEMAP_DEFAULT_LANGUAGE`, `SITEMAP_MAX_PLANT_URLS`, `SITEMAP_PLANT_BATCH_SIZE`, and `SKIP_SITEMAP_GENERATION=1` (useful for very fast local builds).
+- **Supabase access**: provide `SUPABASE_URL` plus either `SUPABASE_SERVICE_ROLE_KEY` or `VITE_SUPABASE_ANON_KEY`. When credentials are missing the script logs a warning and falls back to static URLs only.
+- **Locales**: language variants are inferred from `public/locales/<lang>` and mirrored for every route, respecting `VITE_APP_BASE_PATH` for sub-path deployments.
+- Run `npm run generate:sitemap` manually any time you need to reissue the sitemap without rebuilding the rest of the bundle.
+
 ### Local Deployments
 
 1. **First-time server provisioning**: `sudo ./setup.sh`. This installs system packages, node dependencies, builds the PWA (`npm run build`), provisions nginx/systemd, and links `/var/www/PlantSwipe/plant-swipe` to the repo. Use `PWA_BASE_PATH=/custom/ sudo ./setup.sh` if you serve the UI from a sub-path.

--- a/plant-swipe/package.json
+++ b/plant-swipe/package.json
@@ -5,11 +5,12 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "node --max-old-space-size=6144 ./node_modules/typescript/bin/tsc -b && node --max-old-space-size=6144 ./node_modules/vite/bin/vite.js build",
+    "build": "npm run generate:sitemap && node --max-old-space-size=6144 ./node_modules/typescript/bin/tsc -b && node --max-old-space-size=6144 ./node_modules/vite/bin/vite.js build",
     "lint": "eslint .",
     "preview": "vite preview",
     "serve": "node server.js",
-    "check-translations": "node scripts/check-translations.js"
+    "check-translations": "node scripts/check-translations.js",
+    "generate:sitemap": "node scripts/generate-sitemap.js"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15",

--- a/plant-swipe/public/sitemap.xml
+++ b/plant-swipe/public/sitemap.xml
@@ -1,0 +1,633 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>https://aphylia.app/</loc>
+    <lastmod>2025-11-18T09:37:17.243Z</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>1.0</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/about</loc>
+    <lastmod>2025-11-18T09:37:17.243Z</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/about" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/about" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/about" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/contact</loc>
+    <lastmod>2025-11-18T09:37:17.243Z</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/contact" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/contact" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/contact" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/contact/business</loc>
+    <lastmod>2025-11-18T09:37:17.243Z</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/contact/business" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/contact/business" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/contact/business" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/download</loc>
+    <lastmod>2025-11-18T09:37:17.243Z</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/download" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/download" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/download" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/fr</loc>
+    <lastmod>2025-11-18T09:37:17.243Z</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>1.0</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/fr/about</loc>
+    <lastmod>2025-11-18T09:37:17.243Z</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/about" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/about" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/about" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/fr/contact</loc>
+    <lastmod>2025-11-18T09:37:17.243Z</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/contact" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/contact" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/contact" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/fr/contact/business</loc>
+    <lastmod>2025-11-18T09:37:17.243Z</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/contact/business" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/contact/business" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/contact/business" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/fr/download</loc>
+    <lastmod>2025-11-18T09:37:17.243Z</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/download" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/download" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/download" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/fr/gardens</loc>
+    <lastmod>2025-11-18T09:37:17.243Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/gardens" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/gardens" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/gardens" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/fr/plants/0</loc>
+    <lastmod>2025-09-16T08:43:56.786Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/0" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/0" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/0" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/fr/plants/1</loc>
+    <lastmod>2025-09-16T08:43:56.786Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/1" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/1" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/1" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/fr/plants/1616cddd-e254-4a95-8c51-25ccabb1297f</loc>
+    <lastmod>2025-11-13T19:47:21.684Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/1616cddd-e254-4a95-8c51-25ccabb1297f" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/1616cddd-e254-4a95-8c51-25ccabb1297f" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/1616cddd-e254-4a95-8c51-25ccabb1297f" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/fr/plants/2</loc>
+    <lastmod>2025-09-16T08:43:56.786Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/2" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/2" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/2" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/fr/plants/202bf2d2-281c-4d9a-955f-fd697e3be137</loc>
+    <lastmod>2025-10-13T15:26:05.889Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/202bf2d2-281c-4d9a-955f-fd697e3be137" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/202bf2d2-281c-4d9a-955f-fd697e3be137" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/202bf2d2-281c-4d9a-955f-fd697e3be137" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/fr/plants/2c330fc9-2565-4025-b612-11439b9fd8b2</loc>
+    <lastmod>2025-11-15T01:36:13.111Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/2c330fc9-2565-4025-b612-11439b9fd8b2" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/2c330fc9-2565-4025-b612-11439b9fd8b2" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/2c330fc9-2565-4025-b612-11439b9fd8b2" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/fr/plants/43cd0d55-e799-4f2b-99fd-8dd7c7940530</loc>
+    <lastmod>2025-09-16T08:43:56.786Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/43cd0d55-e799-4f2b-99fd-8dd7c7940530" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/43cd0d55-e799-4f2b-99fd-8dd7c7940530" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/43cd0d55-e799-4f2b-99fd-8dd7c7940530" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/fr/plants/4522e5f1-c045-47cf-ba58-1bf0b45e2a54</loc>
+    <lastmod>2025-11-05T16:49:39.066Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/4522e5f1-c045-47cf-ba58-1bf0b45e2a54" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/4522e5f1-c045-47cf-ba58-1bf0b45e2a54" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/4522e5f1-c045-47cf-ba58-1bf0b45e2a54" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/fr/plants/58510c83-2ef0-4247-8e3d-e564f72f8c34</loc>
+    <lastmod>2025-11-13T17:43:08.264Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/58510c83-2ef0-4247-8e3d-e564f72f8c34" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/58510c83-2ef0-4247-8e3d-e564f72f8c34" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/58510c83-2ef0-4247-8e3d-e564f72f8c34" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/fr/plants/5e19ebb5-828c-4a91-90cd-eb403dc96e77</loc>
+    <lastmod>2025-11-17T12:28:04.771Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/5e19ebb5-828c-4a91-90cd-eb403dc96e77" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/5e19ebb5-828c-4a91-90cd-eb403dc96e77" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/5e19ebb5-828c-4a91-90cd-eb403dc96e77" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/fr/plants/746ff23f-51b2-4314-b17f-671f4c26189e</loc>
+    <lastmod>2025-11-05T16:34:35.343Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/746ff23f-51b2-4314-b17f-671f4c26189e" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/746ff23f-51b2-4314-b17f-671f4c26189e" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/746ff23f-51b2-4314-b17f-671f4c26189e" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/fr/plants/9399922f-4e6a-4b82-af4a-cfe5fc6c0af6</loc>
+    <lastmod>2025-11-05T17:10:19.915Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/9399922f-4e6a-4b82-af4a-cfe5fc6c0af6" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/9399922f-4e6a-4b82-af4a-cfe5fc6c0af6" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/9399922f-4e6a-4b82-af4a-cfe5fc6c0af6" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/fr/plants/96462845-66f1-45de-a27b-e575f6eab1ac</loc>
+    <lastmod>2025-11-11T22:47:49.834Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/96462845-66f1-45de-a27b-e575f6eab1ac" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/96462845-66f1-45de-a27b-e575f6eab1ac" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/96462845-66f1-45de-a27b-e575f6eab1ac" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/fr/plants/a1234288-98e1-4acb-aa48-0a90b1f785e3</loc>
+    <lastmod>2025-11-15T00:53:11.169Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/a1234288-98e1-4acb-aa48-0a90b1f785e3" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/a1234288-98e1-4acb-aa48-0a90b1f785e3" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/a1234288-98e1-4acb-aa48-0a90b1f785e3" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/fr/plants/a6b2e374-1d92-4dd3-b1ee-6d4be57417f5</loc>
+    <lastmod>2025-11-16T22:52:57.482Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/a6b2e374-1d92-4dd3-b1ee-6d4be57417f5" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/a6b2e374-1d92-4dd3-b1ee-6d4be57417f5" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/a6b2e374-1d92-4dd3-b1ee-6d4be57417f5" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/fr/plants/acd98d74-1e19-41f4-9f7e-b5bbe0bd14e5</loc>
+    <lastmod>2025-11-05T09:48:01.892Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/acd98d74-1e19-41f4-9f7e-b5bbe0bd14e5" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/acd98d74-1e19-41f4-9f7e-b5bbe0bd14e5" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/acd98d74-1e19-41f4-9f7e-b5bbe0bd14e5" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/fr/plants/b6f4672e-f444-4748-93ad-3e0af1f8bc6c</loc>
+    <lastmod>2025-11-16T16:44:06.967Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/b6f4672e-f444-4748-93ad-3e0af1f8bc6c" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/b6f4672e-f444-4748-93ad-3e0af1f8bc6c" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/b6f4672e-f444-4748-93ad-3e0af1f8bc6c" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/fr/plants/d55bd63d-fbce-43a7-a18d-c275293eceef</loc>
+    <lastmod>2025-11-13T00:24:41.844Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/d55bd63d-fbce-43a7-a18d-c275293eceef" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/d55bd63d-fbce-43a7-a18d-c275293eceef" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/d55bd63d-fbce-43a7-a18d-c275293eceef" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/fr/plants/d78eee37-38de-4655-a7e2-d1ae3649051b</loc>
+    <lastmod>2025-11-16T19:08:54.845Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/d78eee37-38de-4655-a7e2-d1ae3649051b" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/d78eee37-38de-4655-a7e2-d1ae3649051b" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/d78eee37-38de-4655-a7e2-d1ae3649051b" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/fr/plants/e66dbeb6-a57f-446e-a5c4-11eec2c84e20</loc>
+    <lastmod>2025-11-16T21:10:55.067Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/e66dbeb6-a57f-446e-a5c4-11eec2c84e20" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/e66dbeb6-a57f-446e-a5c4-11eec2c84e20" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/e66dbeb6-a57f-446e-a5c4-11eec2c84e20" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/fr/plants/ea69a2f9-1f26-47a1-8d01-168eb321e2c9</loc>
+    <lastmod>2025-11-05T17:44:25.530Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/ea69a2f9-1f26-47a1-8d01-168eb321e2c9" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/ea69a2f9-1f26-47a1-8d01-168eb321e2c9" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/ea69a2f9-1f26-47a1-8d01-168eb321e2c9" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/fr/plants/ebcb7004-143b-4056-8ee2-3e6050459922</loc>
+    <lastmod>2025-11-17T12:52:51.562Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/ebcb7004-143b-4056-8ee2-3e6050459922" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/ebcb7004-143b-4056-8ee2-3e6050459922" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/ebcb7004-143b-4056-8ee2-3e6050459922" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/fr/plants/ef67a8da-ac79-4799-b11e-b41d8832b606</loc>
+    <lastmod>2025-10-09T08:19:53.196Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/ef67a8da-ac79-4799-b11e-b41d8832b606" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/ef67a8da-ac79-4799-b11e-b41d8832b606" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/ef67a8da-ac79-4799-b11e-b41d8832b606" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/fr/plants/f979bca4-d29d-4cff-ae40-6e6ff76a3868</loc>
+    <lastmod>2025-11-16T19:02:31.995Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/f979bca4-d29d-4cff-ae40-6e6ff76a3868" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/f979bca4-d29d-4cff-ae40-6e6ff76a3868" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/f979bca4-d29d-4cff-ae40-6e6ff76a3868" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/fr/plants/f9ef8c60-631a-47ef-80ca-4703f4ab199c</loc>
+    <lastmod>2025-11-17T13:06:28.203Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/f9ef8c60-631a-47ef-80ca-4703f4ab199c" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/f9ef8c60-631a-47ef-80ca-4703f4ab199c" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/f9ef8c60-631a-47ef-80ca-4703f4ab199c" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/fr/plants/fa63ba9c-cea7-44a0-bcef-0e768ceb53a6</loc>
+    <lastmod>2025-11-17T16:45:17.231Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/fa63ba9c-cea7-44a0-bcef-0e768ceb53a6" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/fa63ba9c-cea7-44a0-bcef-0e768ceb53a6" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/fa63ba9c-cea7-44a0-bcef-0e768ceb53a6" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/fr/plants/fc3c2bc4-39ba-4ec1-bdab-0d3a490460e6</loc>
+    <lastmod>2025-11-05T07:58:42.615Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/fc3c2bc4-39ba-4ec1-bdab-0d3a490460e6" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/fc3c2bc4-39ba-4ec1-bdab-0d3a490460e6" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/fc3c2bc4-39ba-4ec1-bdab-0d3a490460e6" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/fr/search</loc>
+    <lastmod>2025-11-18T09:37:17.243Z</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.9</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/search" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/search" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/search" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/fr/terms</loc>
+    <lastmod>2025-11-18T09:37:17.243Z</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.4</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/terms" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/terms" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/terms" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/gardens</loc>
+    <lastmod>2025-11-18T09:37:17.243Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/gardens" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/gardens" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/gardens" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/plants/0</loc>
+    <lastmod>2025-09-16T08:43:56.786Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/0" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/0" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/0" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/plants/1</loc>
+    <lastmod>2025-09-16T08:43:56.786Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/1" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/1" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/1" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/plants/1616cddd-e254-4a95-8c51-25ccabb1297f</loc>
+    <lastmod>2025-11-13T19:47:21.684Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/1616cddd-e254-4a95-8c51-25ccabb1297f" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/1616cddd-e254-4a95-8c51-25ccabb1297f" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/1616cddd-e254-4a95-8c51-25ccabb1297f" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/plants/2</loc>
+    <lastmod>2025-09-16T08:43:56.786Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/2" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/2" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/2" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/plants/202bf2d2-281c-4d9a-955f-fd697e3be137</loc>
+    <lastmod>2025-10-13T15:26:05.889Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/202bf2d2-281c-4d9a-955f-fd697e3be137" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/202bf2d2-281c-4d9a-955f-fd697e3be137" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/202bf2d2-281c-4d9a-955f-fd697e3be137" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/plants/2c330fc9-2565-4025-b612-11439b9fd8b2</loc>
+    <lastmod>2025-11-15T01:36:13.111Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/2c330fc9-2565-4025-b612-11439b9fd8b2" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/2c330fc9-2565-4025-b612-11439b9fd8b2" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/2c330fc9-2565-4025-b612-11439b9fd8b2" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/plants/43cd0d55-e799-4f2b-99fd-8dd7c7940530</loc>
+    <lastmod>2025-09-16T08:43:56.786Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/43cd0d55-e799-4f2b-99fd-8dd7c7940530" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/43cd0d55-e799-4f2b-99fd-8dd7c7940530" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/43cd0d55-e799-4f2b-99fd-8dd7c7940530" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/plants/4522e5f1-c045-47cf-ba58-1bf0b45e2a54</loc>
+    <lastmod>2025-11-05T16:49:39.066Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/4522e5f1-c045-47cf-ba58-1bf0b45e2a54" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/4522e5f1-c045-47cf-ba58-1bf0b45e2a54" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/4522e5f1-c045-47cf-ba58-1bf0b45e2a54" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/plants/58510c83-2ef0-4247-8e3d-e564f72f8c34</loc>
+    <lastmod>2025-11-13T17:43:08.264Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/58510c83-2ef0-4247-8e3d-e564f72f8c34" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/58510c83-2ef0-4247-8e3d-e564f72f8c34" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/58510c83-2ef0-4247-8e3d-e564f72f8c34" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/plants/5e19ebb5-828c-4a91-90cd-eb403dc96e77</loc>
+    <lastmod>2025-11-17T12:28:04.771Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/5e19ebb5-828c-4a91-90cd-eb403dc96e77" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/5e19ebb5-828c-4a91-90cd-eb403dc96e77" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/5e19ebb5-828c-4a91-90cd-eb403dc96e77" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/plants/746ff23f-51b2-4314-b17f-671f4c26189e</loc>
+    <lastmod>2025-11-05T16:34:35.343Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/746ff23f-51b2-4314-b17f-671f4c26189e" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/746ff23f-51b2-4314-b17f-671f4c26189e" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/746ff23f-51b2-4314-b17f-671f4c26189e" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/plants/9399922f-4e6a-4b82-af4a-cfe5fc6c0af6</loc>
+    <lastmod>2025-11-05T17:10:19.915Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/9399922f-4e6a-4b82-af4a-cfe5fc6c0af6" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/9399922f-4e6a-4b82-af4a-cfe5fc6c0af6" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/9399922f-4e6a-4b82-af4a-cfe5fc6c0af6" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/plants/96462845-66f1-45de-a27b-e575f6eab1ac</loc>
+    <lastmod>2025-11-11T22:47:49.834Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/96462845-66f1-45de-a27b-e575f6eab1ac" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/96462845-66f1-45de-a27b-e575f6eab1ac" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/96462845-66f1-45de-a27b-e575f6eab1ac" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/plants/a1234288-98e1-4acb-aa48-0a90b1f785e3</loc>
+    <lastmod>2025-11-15T00:53:11.169Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/a1234288-98e1-4acb-aa48-0a90b1f785e3" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/a1234288-98e1-4acb-aa48-0a90b1f785e3" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/a1234288-98e1-4acb-aa48-0a90b1f785e3" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/plants/a6b2e374-1d92-4dd3-b1ee-6d4be57417f5</loc>
+    <lastmod>2025-11-16T22:52:57.482Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/a6b2e374-1d92-4dd3-b1ee-6d4be57417f5" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/a6b2e374-1d92-4dd3-b1ee-6d4be57417f5" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/a6b2e374-1d92-4dd3-b1ee-6d4be57417f5" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/plants/acd98d74-1e19-41f4-9f7e-b5bbe0bd14e5</loc>
+    <lastmod>2025-11-05T09:48:01.892Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/acd98d74-1e19-41f4-9f7e-b5bbe0bd14e5" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/acd98d74-1e19-41f4-9f7e-b5bbe0bd14e5" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/acd98d74-1e19-41f4-9f7e-b5bbe0bd14e5" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/plants/b6f4672e-f444-4748-93ad-3e0af1f8bc6c</loc>
+    <lastmod>2025-11-16T16:44:06.967Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/b6f4672e-f444-4748-93ad-3e0af1f8bc6c" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/b6f4672e-f444-4748-93ad-3e0af1f8bc6c" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/b6f4672e-f444-4748-93ad-3e0af1f8bc6c" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/plants/d55bd63d-fbce-43a7-a18d-c275293eceef</loc>
+    <lastmod>2025-11-13T00:24:41.844Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/d55bd63d-fbce-43a7-a18d-c275293eceef" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/d55bd63d-fbce-43a7-a18d-c275293eceef" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/d55bd63d-fbce-43a7-a18d-c275293eceef" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/plants/d78eee37-38de-4655-a7e2-d1ae3649051b</loc>
+    <lastmod>2025-11-16T19:08:54.845Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/d78eee37-38de-4655-a7e2-d1ae3649051b" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/d78eee37-38de-4655-a7e2-d1ae3649051b" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/d78eee37-38de-4655-a7e2-d1ae3649051b" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/plants/e66dbeb6-a57f-446e-a5c4-11eec2c84e20</loc>
+    <lastmod>2025-11-16T21:10:55.067Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/e66dbeb6-a57f-446e-a5c4-11eec2c84e20" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/e66dbeb6-a57f-446e-a5c4-11eec2c84e20" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/e66dbeb6-a57f-446e-a5c4-11eec2c84e20" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/plants/ea69a2f9-1f26-47a1-8d01-168eb321e2c9</loc>
+    <lastmod>2025-11-05T17:44:25.530Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/ea69a2f9-1f26-47a1-8d01-168eb321e2c9" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/ea69a2f9-1f26-47a1-8d01-168eb321e2c9" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/ea69a2f9-1f26-47a1-8d01-168eb321e2c9" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/plants/ebcb7004-143b-4056-8ee2-3e6050459922</loc>
+    <lastmod>2025-11-17T12:52:51.562Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/ebcb7004-143b-4056-8ee2-3e6050459922" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/ebcb7004-143b-4056-8ee2-3e6050459922" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/ebcb7004-143b-4056-8ee2-3e6050459922" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/plants/ef67a8da-ac79-4799-b11e-b41d8832b606</loc>
+    <lastmod>2025-10-09T08:19:53.196Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/ef67a8da-ac79-4799-b11e-b41d8832b606" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/ef67a8da-ac79-4799-b11e-b41d8832b606" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/ef67a8da-ac79-4799-b11e-b41d8832b606" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/plants/f979bca4-d29d-4cff-ae40-6e6ff76a3868</loc>
+    <lastmod>2025-11-16T19:02:31.995Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/f979bca4-d29d-4cff-ae40-6e6ff76a3868" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/f979bca4-d29d-4cff-ae40-6e6ff76a3868" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/f979bca4-d29d-4cff-ae40-6e6ff76a3868" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/plants/f9ef8c60-631a-47ef-80ca-4703f4ab199c</loc>
+    <lastmod>2025-11-17T13:06:28.203Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/f9ef8c60-631a-47ef-80ca-4703f4ab199c" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/f9ef8c60-631a-47ef-80ca-4703f4ab199c" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/f9ef8c60-631a-47ef-80ca-4703f4ab199c" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/plants/fa63ba9c-cea7-44a0-bcef-0e768ceb53a6</loc>
+    <lastmod>2025-11-17T16:45:17.231Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/fa63ba9c-cea7-44a0-bcef-0e768ceb53a6" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/fa63ba9c-cea7-44a0-bcef-0e768ceb53a6" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/fa63ba9c-cea7-44a0-bcef-0e768ceb53a6" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/plants/fc3c2bc4-39ba-4ec1-bdab-0d3a490460e6</loc>
+    <lastmod>2025-11-05T07:58:42.615Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/plants/fc3c2bc4-39ba-4ec1-bdab-0d3a490460e6" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/plants/fc3c2bc4-39ba-4ec1-bdab-0d3a490460e6" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/plants/fc3c2bc4-39ba-4ec1-bdab-0d3a490460e6" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/search</loc>
+    <lastmod>2025-11-18T09:37:17.243Z</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.9</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/search" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/search" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/search" />
+  </url>
+  <url>
+    <loc>https://aphylia.app/terms</loc>
+    <lastmod>2025-11-18T09:37:17.243Z</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.4</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://aphylia.app/terms" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://aphylia.app/fr/terms" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://aphylia.app/terms" />
+  </url>
+</urlset>


### PR DESCRIPTION
Adds an automated sitemap generator to `npm run build` for improved SEO readiness.

This change introduces `scripts/generate-sitemap.js` which creates a localized `public/sitemap.xml` including static routes and dynamic plant pages fetched from Supabase. It runs automatically as part of `npm run build` (and thus `scripts/refresh-plant-swipe.sh`), ensuring the sitemap is always current for search engines.

---
<a href="https://cursor.com/background-agent?bcId=bc-4eebed43-9558-411b-85de-5cc331db3da7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4eebed43-9558-411b-85de-5cc331db3da7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

