### PR TITLE
Fix function return type error during sync

### DIFF
--- a/plant-swipe/supabase/000_sync_schema.sql
+++ b/plant-swipe/supabase/000_sync_schema.sql
@@ -22,6 +22,7 @@ drop policy if exists "Service role only" on public.admin_secrets;
 create policy "Service role only" on public.admin_secrets for all using (false);
 
 -- ========== Helper: Invoke Edge Function ==========
+drop function if exists public.invoke_edge_function(text, jsonb);
 create or replace function public.invoke_edge_function(
   function_name text,
   payload jsonb default '{}'::jsonb


### PR DESCRIPTION
Add `DROP FUNCTION IF EXISTS` for `invoke_edge_function` to resolve `cannot change return type` errors during schema sync.

---
<a href="https://cursor.com/background-agent?bcId=bc-4d1babd7-2c86-4990-8e71-52532ef69b2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4d1babd7-2c86-4990-8e71-52532ef69b2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

