### PR TITLE
Update plant viewer and gallery interactions

### DIFF
--- a/plant-swipe/src/components/plant/PlantDetails.tsx
+++ b/plant-swipe/src/components/plant/PlantDetails.tsx
@@ -966,14 +966,26 @@ export const PlantDetails: React.FC<PlantDetailsProps> = ({ plant, liked, onTogg
         {galleryHasContent ? (
           <Section title="Gallery" icon={<Layers className="h-4 w-4" />}>
             <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
-              {(plant.images ?? []).map((img) => (
-                <div key={img.id || img.link} className="relative overflow-hidden rounded-xl border border-muted/60 bg-white/80 shadow-sm">
-                  <img src={img.link} alt={plant.name} className="h-32 w-full object-cover sm:h-40" loading="lazy" />
-                  <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/60 to-transparent px-2 py-1 text-[11px] uppercase tracking-wide text-white">
-                    {img.use}
+              {(plant.images ?? []).map((img) => {
+                const imageIndex = images.findIndex((i) => i.id === img.id || i.link === img.link)
+                return (
+                  <div
+                    key={img.id || img.link}
+                    className="relative overflow-hidden rounded-xl border border-muted/60 bg-white/80 shadow-sm cursor-pointer transition hover:scale-105 hover:shadow-md"
+                    onClick={() => {
+                      if (imageIndex >= 0) {
+                        setActiveImageIndex(imageIndex)
+                        setViewerOpen(true)
+                      }
+                    }}
+                  >
+                    <img src={img.link} alt={plant.name} className="h-32 w-full object-cover sm:h-40" loading="lazy" />
+                    <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/60 to-transparent px-2 py-1 text-[11px] uppercase tracking-wide text-white">
+                      {img.use}
+                    </div>
                   </div>
-                </div>
-              ))}
+                )
+              })}
             </div>
           </Section>
         ) : null}

--- a/plant-swipe/src/pages/PlantInfoPage.tsx
+++ b/plant-swipe/src/pages/PlantInfoPage.tsx
@@ -921,10 +921,7 @@ const DimensionCube: React.FC<{ scale: number }> = ({ scale }) => {
       camera.position.y = cameraHeight
       camera.lookAt(cubeCenter)
 
-      // Rotate meshes around their own center (which is at cubeCenter)
-      outerMesh.rotation.y = totalRotation
-      outerWire.rotation.y = totalRotation
-      innerWire.rotation.y = -totalRotation * 0.833 // Maintain relative rotation
+      // Don't rotate the meshes - only the camera rotates around the cube
 
       renderer.render(scene, camera)
       frameId = requestAnimationFrame(animate)


### PR DESCRIPTION
Make gallery images clickable to open a popup viewer and stop the 3D cube from spinning, allowing only the camera to rotate.

The 3D cube in the plant info page previously rotated the cube meshes, but the user requested that only the camera should orbit the stationary cube and grid. Additionally, gallery images now open a full-screen viewer on click, matching the behavior of the hero grid images.

---
<a href="https://cursor.com/background-agent?bcId=bc-5d53cfc6-299a-4f1c-864c-a8c7a2eac1b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5d53cfc6-299a-4f1c-864c-a8c7a2eac1b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

