### PR TITLE
Prepare for new plant types

### DIFF
--- a/plant-swipe/public/locales/en/common.json
+++ b/plant-swipe/public/locales/en/common.json
@@ -463,6 +463,8 @@
         "bambu": "Bamboo",
         "shrub": "Shrub",
         "tree": "Tree",
+        "cactus": "Cactus",
+        "succulent": "Succulent",
         "other": "Other"
       },
       "utility": {
@@ -1169,7 +1171,9 @@
           "flower": "Flower",
           "bamboo": "Bamboo",
           "shrub": "Shrub",
-          "tree": "Tree"
+          "tree": "Tree",
+          "cactus": "Cactus",
+          "succulent": "Succulent"
         },
         "utility": {
           "comestible": "Edible",

--- a/plant-swipe/public/locales/fr/common.json
+++ b/plant-swipe/public/locales/fr/common.json
@@ -463,6 +463,8 @@
         "bambu": "Bambou",
         "shrub": "Arbuste",
         "tree": "Arbre",
+        "cactus": "Cactus",
+        "succulent": "Plante grasse",
         "other": "Autre"
       },
       "utility": {
@@ -1169,7 +1171,9 @@
           "flower": "Fleur",
           "bamboo": "Bambou",
           "shrub": "Arbuste",
-          "tree": "Arbre"
+          "tree": "Arbre",
+          "cactus": "Cactus",
+          "succulent": "Plante grasse"
         },
         "utility": {
           "comestible": "Comestible",

--- a/plant-swipe/src/components/plant/PlantProfileForm.tsx
+++ b/plant-swipe/src/components/plant/PlantProfileForm.tsx
@@ -522,7 +522,7 @@ const metaFields: FieldConfig[] = [
 const utilityOptions = ["comestible","ornemental","produce_fruit","aromatic","medicinal","odorous","climbing","cereal","spice"] as const
 const comestibleOptions = ["flower","fruit","seed","leaf","stem","root","bulb","bark","wood"] as const
 const fruitOptions = ["nut","seed","stone"] as const
-const plantTypeOptions = ["plant","flower","bamboo","shrub","tree"] as const
+const plantTypeOptions = ["plant","flower","bamboo","shrub","tree","cactus","succulent"] as const
 
 function renderField(plant: Plant, onChange: (path: string, value: any) => void, field: FieldConfig, t: TFunction<'common'>) {
     const value = getValue(plant, field.key)

--- a/plant-swipe/src/constants/classification.ts
+++ b/plant-swipe/src/constants/classification.ts
@@ -7,13 +7,15 @@ import type {
   PlantTypeValue,
 } from "@/types/plant"
 
-export const PLANT_TYPE_OPTIONS: PlantTypeValue[] = ["plant", "bambu", "shrub", "tree", "other"]
+export const PLANT_TYPE_OPTIONS: PlantTypeValue[] = ["plant", "bambu", "shrub", "tree", "cactus", "succulent", "other"]
 
 export const PLANT_SUBCLASS_OPTIONS: Record<PlantTypeValue, PlantSubclassValue[]> = {
   plant: ["flower", "vegetable", "cereal", "spice"],
   bambu: [],
   shrub: [],
   tree: [],
+  cactus: [],
+  succulent: [],
   other: [],
 }
 

--- a/plant-swipe/src/lib/aiFieldPrompts.json
+++ b/plant-swipe/src/lib/aiFieldPrompts.json
@@ -1,7 +1,7 @@
 {
   "plantType": [
     "Classify {{plantName}} by its dominant growth habit or planting form.",
-    "Return a single lowercase string chosen from: \"plant\", \"flower\", \"bamboo\", \"shrub\", \"tree\"."
+    "Return a single lowercase string chosen from: \"plant\", \"flower\", \"bamboo\", \"shrub\", \"tree\", \"cactus\", \"succulent\"."
   ],
   "utility": [
     "List every practical or ornamental role {{plantName}} is commonly grown for.",

--- a/plant-swipe/src/lib/composition.ts
+++ b/plant-swipe/src/lib/composition.ts
@@ -203,6 +203,8 @@ export const plantTypeEnum = createEnumTools([
   { dbValue: 'bamboo', uiValue: 'bamboo' },
   { dbValue: 'shrub', uiValue: 'shrub' },
   { dbValue: 'tree', uiValue: 'tree' },
+  { dbValue: 'cactus', uiValue: 'cactus' },
+  { dbValue: 'succulent', uiValue: 'succulent' },
 ])
 
 export const utilityEnum = createEnumTools([

--- a/plant-swipe/src/types/plant.ts
+++ b/plant-swipe/src/types/plant.ts
@@ -1,5 +1,5 @@
-export type PlantType = "plant" | "flower" | "bamboo" | "shrub" | "tree"
-export type PlantTypeValue = "plant" | "bambu" | "shrub" | "tree" | "other"
+export type PlantType = "plant" | "flower" | "bamboo" | "shrub" | "tree" | "cactus" | "succulent"
+export type PlantTypeValue = "plant" | "bambu" | "shrub" | "tree" | "cactus" | "succulent" | "other"
 export type PlantSubclassValue = "flower" | "vegetable" | "cereal" | "spice"
 export type PlantSubSubclassValue = "fruit" | "seed" | "root" | "leaf" | "flower"
 export type PlantActivityValue = "ornemental" | "comestible" | "aromatic" | "medicinal"

--- a/plant-swipe/supabase/000_sync_schema.sql
+++ b/plant-swipe/supabase/000_sync_schema.sql
@@ -278,7 +278,7 @@ create table if not exists public.plants (
   id text primary key,
   -- Plant primary name (unique)
   name text not null,
-  plant_type text check (plant_type in ('plant','flower','bamboo','shrub','tree')),
+  plant_type text check (plant_type in ('plant','flower','bamboo','shrub','tree','cactus','succulent')),
   utility text[] not null default '{}'::text[] check (utility <@ array['comestible','ornemental','produce_fruit','aromatic','medicinal','odorous','climbing','cereal','spice']),
   comestible_part text[] not null default '{}'::text[] check (comestible_part <@ array['flower','fruit','seed','leaf','stem','root','bulb','bark','wood']),
   fruit_type text[] not null default '{}'::text[] check (fruit_type <@ array['nut','seed','stone']),
@@ -377,7 +377,7 @@ alter table if exists public.plants alter column status set default 'in progres'
 update public.plants set status = 'in progres' where status is null;
 
 -- Backfill all plant attribute columns on existing deployments
-alter table if exists public.plants add column if not exists plant_type text check (plant_type in ('plant','flower','bamboo','shrub','tree'));
+alter table if exists public.plants add column if not exists plant_type text check (plant_type in ('plant','flower','bamboo','shrub','tree','cactus','succulent'));
 alter table if exists public.plants add column if not exists utility text[] not null default '{}'::text[] check (utility <@ array['comestible','ornemental','produce_fruit','aromatic','medicinal','odorous','climbing','cereal','spice']);
 alter table if exists public.plants add column if not exists comestible_part text[] not null default '{}'::text[] check (comestible_part <@ array['flower','fruit','seed','leaf','stem','root','bulb','bark','wood']);
 alter table if exists public.plants add column if not exists fruit_type text[] not null default '{}'::text[] check (fruit_type <@ array['nut','seed','stone']);


### PR DESCRIPTION
Add "cactus" and "succulent" plant types to the application to support new plant classifications.

This PR updates TypeScript types, classification constants, UI forms, database schema, English and French translations, and AI field prompts to fully integrate the new plant types. A database migration is required to update the `plant_type` CHECK constraint.

---
<a href="https://cursor.com/background-agent?bcId=bc-34241f83-7f38-4e46-985f-f7081ace4a25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-34241f83-7f38-4e46-985f-f7081ace4a25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

