### PR TITLE
Include blog posts in sitemap generation

### DIFF
--- a/plant-swipe/scripts/generate-sitemap.js
+++ b/plant-swipe/scripts/generate-sitemap.js
@@ -165,31 +165,11 @@ async function detectLanguages(localesDir, fallback) {
 }
 
 async function loadPlantRoutes() {
-  const supabaseUrl =
-    process.env.SUPABASE_URL ||
-    process.env.VITE_SUPABASE_URL ||
-    process.env.REACT_APP_SUPABASE_URL ||
-    process.env.NEXT_PUBLIC_SUPABASE_URL
-
-  const supabaseKey =
-    process.env.SUPABASE_SERVICE_ROLE_KEY ||
-    process.env.SUPABASE_SERVICE_KEY ||
-    process.env.SUPABASE_SERVICE_ROLE ||
-    process.env.SUPABASE_SERVICE_ROLE_TOKEN ||
-    process.env.SUPABASE_ANON_KEY ||
-    process.env.VITE_SUPABASE_ANON_KEY ||
-    process.env.REACT_APP_SUPABASE_ANON_KEY ||
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
-    ''
-
-  if (!supabaseUrl || !supabaseKey) {
+  const client = getSupabaseClient()
+  if (!client) {
     console.warn('[sitemap] Supabase credentials missing — static routes only.')
     return []
   }
-
-  const client = createSupabaseClient(supabaseUrl, supabaseKey, {
-    auth: { persistSession: false, autoRefreshToken: false },
-  })
 
   const maxPlants = positiveInteger(process.env.SITEMAP_MAX_PLANT_URLS, 5000)
   const batchSize = positiveInteger(process.env.SITEMAP_PLANT_BATCH_SIZE, 500)


### PR DESCRIPTION
Add blog posts to the website sitemap generation to ensure all articles are discoverable by search engines.

---
<a href="https://cursor.com/background-agent?bcId=bc-d8f138e6-608a-4c4e-8fc8-c57b2c338593"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d8f138e6-608a-4c4e-8fc8-c57b2c338593"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

