### PR TITLE
Fix donut graph colors in admin

### DIFF
--- a/plant-swipe/src/components/admin/LazyChart.tsx
+++ b/plant-swipe/src/components/admin/LazyChart.tsx
@@ -40,86 +40,103 @@ const ResponsiveContainerImpl: React.FC<any> = (props) => {
   const charts = useCharts()
   return <charts.ResponsiveContainer {...props} />
 }
+ResponsiveContainerImpl.displayName = 'ResponsiveContainer'
 
 const ComposedChartImpl: React.FC<any> = (props) => {
   const charts = useCharts()
   return <charts.ComposedChart {...props} />
 }
+ComposedChartImpl.displayName = 'ComposedChart'
 
 const LineImpl: React.FC<any> = (props) => {
   const charts = useCharts()
   return <charts.Line {...props} />
 }
+LineImpl.displayName = 'Line'
 
 const AreaImpl: React.FC<any> = (props) => {
   const charts = useCharts()
   return <charts.Area {...props} />
 }
+AreaImpl.displayName = 'Area'
 
 const CartesianGridImpl: React.FC<any> = (props) => {
   const charts = useCharts()
   return <charts.CartesianGrid {...props} />
 }
+CartesianGridImpl.displayName = 'CartesianGrid'
 
 const XAxisImpl: React.FC<any> = (props) => {
   const charts = useCharts()
   return <charts.XAxis {...props} />
 }
+XAxisImpl.displayName = 'XAxis'
 
 const YAxisImpl: React.FC<any> = (props) => {
   const charts = useCharts()
   return <charts.YAxis {...props} />
 }
+YAxisImpl.displayName = 'YAxis'
 
 const TooltipImpl: React.FC<any> = (props) => {
   const charts = useCharts()
   return <charts.Tooltip {...props} />
 }
+TooltipImpl.displayName = 'Tooltip'
 
 const ReferenceLineImpl: React.FC<any> = (props) => {
   const charts = useCharts()
   return <charts.ReferenceLine {...props} />
 }
+ReferenceLineImpl.displayName = 'ReferenceLine'
 
 const PieChartImpl: React.FC<any> = (props) => {
   const charts = useCharts()
   return <charts.PieChart {...props} />
 }
+PieChartImpl.displayName = 'PieChart'
 
 const PieImpl: React.FC<any> = (props) => {
   const charts = useCharts()
   return <charts.Pie {...props} />
 }
+PieImpl.displayName = 'Pie'
 
 const CellImpl: React.FC<any> = (props) => {
   const charts = useCharts()
   return <charts.Cell {...props} />
 }
+CellImpl.displayName = 'Cell'
 
 const BarChartImpl: React.FC<any> = (props) => {
   const charts = useCharts()
   return <charts.BarChart {...props} />
 }
+BarChartImpl.displayName = 'BarChart'
 
 const BarImpl: React.FC<any> = (props) => {
   const charts = useCharts()
   return <charts.Bar {...props} />
 }
+BarImpl.displayName = 'Bar'
 
 const RadialBarChartImpl: React.FC<any> = (props) => {
   const charts = useCharts()
   return <charts.RadialBarChart {...props} />
 }
+RadialBarChartImpl.displayName = 'RadialBarChart'
 
 const RadialBarImpl: React.FC<any> = (props) => {
   const charts = useCharts()
   return <charts.RadialBar {...props} />
 }
+RadialBarImpl.displayName = 'RadialBar'
 
 const PolarAngleAxisImpl: React.FC<any> = (props) => {
   const charts = useCharts()
   return <charts.PolarAngleAxis {...props} />
 }
+PolarAngleAxisImpl.displayName = 'PolarAngleAxis'
 
 // Export chart components wrapped in provider
 export const LazyCharts = {


### PR DESCRIPTION
Add `displayName` to `LazyCharts` wrapper components to fix the grey "Status Repartition" donut graph by allowing Recharts to correctly apply custom colors.

Recharts relies on `child.type.displayName` to identify its configuration components (like `Cell` for colors). The `LazyCharts` wrappers were missing this property, causing Recharts to ignore the `Cell` components that defined the custom status colors, resulting in the graph defaulting to grey. Adding `displayName` ensures these components are correctly recognized and their color properties are applied.

---
<a href="https://cursor.com/background-agent?bcId=bc-7b2e2f66-5655-489f-b469-46c393159e99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7b2e2f66-5655-489f-b469-46c393159e99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

