### PR TITLE
Add share button to public pages

### DIFF
--- a/plant-swipe/public/locales/en/common.json
+++ b/plant-swipe/public/locales/en/common.json
@@ -40,7 +40,8 @@
       "blog": "Blog",
       "contactUs": "Contact Us",
       "termsOfServices": "Terms of Services"
-    }
+    },
+    "share": "Share"
   },
   "pricing": {
     "pageTitle": "Pricing – Aphylia",

--- a/plant-swipe/public/locales/fr/common.json
+++ b/plant-swipe/public/locales/fr/common.json
@@ -40,7 +40,8 @@
       "blog": "Blog",
       "contactUs": "Nous contacter",
       "termsOfServices": "Conditions d'utilisation"
-    }
+    },
+    "share": "Partager"
   },
   "pricing": {
     "pageTitle": "Tarifs – Aphylia",


### PR DESCRIPTION
Add share buttons to public profile and garden overview pages to enable users to easily share page URLs.

---
<a href="https://cursor.com/background-agent?bcId=bc-7af10693-d098-438b-b36c-f86a1ee8bb42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7af10693-d098-438b-b36c-f86a1ee8bb42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

