### PR TITLE
Add resend email service link

### DIFF
--- a/plant-swipe/src/pages/AdminPage.tsx
+++ b/plant-swipe/src/pages/AdminPage.tsx
@@ -5194,6 +5194,21 @@ export const AdminPage: React.FC = () => {
                           className="rounded-2xl"
                         >
                           <a
+                            href="https://resend.com/emails"
+                            target="_blank"
+                            rel="noreferrer"
+                          >
+                            <span className="inline-block h-3 w-3 rounded-sm bg-purple-600 dark:bg-purple-500" />
+                            <span>Resend</span>
+                            <ExternalLink className="h-3 w-3 opacity-70" />
+                          </a>
+                        </Button>
+                        <Button
+                          asChild
+                          variant="outline"
+                          className="rounded-2xl"
+                        >
+                          <a
                             href="https://supabase.com/dashboard/project/lxnkcguwewrskqnyzjwi"
                             target="_blank"
                             rel="noreferrer"


### PR DESCRIPTION
Add a link to Resend email service in the Admin Page's Quick Links section.

---
<a href="https://cursor.com/background-agent?bcId=bc-8b21ecb0-4c53-4b7e-900c-e9bcaa5506c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8b21ecb0-4c53-4b7e-900c-e9bcaa5506c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

