### PR TITLE
Remove unused useAuth import

### DIFF
--- a/plant-swipe/src/App.tsx
+++ b/plant-swipe/src/App.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 const PlantSwipe = React.lazy(() => import("@/PlantSwipe"))
 import ServiceWorkerToast from '@/components/pwa/ServiceWorkerToast'
-import { AuthProvider, useAuth } from '@/context/AuthContext'
+import { AuthProvider } from '@/context/AuthContext'
 import { ThemeProvider } from '@/context/ThemeContext'
 import { BrowserRouter, Routes, Route, useLocation, useNavigate } from 'react-router-dom'
 import { I18nextProvider } from 'react-i18next'


### PR DESCRIPTION
Remove unused `useAuth` import to resolve TS6133 error.

---
<a href="https://cursor.com/background-agent?bcId=bc-f05ac6cd-2c47-474c-9463-e8ba20d4fb8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f05ac6cd-2c47-474c-9463-e8ba20d4fb8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

