### PR TITLE
Fix admin page branch and overview data

### DIFF
--- a/plant-swipe/server.js
+++ b/plant-swipe/server.js
@@ -2605,7 +2605,7 @@ const supabaseAdmin = null
 // ADMIN STATS CACHE - Background refresh for instant responses
 // ============================================================================
 const adminStatsCache = {
-  stats: { profilesCount: 0, authUsersCount: null, plantsCount: null },
+  stats: { profilesCount: 0, authUsersCount: null, plantsCount: 0 },
   visitors: { currentUniqueVisitors10m: 0, uniqueIpsLast30m: 0, uniqueIpsLast60m: 0, visitsLast60m: 0, uniqueIps7d: 0, series7d: [] },
   sources: { topCountries: [], otherCountries: {}, topReferrers: [], otherReferrers: {} },
   onlineUsers: { count: 0 },
@@ -2622,7 +2622,7 @@ async function refreshStatsCache() {
   adminStatsCache.refreshing.stats = true
   const REFRESH_TIMEOUT = 5000 // 5 second timeout for background refresh
   try {
-    let profilesCount = 0, authUsersCount = null, plantsCount = null
+    let profilesCount = 0, authUsersCount = null, plantsCount = 0
     
     // Try direct SQL first
     if (sql) {
@@ -6503,7 +6503,7 @@ app.post('/api/send-automatic-email', async (req, res) => {
   
   // Cache is stale/empty - do a quick fetch with short timeout
   try {
-    let profilesCount = 0, authUsersCount = null, plantsCount = null
+    let profilesCount = 0, authUsersCount = null, plantsCount = 0
     if (sql) {
       const [p, a, pl] = await Promise.all([
         withTimeout(sql`select count(*)::int as count from public.profiles`, 1500, 'PROFILES_TIMEOUT').catch(() => []),

--- a/plant-swipe/src/pages/AdminPage.tsx
+++ b/plant-swipe/src/pages/AdminPage.tsx
@@ -2175,16 +2175,14 @@ export const AdminPage: React.FC = () => {
       } catch (e) {
         console.error("[AdminPage] Failed to load branches:", e);
         // Don't clear existing data on error - keep what we have
-        // Only clear on initial load if we have no data yet
-        if (isInitial && branchOptions.length === 0) {
-          // Only clear if we truly have no data
-        }
       } finally {
         if (isInitial) setBranchesLoading(false);
         else setBranchesRefreshing(false);
       }
     },
-    [safeJson, fetchWithRetry, branchOptions.length],
+    // Note: intentionally omitting branchOptions from deps to avoid re-triggering on data change
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [safeJson, fetchWithRetry],
   );
 
   React.useEffect(() => {


### PR DESCRIPTION
Fixes Admin page issues by preventing branches from loading twice and ensuring overview data displays correctly.

The `loadBranches` function in `AdminPage.tsx` was re-triggering due to `branchOptions.length` being in its dependency array, causing a double load. Removing it ensures the function runs only once on mount.

The `plantsCount` in `server.js` was initialized to `null` instead of `0`. This caused the client-side check `typeof data?.plantsCount === "number"` to fail, resulting in overview data (like total plants) displaying "-" instead of the actual count. Initializing it to `0` resolves this display issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-5054f077-2b2c-44ba-8ff8-eb3bb6c746f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5054f077-2b2c-44ba-8ff8-eb3bb6c746f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

