### PR TITLE
Fix unresponsive login after logout

### DIFF
--- a/plant-swipe/src/PlantSwipe.tsx
+++ b/plant-swipe/src/PlantSwipe.tsx
@@ -756,6 +756,8 @@ export default function PlantSwipe() {
         }
         console.log('[auth] login ok')
       }
+      // Reset submitting state before closing dialog
+      setAuthSubmitting(false)
       setAuthOpen(false)
     } catch (e: unknown) {
       console.error('[auth] unexpected error', e)
@@ -772,9 +774,16 @@ export default function PlantSwipe() {
     }
   }, [user])
 
+  // Reset form state when dialog closes
   React.useEffect(() => {
     if (!authOpen) {
       setAuthAcceptedTerms(false)
+      setAuthSubmitting(false)
+      setAuthError(null)
+      setAuthEmail("")
+      setAuthPassword("")
+      setAuthPassword2("")
+      setAuthDisplayName("")
     }
   }, [authOpen])
 


### PR DESCRIPTION
Reset `authSubmitting` state and other form fields to fix login inputs remaining disabled after logout.

The `authSubmitting` state was not being reset after a successful login, causing the input fields to remain disabled when the user logged out and tried to log in again. This PR ensures the state is reset on successful authentication and when the auth dialog closes.

---
<a href="https://cursor.com/background-agent?bcId=bc-b6587d55-485f-4aff-80ab-8e4bb4db5f3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b6587d55-485f-4aff-80ab-8e4bb4db5f3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

