### PR TITLE
Remove unused flame import

### DIFF
--- a/plant-swipe/src/components/plant/PlantDetails.tsx
+++ b/plant-swipe/src/components/plant/PlantDetails.tsx
@@ -6,7 +6,6 @@ import type { Plant } from "@/types/plant"
 import { Link } from "react-router-dom"
 import { supabase } from "@/lib/supabaseClient"
 import {
-  Flame,
   SunMedium,
   Droplets,
   Thermometer,


### PR DESCRIPTION
Remove unused 'Flame' import to resolve TypeScript error TS6133.

---
<a href="https://cursor.com/background-agent?bcId=bc-062b6a27-11ca-4acf-8f4b-ef13c557bbeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-062b6a27-11ca-4acf-8f4b-ef13c557bbeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

