### PR TITLE
Fix unused variables and type errors

### DIFF
--- a/plant-swipe/src/PlantSwipe.tsx
+++ b/plant-swipe/src/PlantSwipe.tsx
@@ -21,7 +21,7 @@ import { AuthActionsProvider } from "@/context/AuthActionsContext";
 import RequireAdmin from "@/pages/RequireAdmin";
 import { supabase } from "@/lib/supabaseClient";
 import { useLanguage } from "@/lib/i18nRouting";
-import { loadPlantsWithTranslations, loadPlantPreviews } from "@/lib/plantTranslationLoader";
+import { loadPlantPreviews } from "@/lib/plantTranslationLoader";
 import { getDiscoveryPageImageUrl } from "@/lib/photos";
 import { isPlantOfTheMonth } from "@/lib/plantHighlights";
 import { formatClassificationLabel } from "@/constants/classification";

--- a/plant-swipe/src/lib/plantTranslationLoader.ts
+++ b/plant-swipe/src/lib/plantTranslationLoader.ts
@@ -632,7 +632,8 @@ export async function loadPlantPreviews(language: SupportedLanguage): Promise<Pl
       supabase.rpc('top_liked_plants', { limit_count: TOP_LIKED_LIMIT }),
     ])
 
-    const { data: plants, error } = plantsResponse
+    const { data: plantsData, error } = plantsResponse
+    const plants = plantsData as any[]
     const { data: topLiked, error: topLikedError } = topLikedResponse
 
     if (error) throw error
@@ -661,11 +662,13 @@ export async function loadPlantPreviews(language: SupportedLanguage): Promise<Pl
       'identity', 'ecology', 'usage',
     ].join(',')
 
-    const { data: translations } = await supabase
+    const { data: translationsData } = await supabase
       .from('plant_translations')
       .select(translationColumns)
       .eq('language', language)
       .in('plant_id', plantIds)
+
+    const translations = translationsData as any[]
 
     const translationMap = new Map<string, any>()
     if (translations) {


### PR DESCRIPTION
Fixes TypeScript errors by removing an unused import and explicitly casting Supabase query results to `any[]`.

---
<a href="https://cursor.com/background-agent?bcId=bc-5c53e5c6-c341-4c9f-bab0-7860c37cd887"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5c53e5c6-c341-4c9f-bab0-7860c37cd887"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

