### PR TITLE
Pull, build, and handle pwa asset size error

### DIFF
--- a/plant-swipe/vite.config.ts
+++ b/plant-swipe/vite.config.ts
@@ -79,7 +79,7 @@ export default defineConfig({
       },
       injectManifest: {
         globPatterns: ['**/*.{js,css,html,ico,png,svg,webp,json,txt,woff,woff2,ttf}'],
-        globIgnores: ['**/*.map', '**/node_modules/**'],
+        globIgnores: ['**/*.map', '**/node_modules/**', '**/plant-swipe-icon-outline.svg'],
       },
       devOptions: {
         enabled: process.env.VITE_ENABLE_PWA === 'true',


### PR DESCRIPTION
Exclude `plant-swipe-icon-outline.svg` from PWA precaching to fix the build error caused by its large file size.

The `plant-swipe-icon-outline.svg` file is 2.64 MB, exceeding the default 2 MiB limit for assets to be precached by the PWA service worker. This SVG, which contains a large base64-encoded PNG, was being included in the `globPatterns` for precaching, leading to a build failure. By adding it to `globIgnores`, the build now succeeds without precaching this non-essential asset.

---
<a href="https://cursor.com/background-agent?bcId=bc-e917a151-df20-41d5-84d4-fff24949396a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e917a151-df20-41d5-84d4-fff24949396a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

