### PR TITLE
Fix unused variables and import errors

### DIFF
--- a/plant-swipe/src/App.tsx
+++ b/plant-swipe/src/App.tsx
@@ -9,7 +9,6 @@ import i18n, { DEFAULT_LANGUAGE, SUPPORTED_LANGUAGES } from '@/lib/i18n'
 import { getLanguageFromPath, getSavedLanguagePreference, detectBrowserLanguage, addLanguagePrefix } from '@/lib/i18nRouting'
 
 function AppShell() {
-  const { loading } = useAuth()
   const location = useLocation()
   const navigate = useNavigate()
   

--- a/plant-swipe/src/PlantSwipe.tsx
+++ b/plant-swipe/src/PlantSwipe.tsx
@@ -1356,7 +1356,7 @@ export default function PlantSwipe() {
               path="/"
               element={plants.length > 0 ? (
                 <Suspense fallback={routeLoadingFallback}>
-                  <SwipePageLazy
+                  <SwipePage
                     current={current}
                     index={index}
                     setIndex={setIndex}


### PR DESCRIPTION
Fix TypeScript errors by removing an unused `loading` variable and correcting a component name from `SwipePageLazy` to `SwipePage`.

---
<a href="https://cursor.com/background-agent?bcId=bc-f98276c4-1eec-4554-bc93-28baf60340e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f98276c4-1eec-4554-bc93-28baf60340e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

