### PR TITLE
Update discovery page image logic

### DIFF
--- a/plant-swipe/src/PlantSwipe.tsx
+++ b/plant-swipe/src/PlantSwipe.tsx
@@ -22,7 +22,7 @@ import RequireAdmin from "@/pages/RequireAdmin";
 import { supabase } from "@/lib/supabaseClient";
 import { useLanguage } from "@/lib/i18nRouting";
 import { loadPlantsWithTranslations } from "@/lib/plantTranslationLoader";
-import { getVerticalPhotoUrl } from "@/lib/photos";
+import { getDiscoveryPageImageUrl } from "@/lib/photos";
 import { isPlantOfTheMonth } from "@/lib/plantHighlights";
 import { formatClassificationLabel } from "@/constants/classification";
 import { useTranslation } from "react-i18next";
@@ -492,7 +492,7 @@ export default function PlantSwipe() {
   }, [filtered, searchSort, likedSet])
 
   const current = swipeList.length > 0 ? swipeList[index % swipeList.length] : undefined
-  const heroImageCandidate = current ? (getVerticalPhotoUrl(current.photos ?? []) || current.image || "") : ""
+  const heroImageCandidate = current ? getDiscoveryPageImageUrl(current) : ""
   const boostImagePriority = initialCardBoostRef.current && index === 0 && Boolean(heroImageCandidate)
 
   React.useEffect(() => {

--- a/plant-swipe/src/lib/photos.ts
+++ b/plant-swipe/src/lib/photos.ts
@@ -1,4 +1,4 @@
-import type { PlantPhoto } from "@/types/plant"
+import type { PlantImage, PlantPhoto } from "@/types/plant"
 
 export const MAX_PLANT_PHOTOS = 5
 
@@ -88,6 +88,38 @@ export function getVerticalPhotoUrl(photos: PlantPhoto[]): string {
   const vertical = photos.find((photo) => photo.isVertical && safeTrim(photo.url))
   if (vertical) return safeTrim(vertical.url)
   return ""
+}
+
+const extractImageLink = (image?: PlantImage | null): string => {
+  if (!image) return ""
+  return safeTrim(image.link) || safeTrim(image.url)
+}
+
+const getImageLinkByUse = (images: PlantImage[] | undefined, use: PlantImage["use"]): string => {
+  if (!Array.isArray(images) || !use) return ""
+  const candidate = images.find((image) => image?.use === use && extractImageLink(image))
+  return extractImageLink(candidate)
+}
+
+export function getDiscoveryPageImageUrl(
+  plant?: { images?: PlantImage[]; photos?: PlantPhoto[]; image?: string },
+): string {
+  if (!plant) return ""
+  const discovery = getImageLinkByUse(plant.images, "discovery")
+  if (discovery) return discovery
+
+  const primary = getImageLinkByUse(plant.images, "primary")
+  if (primary) return primary
+
+  if (plant.photos) {
+    const vertical = getVerticalPhotoUrl(plant.photos)
+    if (vertical) return vertical
+
+    const primaryPhoto = getPrimaryPhotoUrl(plant.photos)
+    if (primaryPhoto) return primaryPhoto
+  }
+
+  return safeTrim(plant.image)
 }
 
 export function upsertPrimaryPhoto(current: PlantPhoto[], url: string): PlantPhoto[] {

--- a/plant-swipe/src/pages/SwipePage.tsx
+++ b/plant-swipe/src/pages/SwipePage.tsx
@@ -28,7 +28,7 @@ import { useTranslation } from "react-i18next"
 import type { TFunction } from "i18next"
 import { Link } from "@/components/i18n/Link"
 import { isNewPlant, isPlantOfTheMonth, isPopularPlant } from "@/lib/plantHighlights"
-import { getVerticalPhotoUrl } from "@/lib/photos"
+import { getDiscoveryPageImageUrl } from "@/lib/photos"
 import { cn, deriveWaterLevelFromFrequency } from "@/lib/utils"
 import { resolveColorValue, DEFAULT_PLANT_COLOR } from "@/lib/colors"
 import { usePageMetadata } from "@/hooks/usePageMetadata"
@@ -115,11 +115,7 @@ export const SwipePage: React.FC<SwipePageProps> = ({
 
   const rarityKey = current?.rarity && rarityTone[current.rarity] ? current.rarity : "Common"
   const seasons = (current?.seasons ?? []) as PlantSeason[]
-  const displayImage = React.useMemo(() => {
-    if (!current) return ""
-    const vertical = getVerticalPhotoUrl(current.photos ?? [])
-    return vertical || current.image || ""
-  }, [current])
+  const displayImage = React.useMemo(() => getDiscoveryPageImageUrl(current), [current])
   const shouldPrioritizeImage = Boolean(boostImagePriority && displayImage)
   const highlightBadges = React.useMemo(() => {
     if (!current) return []


### PR DESCRIPTION
Prioritize "discovery" and "primary" tagged images for the Discovery page to ensure the correct images are displayed and preloaded.

The Discovery page previously only used vertical photos or a generic image field, ignoring specific "discovery" or "primary" image tags. This change implements the requested priority order for image selection, using a shared helper function for consistency between display and preloading.

---
<a href="https://cursor.com/background-agent?bcId=bc-e51918af-4861-4dee-b5c1-ce067aeb52a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e51918af-4861-4dee-b5c1-ce067aeb52a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

