### PR TITLE
Generate sitemap, fix type error, and remove sitemap

### DIFF
--- a/plant-swipe/src/pages/SwipePage.tsx
+++ b/plant-swipe/src/pages/SwipePage.tsx
@@ -43,27 +43,28 @@ interface SwipePageProps {
   handleInfo: () => void
   handlePass: () => void
   handlePrevious: () => void
-    liked?: boolean
-    onToggleLike?: () => void
-    boostImagePriority?: boolean
-    isLoading?: boolean
+  liked?: boolean
+  onToggleLike?: () => void
+  boostImagePriority?: boolean
+  isLoading?: boolean
 }
 
-export const SwipePage: React.FC<SwipePageProps> = ({
-  current,
-  index,
-  setIndex,
-  x,
-  y,
-  onDragEnd,
-  handleInfo,
-  handlePass,
-  handlePrevious,
-  liked = false,
-  onToggleLike,
-  boostImagePriority = false,
-  isLoading = false,
-}) => {
+export const SwipePage: React.FC<SwipePageProps> = (props) => {
+  const {
+    current,
+    index,
+    setIndex,
+    x,
+    y,
+    onDragEnd,
+    handleInfo,
+    handlePass,
+    handlePrevious,
+    liked = false,
+    onToggleLike,
+    boostImagePriority = false,
+    isLoading = false,
+  } = props
   const { t } = useTranslation("common")
     const seoTitle = t("seo.home.title", { defaultValue: "Aphylia" })
       const seoDescription = t("seo.home.description", {
@@ -121,7 +122,10 @@ export const SwipePage: React.FC<SwipePageProps> = ({
     const vertical = getVerticalPhotoUrl(current.photos ?? [])
     return vertical || current.image || ""
   }, [current])
-  const shouldPrioritizeImage = Boolean(boostImagePriority && displayImage)
+  const shouldPrioritizeImage = React.useMemo(
+    () => Boolean(displayImage && boostImagePriority),
+    [boostImagePriority, displayImage],
+  )
 
   React.useEffect(() => {
     if (!shouldPrioritizeImage || !displayImage || typeof document === "undefined") {


### PR DESCRIPTION
Fix `TS2304` error in `SwipePage.tsx` by ensuring `boostImagePriority` is always defined and remove the generated `public/sitemap.xml` artifact.

---
<a href="https://cursor.com/background-agent?bcId=bc-12045771-bfa4-48ec-813a-15471a05b96c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-12045771-bfa4-48ec-813a-15471a05b96c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

