### PR TITLE
Fix nginx config and setup script

### DIFF
--- a/plant-swipe.conf
+++ b/plant-swipe.conf
@@ -1,4 +1,6 @@
 # Media CDN - Reverse proxy to Supabase storage (no caching, passthrough only)
+# This block is conditionally included by setup.sh if media.aphylia.app is in domain.json
+# __MEDIA_SERVER_BLOCK_START__
 server {
     listen 80;
     listen [::]:80;
@@ -6,8 +8,8 @@ server {
     listen [::]:443 ssl;
     server_name media.aphylia.app;
 
-    ssl_certificate /etc/letsencrypt/live/dev01.aphylia.app/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/dev01.aphylia.app/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/__PRIMARY_DOMAIN__/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/__PRIMARY_DOMAIN__/privkey.pem;
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_ciphers HIGH:!aNULL:!MD5;
     ssl_prefer_server_ciphers on;
@@ -31,6 +33,7 @@ server {
         proxy_send_timeout 60s;
     }
 }
+# __MEDIA_SERVER_BLOCK_END__
 
 # Main application server
 server {
@@ -40,8 +43,8 @@ server {
     listen [::]:443 ssl;
     server_name aphylia.app *.aphylia.app;
     client_max_body_size 15M;
-    ssl_certificate /etc/letsencrypt/live/dev01.aphylia.app/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/dev01.aphylia.app/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/__PRIMARY_DOMAIN__/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/__PRIMARY_DOMAIN__/privkey.pem;
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_ciphers HIGH:!aNULL:!MD5;
     ssl_prefer_server_ciphers on;


### PR DESCRIPTION
Fix Nginx configuration to dynamically use server-specific SSL certificates and conditionally include the media server block based on `domain.json`.

The previous Nginx configuration hardcoded SSL certificate paths to `dev01.aphylia.app`, causing failures on other servers. This PR updates `setup.sh` to dynamically determine the primary domain for SSL certificates and modifies `plant-swipe.conf` to use a placeholder. It also ensures the `media.aphylia.app` server block is only included if `media.aphylia.app` is present in the `domain.json` file.

---
<a href="https://cursor.com/background-agent?bcId=bc-19da3609-d267-405b-b9b6-09addf447146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-19da3609-d267-405b-b9b6-09addf447146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

