### PR TITLE
Fix bottom nav bar flashing on discovery swipe

### DIFF
--- a/plant-swipe/src/components/layout/MobileNavBar.tsx
+++ b/plant-swipe/src/components/layout/MobileNavBar.tsx
@@ -24,14 +24,6 @@ export const MobileNavBar: React.FC<MobileNavBarProps> = ({ canCreate, onProfile
   const { t } = useTranslation('common')
   const [profileMenuOpen, setProfileMenuOpen] = React.useState(false)
   const canUseDOM = typeof document !== "undefined"
-  const navLayerStyle = React.useMemo<React.CSSProperties>(() => ({
-    willChange: "transform",
-    transform: "translateZ(0)",
-    WebkitTransform: "translateZ(0)",
-    backfaceVisibility: "hidden",
-    WebkitBackfaceVisibility: "hidden",
-    contain: "layout paint",
-  }), [])
   
   const currentView: "discovery" | "gardens" | "search" | "create" | "profile" =
     pathWithoutLang === "/" ? "discovery" :
@@ -46,10 +38,9 @@ export const MobileNavBar: React.FC<MobileNavBarProps> = ({ canCreate, onProfile
 
   const navElement = (
     <nav
-      className="fixed bottom-0 left-0 right-0 md:hidden z-50 isolate border-t border-stone-200 dark:border-[#3e3e42] bg-white/70 dark:bg-[#252526]/90 backdrop-blur-xl supports-[backdrop-filter]:bg-white/50 dark:supports-[backdrop-filter]:bg-[#252526]/80 shadow-[0_-8px_30px_rgba(0,0,0,0.08)] dark:shadow-[0_-8px_30px_rgba(0,0,0,0.3)] pb-[max(env(safe-area-inset-bottom),0px)]"
+      className="fixed bottom-0 left-0 right-0 md:hidden z-50 border-t border-stone-200 dark:border-[#3e3e42] bg-white/70 dark:bg-[#252526]/90 backdrop-blur-xl supports-[backdrop-filter]:bg-white/50 dark:supports-[backdrop-filter]:bg-[#252526]/80 shadow-[0_-8px_30px_rgba(0,0,0,0.08)] dark:shadow-[0_-8px_30px_rgba(0,0,0,0.3)] pb-[max(env(safe-area-inset-bottom),0px)]"
       role="navigation"
       aria-label="Primary"
-      style={navLayerStyle}
     >
       <div className="relative mx-auto max-w-6xl px-6 pt-3 pb-3">
         {/* Center floating create button */}


### PR DESCRIPTION
Remove GPU/compositing hints from the mobile nav bar to prevent it from flashing and disappearing on mobile Safari when swiping.

Safari drops `backdrop-filter` layers that claim to be paint-independent, which caused the nav bar to flash and disappear when the discovery card animated underneath it. Removing these hints allows the nav to render with the original stable class list and sample the live background.

---
<a href="https://cursor.com/background-agent?bcId=bc-3509d604-b358-479d-9b45-a6967c56249a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3509d604-b358-479d-9b45-a6967c56249a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

