### PR TITLE
Optimize main page load speed

### DIFF
--- a/plant-swipe/src/PlantSwipe.tsx
+++ b/plant-swipe/src/PlantSwipe.tsx
@@ -21,7 +21,7 @@ import { AuthActionsProvider } from "@/context/AuthActionsContext";
 import RequireAdmin from "@/pages/RequireAdmin";
 import { supabase } from "@/lib/supabaseClient";
 import { useLanguage } from "@/lib/i18nRouting";
-import { loadPlantsWithTranslations } from "@/lib/plantTranslationLoader";
+import { loadPlantsWithTranslations, loadPlantPreviews } from "@/lib/plantTranslationLoader";
 import { getDiscoveryPageImageUrl } from "@/lib/photos";
 import { isPlantOfTheMonth } from "@/lib/plantHighlights";
 import { formatClassificationLabel } from "@/constants/classification";
@@ -193,7 +193,8 @@ export default function PlantSwipe() {
       // Always use Supabase with translations to ensure plants created in one language
       // display correctly when viewed in another language
       // This ensures translations are properly loaded for all languages, including English
-      const plantsWithTranslations = await loadPlantsWithTranslations(currentLang)
+      // Using optimized preview loader for faster initial render
+      const plantsWithTranslations = await loadPlantPreviews(currentLang)
       setPlants(plantsWithTranslations)
       ok = true
     } catch (e: unknown) {

--- a/plant-swipe/src/lib/plantTranslationLoader.ts
+++ b/plant-swipe/src/lib/plantTranslationLoader.ts
@@ -601,3 +601,194 @@ export async function loadPlantsWithTranslations(language: SupportedLanguage): P
     }
   }
 }
+
+/**
+ * Optimized loader for plant previews (discovery/swipe/search)
+ * Fetches only the fields necessary for listing, filtering, and swipe cards.
+ */
+export async function loadPlantPreviews(language: SupportedLanguage): Promise<Plant[]> {
+  try {
+    const TOP_LIKED_LIMIT = 5
+    
+    const plantColumns = [
+      'id', 'name', 'scientific_name', 'meaning', 'plant_type', 
+      'utility', 'comestible_part', 'fruit_type',
+      'colors', 'season', 'rarity', 'seeds_available',
+      'level_sun', 
+      'water_freq_unit', 'water_freq_value', 'water_freq_period', 'water_freq_amount',
+      'ecology', 'identity', 'usage', 'plant_month',
+      'created_at', 'created_time', 'updated_at', 'updated_time',
+      'plant_images (link,use)',
+      'plant_colors (colors (id,name,hex_code))',
+      'plant_watering_schedules (season,quantity,time_period)',
+      'plant_sources (id,name,url)',
+    ].join(',')
+
+    const [plantsResponse, topLikedResponse] = await Promise.all([
+      supabase
+        .from('plants')
+        .select(plantColumns)
+        .order('name', { ascending: true }),
+      supabase.rpc('top_liked_plants', { limit_count: TOP_LIKED_LIMIT }),
+    ])
+
+    const { data: plants, error } = plantsResponse
+    const { data: topLiked, error: topLikedError } = topLikedResponse
+
+    if (error) throw error
+    if (!plants || plants.length === 0) return []
+
+    if (topLikedError) {
+      console.warn('Failed to load top liked plants', topLikedError)
+    }
+
+    const popularityMap = new Map<string, { likes: number; rank: number }>()
+    if (Array.isArray(topLiked)) {
+      topLiked.forEach((entry, index) => {
+        if (!entry || !entry.plant_id) return
+        const likesNumber = typeof entry.likes === 'number' ? entry.likes : Number(entry.likes ?? 0)
+        popularityMap.set(String(entry.plant_id), {
+          likes: likesNumber,
+          rank: index + 1,
+        })
+      })
+    }
+
+    const plantIds = plants.map((p) => p.id)
+    const translationColumns = [
+      'plant_id', 'language', 
+      'name', 'scientific_name', 'meaning',
+      'identity', 'ecology', 'usage',
+    ].join(',')
+
+    const { data: translations } = await supabase
+      .from('plant_translations')
+      .select(translationColumns)
+      .eq('language', language)
+      .in('plant_id', plantIds)
+
+    const translationMap = new Map<string, any>()
+    if (translations) {
+      translations.forEach((t) => translationMap.set(t.plant_id, t))
+    }
+
+    const toTitleCase = (val: string | null | undefined): string | undefined => {
+      if (!val) return undefined
+      return val.charAt(0).toUpperCase() + val.slice(1)
+    }
+
+    return plants.map((basePlant: any) => {
+      const translation = translationMap.get(basePlant.id) || {}
+      
+      const parseIfNeeded = (val: any) => (typeof val === 'string' ? JSON.parse(val) : val)
+      
+      const identity = parseIfNeeded(basePlant.identity) || {}
+      const transIdentity = parseIfNeeded(translation.identity) || {}
+      const usage = parseIfNeeded(basePlant.usage) || {}
+      const transUsage = parseIfNeeded(translation.usage) || {}
+      const ecology = parseIfNeeded(basePlant.ecology) || {}
+      const transEcology = parseIfNeeded(translation.ecology) || {}
+      
+      const colorObjects = ((basePlant.plant_colors as any[]) || []).map((pc) => ({
+        id: pc?.colors?.id,
+        name: pc?.colors?.name,
+        hexCode: pc?.colors?.hex_code,
+      })).filter((c) => c.name)
+
+      const seasonsRaw = translation.season ?? basePlant.season ?? []
+      const seasons: PlantSeason[] = seasonEnum.toUiArray(seasonsRaw) as PlantSeason[]
+
+      const images: PlantImage[] = ((basePlant.plant_images as any[]) || []).map((img) => ({
+        link: img?.link,
+        use: img?.use,
+      }))
+      const primaryImage = images.find((i) => i.use === 'primary')?.link
+        || images.find((i) => i.use === 'discovery')?.link
+        || images[0]?.link
+
+      const mergedIdentity = {
+        ...identity,
+        ...transIdentity,
+        scientificName: translation.scientific_name || basePlant.scientific_name || identity.scientificName,
+        promotionMonth: monthSlugToNumber(transIdentity.promotion_month || identity.promotionMonth || basePlant.promotion_month) ?? undefined,
+        colors: colorObjects,
+        season: seasons,
+        scent: basePlant.scent ?? identity.scent ?? false,
+      }
+
+      const mergedUsage = {
+        ...usage,
+        ...transUsage,
+        adviceMedicinal: transUsage.adviceMedicinal || usage.adviceMedicinal || basePlant.advice_medicinal,
+        aromatherapy: basePlant.aromatherapy ?? usage.aromatherapy ?? false,
+      }
+      
+      const mergedEcology = {
+        ...ecology,
+        ...transEcology,
+        nativeRange: transEcology.nativeRange || ecology.nativeRange || undefined,
+      }
+
+      const plant: Plant = {
+        id: String(basePlant.id),
+        name: translation.name || basePlant.name || '',
+        scientificName: translation.scientific_name || basePlant.scientific_name || '',
+        meaning: translation.meaning || basePlant.meaning || '',
+        plantType: (plantTypeEnum.toUi(basePlant.plant_type) as Plant["plantType"]) || undefined,
+        utility: utilityEnum.toUiArray(basePlant.utility) as Plant["utility"],
+        comestiblePart: comestiblePartEnum.toUiArray(basePlant.comestible_part) as Plant["comestiblePart"],
+        fruitType: fruitTypeEnum.toUiArray(basePlant.fruit_type) as Plant["fruitType"],
+        
+        images,
+        image: primaryImage,
+        
+        identity: mergedIdentity,
+        usage: mergedUsage,
+        ecology: mergedEcology,
+        
+        plantCare: {
+          levelSun: (levelSunEnum.toUi(basePlant.level_sun) as PlantCareData["levelSun"]) || undefined,
+          watering: {
+            schedules: ((basePlant.plant_watering_schedules as any[]) || []).map((row) => ({
+               season: row?.season ? toTitleCase(row.season) : undefined,
+               quantity: row?.quantity !== null ? Number(row.quantity) : undefined,
+               timePeriod: row?.time_period || undefined,
+            })).filter((e) => e.season || e.quantity !== undefined || e.timePeriod),
+          }
+        },
+        
+        colors: colorObjects.map((c) => c.name as string),
+        seasons,
+        rarity: (basePlant.rarity || 'Common') as Plant['rarity'],
+        seedsAvailable: Boolean(basePlant.seeds_available ?? false),
+        
+        waterFreqUnit: basePlant.water_freq_unit,
+        waterFreqValue: basePlant.water_freq_value,
+        waterFreqPeriod: basePlant.water_freq_period,
+        waterFreqAmount: basePlant.water_freq_amount,
+        
+        popularity: popularityMap.get(String(basePlant.id)),
+        meta: {
+            createdAt: basePlant.created_at || basePlant.created_time,
+            updatedAt: basePlant.updated_at || basePlant.updated_time,
+        },
+        
+        planting: {
+            calendar: {
+                promotionMonth: Array.isArray(basePlant.plant_month) && basePlant.plant_month.length > 0
+                    ? basePlant.plant_month[0]
+                    : undefined
+            }
+        },
+        
+        classification: basePlant.plant_type ? { type: basePlant.plant_type } : undefined,
+      }
+      
+      return sanitizeDeep(plant) as Plant
+    })
+
+  } catch (error) {
+    console.error('Failed to load plant previews:', error)
+    return [] 
+  }
+}


### PR DESCRIPTION
Optimize main page load by fetching only essential plant preview data for initial render.

Previously, the main page fetched the entire plant database, including heavy text fields, which caused significant network delays and blocked the main thread. This change introduces a lightweight data loader (`loadPlantPreviews`) that retrieves only the necessary fields for swipe cards and filters, drastically reducing the initial payload and improving First Contentful Paint.

---
<a href="https://cursor.com/background-agent?bcId=bc-a8696d6e-ac0f-495e-a5a7-4a566dc3145b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a8696d6e-ac0f-495e-a5a7-4a566dc3145b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

