### PR TITLE
Organize colors by name length

### DIFF
--- a/plant-swipe/src/components/plant/PlantProfileForm.tsx
+++ b/plant-swipe/src/components/plant/PlantProfileForm.tsx
@@ -30,6 +30,16 @@ const normalizeHex = (hex?: string) => {
   return trimmed.startsWith("#") ? trimmed : `#${trimmed}`
 }
 
+const isSingleWordColorName = (name?: string) => {
+  if (!name) return false
+  const normalized = name
+    .trim()
+    .replace(/[\u2010-\u2015]/g, "-") // normalize special dashes
+    .replace(/[-_/]+/g, " ")
+  if (!normalized) return false
+  return normalized.split(/\s+/).filter(Boolean).length === 1
+}
+
 type FieldType =
   | "text"
   | "textarea"
@@ -903,8 +913,7 @@ function ColorPicker({ colors, onChange }: { colors: PlantColor[]; onChange: (v:
     const single: PlantColor[] = []
     const multi: PlantColor[] = []
     ;(available || []).forEach((color) => {
-      const name = (color.name || "").trim()
-      if (name && !/\s/.test(name)) {
+      if (isSingleWordColorName(color.name)) {
         single.push(color)
       } else {
         multi.push(color)


### PR DESCRIPTION
Display single-word colors by default and move multi-word colors to a collapsed "Advanced" tab in the color picker.

---
<a href="https://cursor.com/background-agent?bcId=bc-5213c209-7a7c-49f4-ad86-524dede84331"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5213c209-7a7c-49f4-ad86-524dede84331"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

