### PR TITLE
Fix plant status donut chart colors

### DIFF
--- a/plant-swipe/src/pages/AdminPage.tsx
+++ b/plant-swipe/src/pages/AdminPage.tsx
@@ -5345,9 +5345,15 @@ export const AdminPage: React.FC = () => {
                                                 startAngle={90}
                                                 endAngle={-270}
                                                 paddingAngle={3}
+                                                isAnimationActive={false}
                                               >
                                                 {plantStatusDonutData.map((slice) => (
-                                                  <Cell key={slice.key} fill={slice.color} />
+                                                  <Cell
+                                                    key={slice.key}
+                                                    fill={slice.color}
+                                                    stroke={isDark ? slice.color : slice.color}
+                                                    strokeWidth={isDark ? 0 : 2}
+                                                  />
                                                 ))}
                                               </Pie>
                                               <Tooltip


### PR DESCRIPTION
Fixes the 'Status repartition' donut chart on `/admin/requests/plants` to display correct colors by applying consistent styling from the Admin Overview chart.

The chart was previously displaying in grey because the `Cell` components within the `PieChart` were missing `stroke` and `strokeWidth` properties, which are crucial for rendering the segment colors correctly across themes. Animation was also disabled for consistency with the working chart.

---
<a href="https://cursor.com/background-agent?bcId=bc-74016804-135a-4ed4-b965-ed4c43cfa54b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-74016804-135a-4ed4-b965-ed4c43cfa54b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

