### PR TITLE
Debug user profile loading errors

### DIFF
--- a/plant-swipe/src/pages/PublicProfilePage.tsx
+++ b/plant-swipe/src/pages/PublicProfilePage.tsx
@@ -415,8 +415,13 @@ export default function PublicProfilePage() {
       }
 
       const fetchViaApi = async () => {
+        const session = (await supabase.auth.getSession()).data.session
+        const token = session?.access_token
+        if (!token) return null
+        const headers: Record<string, string> = { Accept: 'application/json' }
+        headers['Authorization'] = `Bearer ${token}`
         const resp = await fetch(`/api/users/${targetId}/private`, {
-          headers: { Accept: 'application/json' },
+          headers,
           credentials: 'same-origin',
         })
         if (!resp.ok) return null


### PR DESCRIPTION
Add Authorization header to `/api/users/:id/private` API call to fix 401 Unauthorized errors on profile pages and prevent RPC fallback.

The client-side `fetchViaApi` function was not including the necessary Bearer token in the `Authorization` header when requesting private user data, leading to a 401 response from the server and a subsequent, slower RPC call. This change ensures the token is sent, allowing the API call to succeed.

---
<a href="https://cursor.com/background-agent?bcId=bc-eca5cfe0-fe11-4253-aca3-fd7f16135ec2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-eca5cfe0-fe11-4253-aca3-fd7f16135ec2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

