### PR TITLE
Fix plant discovery image display logic

### DIFF
--- a/plant-swipe/src/PlantSwipe.tsx
+++ b/plant-swipe/src/PlantSwipe.tsx
@@ -22,7 +22,7 @@ import RequireAdmin from "@/pages/RequireAdmin";
 import { supabase } from "@/lib/supabaseClient";
 import { useLanguage } from "@/lib/i18nRouting";
 import { loadPlantsWithTranslations } from "@/lib/plantTranslationLoader";
-import { getVerticalPhotoUrl } from "@/lib/photos";
+import { getDiscoveryImageUrl } from "@/lib/photos";
 import { isPlantOfTheMonth } from "@/lib/plantHighlights";
 import { formatClassificationLabel } from "@/constants/classification";
 import { useTranslation } from "react-i18next";
@@ -492,7 +492,7 @@ export default function PlantSwipe() {
   }, [filtered, searchSort, likedSet])
 
   const current = swipeList.length > 0 ? swipeList[index % swipeList.length] : undefined
-  const heroImageCandidate = current ? (getVerticalPhotoUrl(current.photos ?? []) || current.image || "") : ""
+  const heroImageCandidate = current ? getDiscoveryImageUrl(current) : ""
   const boostImagePriority = initialCardBoostRef.current && index === 0 && Boolean(heroImageCandidate)
 
   React.useEffect(() => {

--- a/plant-swipe/src/lib/photos.ts
+++ b/plant-swipe/src/lib/photos.ts
@@ -1,4 +1,4 @@
-import type { PlantPhoto } from "@/types/plant"
+import type { Plant, PlantPhoto } from "@/types/plant"
 
 export const MAX_PLANT_PHOTOS = 5
 
@@ -118,4 +118,38 @@ export function ensureAtLeastOnePhoto(photos: PlantPhoto[]): PlantPhoto[] {
     sanitized = [...sanitized, createEmptyPhoto(sanitized.every((photo) => !photo.isPrimary))]
   }
   return sanitized
+}
+
+const normalizeImageLink = (value?: string | null) => (typeof value === "string" ? value.trim() : "")
+
+const pickImageByUse = (images: PlantPhoto[], use: NonNullable<PlantPhoto["use"]>): string => {
+  const match = images.find((image) => image?.use === use && normalizeImageLink(image.link || image.url))
+  return match ? normalizeImageLink(match.link || match.url) : ""
+}
+
+const pickFirstImageLink = (images: PlantPhoto[]): string => {
+  const match = images.find((image) => normalizeImageLink(image?.link || image?.url))
+  return match ? normalizeImageLink(match.link || match.url) : ""
+}
+
+export function getDiscoveryImageUrl(
+  plant?: Pick<Plant, "images" | "photos" | "image"> | null,
+): string {
+  if (!plant) return ""
+
+  const images = Array.isArray(plant.images) ? plant.images : []
+  const discoveryImage = pickImageByUse(images, "discovery")
+  if (discoveryImage) return discoveryImage
+
+  const primaryImage = pickImageByUse(images, "primary")
+  if (primaryImage) return primaryImage
+
+  const fallbackImage = pickFirstImageLink(images)
+  if (fallbackImage) return fallbackImage
+
+  const photos = Array.isArray(plant.photos) ? plant.photos : []
+  const verticalPhoto = photos.length ? getVerticalPhotoUrl(photos) : ""
+  if (verticalPhoto) return verticalPhoto
+
+  return normalizeImageLink(plant.image)
 }

--- a/plant-swipe/src/pages/SwipePage.tsx
+++ b/plant-swipe/src/pages/SwipePage.tsx
@@ -28,7 +28,7 @@ import { useTranslation } from "react-i18next"
 import type { TFunction } from "i18next"
 import { Link } from "@/components/i18n/Link"
 import { isNewPlant, isPlantOfTheMonth, isPopularPlant } from "@/lib/plantHighlights"
-import { getVerticalPhotoUrl } from "@/lib/photos"
+import { getDiscoveryImageUrl } from "@/lib/photos"
 import { cn, deriveWaterLevelFromFrequency } from "@/lib/utils"
 import { resolveColorValue, DEFAULT_PLANT_COLOR } from "@/lib/colors"
 import { usePageMetadata } from "@/hooks/usePageMetadata"
@@ -115,11 +115,7 @@ export const SwipePage: React.FC<SwipePageProps> = ({
 
   const rarityKey = current?.rarity && rarityTone[current.rarity] ? current.rarity : "Common"
   const seasons = (current?.seasons ?? []) as PlantSeason[]
-  const displayImage = React.useMemo(() => {
-    if (!current) return ""
-    const vertical = getVerticalPhotoUrl(current.photos ?? [])
-    return vertical || current.image || ""
-  }, [current])
+  const displayImage = React.useMemo(() => getDiscoveryImageUrl(current), [current])
   const shouldPrioritizeImage = Boolean(boostImagePriority && displayImage)
   const highlightBadges = React.useMemo(() => {
     if (!current) return []


### PR DESCRIPTION
Prioritize discovery-tagged images for display in the Discovery tab, falling back to primary or other available images.

---
<a href="https://cursor.com/background-agent?bcId=bc-7962b392-cc71-48b6-8698-7b0ab28655b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7962b392-cc71-48b6-8698-7b0ab28655b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

