### PR TITLE
Fix timezone notification system

### DIFF
--- a/plant-swipe/server.js
+++ b/plant-swipe/server.js
@@ -3302,6 +3302,10 @@ async function ensureBroadcastTable() {
 }
 
 let notificationTablesEnsured = false
+
+// Default timezone for notifications and users - MUST be defined before notification API routes
+const DEFAULT_TIMEZONE = 'Europe/London'
+
 async function ensureNotificationTables() {
   if (!sql) return
   if (notificationTablesEnsured) return
@@ -9588,9 +9592,6 @@ function toStringArray(value) {
 function toUuidArray(value) {
   return toStringArray(value)
 }
-
-// Default timezone for users and campaigns
-const DEFAULT_TIMEZONE = 'Europe/London'
 
 function normalizeNotificationCampaign(row) {
   if (!row) return null

--- a/plant-swipe/src/components/admin/AdminNotificationsPanel.tsx
+++ b/plant-swipe/src/components/admin/AdminNotificationsPanel.tsx
@@ -92,6 +92,9 @@ type FormState = {
   customUserIds: string
 }
 
+// Default timezone for notification campaigns - must be defined before defaultFormState
+const DEFAULT_TIMEZONE = 'Europe/London'
+
 const defaultFormState = (): FormState => ({
   title: '',
   description: '',
@@ -111,9 +114,6 @@ const defaultFormState = (): FormState => ({
 const TEMPLATE_VARIABLES = [
   { variable: '{{user}}', description: 'User display name' },
 ]
-
-// Default timezone for notification campaigns
-const DEFAULT_TIMEZONE = 'Europe/London'
 
 function isoToInputValue(value?: string | null): string {
   if (!value) return ''


### PR DESCRIPTION
Fix notification system by moving `DEFAULT_TIMEZONE` constant definitions to before their first use, resolving 'Cannot access before initialization' errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-069f42e8-e660-46e0-9a5b-4b904306c6c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-069f42e8-e660-46e0-9a5b-4b904306c6c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

