### PR TITLE
Clean up unused gardens and ensure permanent deletion

### DIFF
--- a/plant-swipe/src/lib/gardens.ts
+++ b/plant-swipe/src/lib/gardens.ts
@@ -756,6 +756,19 @@ export async function addMemberByNameOrEmail(params: { gardenId: string; input: 
 
 // Legacy watering schedule helpers removed
 
+/**
+ * Delete a garden and all its associated data.
+ * All child tables (garden_members, garden_plants, garden_tasks, etc.) will be
+ * cascade-deleted by the database.
+ */
+export async function deleteGarden(gardenId: string): Promise<void> {
+  const { error } = await supabase
+    .from('gardens')
+    .delete()
+    .eq('id', gardenId)
+  if (error) throw new Error(error.message)
+}
+
 export async function deleteGardenPlant(gardenPlantId: string): Promise<void> {
   const { error } = await supabase
     .from('garden_plants')

--- a/plant-swipe/src/pages/GardenDashboardPage.tsx
+++ b/plant-swipe/src/pages/GardenDashboardPage.tsx
@@ -37,6 +37,7 @@ import {
   getGardenPlants,
   getGardenMembers,
   addMemberByNameOrEmail,
+  deleteGarden,
   deleteGardenPlant,
   addPlantToGarden,
   fetchServerNowISO,
@@ -2952,10 +2953,7 @@ export const GardenDashboardPage: React.FC = () => {
                             )
                               return;
                             try {
-                              await supabase
-                                .from("gardens")
-                                .delete()
-                                .eq("id", id);
+                              await deleteGarden(id);
                               navigate("/gardens");
                             } catch (e) {
                               alert(


### PR DESCRIPTION
Enhance account deletion to permanently remove all user-associated gardens and refactor garden deletion into a shared helper.

Previously, account deletion only removed gardens where the user was an owner, potentially leaving gardens created by the user but without ownership orphaned. This change addresses that edge case and adds a general cleanup for any gardens without members to ensure complete data removal.

---
<a href="https://cursor.com/background-agent?bcId=bc-5873d489-27ce-442e-ad2a-8fff6fc83b9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5873d489-27ce-442e-ad2a-8fff6fc83b9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

