### PR TITLE
Update sitemap for dynamic plant links

### DIFF
--- a/plant-swipe/scripts/generate-sitemap.js
+++ b/plant-swipe/scripts/generate-sitemap.js
@@ -196,8 +196,8 @@ async function loadPlantRoutes() {
     const to = offset + limit - 1
     const { data, error } = await client
       .from('plants')
-      .select('id, updated_at, meta')
-      .order('updated_at', { ascending: false })
+      .select('id, updated_time, created_time')
+      .order('updated_time', { ascending: false, nullsFirst: false })
       .range(offset, to)
 
     if (error) {
@@ -229,23 +229,12 @@ async function loadPlantRoutes() {
 }
 
 function pickLastmod(row) {
-  if (row?.updated_at) {
-    const iso = toIsoString(row.updated_at)
-    if (iso) return iso
-  }
-  if (!row?.meta) return null
-  let meta = row.meta
-  if (typeof meta === 'string') {
-    try {
-      meta = JSON.parse(meta)
-    } catch {
-      meta = null
-    }
-  }
-  if (meta && typeof meta === 'object') {
-    const iso = toIsoString(meta.updatedAt || meta.updated_at)
-    if (iso) return iso
-  }
+  const updated = row?.updated_time || row?.updatedTime
+  const created = row?.created_time || row?.createdTime
+  const updatedIso = toIsoString(updated)
+  if (updatedIso) return updatedIso
+  const createdIso = toIsoString(created)
+  if (createdIso) return createdIso
   return null
 }
 


### PR DESCRIPTION
Update sitemap generation to use `updated_time` and `created_time` columns for dynamic plant links, resolving the `updated_at` column not found error.

---
<a href="https://cursor.com/background-agent?bcId=bc-545f55a6-1b3d-45af-b431-59fe224394ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-545f55a6-1b3d-45af-b431-59fe224394ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

