### PR TITLE
Fix desktop page double scrollbars

### DIFF
--- a/plant-swipe/src/index.css
+++ b/plant-swipe/src/index.css
@@ -7,10 +7,12 @@
 }
 
 @layer base {
-  html {
-    min-height: 100%;
-    overflow-y: auto;
-    overscroll-behavior-y: auto;
+    html {
+      min-height: 100%;
+      min-height: 100dvh;
+      overflow-y: auto;
+      overflow-x: hidden;
+      overscroll-behavior-y: auto;
     font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
     line-height: 1.5;
     font-weight: 400;
@@ -21,14 +23,12 @@
     -moz-osx-font-smoothing: grayscale;
   }
 
-  body {
-    min-height: 100vh;
-    min-height: 100dvh;
-    margin: 0;
-    min-width: 320px;
-    overflow-y: auto;
-    overflow-x: hidden;
-    overscroll-behavior-y: auto;
+    body {
+      min-height: 100vh;
+      min-height: 100dvh;
+      margin: 0;
+      min-width: 320px;
+      overscroll-behavior-y: inherit;
     -webkit-user-select: none;
     -ms-user-select: none;
     user-select: none;


### PR DESCRIPTION
Make the root `<html>` element the sole scroll container to remove the double scrollbar issue on desktop pages.

The previous setup had both `html` and `body` elements configured for scrolling, leading to two scrollbars. By explicitly setting `overflow-y: auto` and `overflow-x: hidden` on `html` and letting `body` inherit its overflow behavior, only one scrollbar is rendered.

---
<a href="https://cursor.com/background-agent?bcId=bc-e04f79e8-94de-434e-a9f0-a1ffeec21926"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e04f79e8-94de-434e-a9f0-a1ffeec21926"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

