### PR TITLE
Remove unused limitPerGarden variable

### DIFF
--- a/plant-swipe/src/lib/gardens.ts
+++ b/plant-swipe/src/lib/gardens.ts
@@ -330,7 +330,7 @@ export async function getGardenMemberCountsBatch(gardenIds: string[]): Promise<R
   return counts
 }
 
-export async function listTasksForMultipleGardensMinimal(gardenIds: string[], limitPerGarden: number = 500): Promise<Record<string, Array<{ id: string; type: TaskType; emoji: string | null; gardenPlantId: string }>>> {
+export async function listTasksForMultipleGardensMinimal(gardenIds: string[], _limitPerGarden: number = 500): Promise<Record<string, Array<{ id: string; type: TaskType; emoji: string | null; gardenPlantId: string }>>> {
   const { valid: safeIds } = normalizeGardenIdList(gardenIds)
   if (safeIds.length === 0) return {}
 


### PR DESCRIPTION
Prefix `limitPerGarden` with an underscore to resolve an unused variable TypeScript error.

---
<a href="https://cursor.com/background-agent?bcId=bc-ff7be9c5-867f-4138-86f1-0f4be228bdd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ff7be9c5-867f-4138-86f1-0f4be228bdd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

