### PR TITLE
Update plant status on garden page

### DIFF
--- a/plant-swipe/server.js
+++ b/plant-swipe/server.js
@@ -10305,7 +10305,7 @@ app.get('/api/garden/:id/overview', async (req, res) => {
       }
 
       // Garden plants
-      const gpUrl = `${supabaseUrlEnv}/rest/v1/garden_plants?garden_id=eq.${encodeURIComponent(gardenId)}&select=id,garden_id,plant_id,nickname,seeds_planted,planted_at,expected_bloom_date,override_water_freq_unit,override_water_freq_value,plants_on_hand,sort_index`
+      const gpUrl = `${supabaseUrlEnv}/rest/v1/garden_plants?garden_id=eq.${encodeURIComponent(gardenId)}&select=id,garden_id,plant_id,nickname,seeds_planted,planted_at,expected_bloom_date,override_water_freq_unit,override_water_freq_value,plants_on_hand,sort_index,health_status,notes,last_health_update`
       const gpResp = await fetch(gpUrl, { headers })
       let gpRows = []
       if (gpResp.ok) gpRows = await gpResp.json().catch(() => [])
@@ -10351,6 +10351,9 @@ app.get('/api/garden/:id/overview', async (req, res) => {
         overrideWaterFreqValue: (r.override_water_freq_value ?? null),
         plantsOnHand: Number(r.plants_on_hand || 0),
         sortIndex: (r.sort_index ?? null),
+        healthStatus: r.health_status || null,
+        notes: r.notes || null,
+        lastHealthUpdate: r.last_health_update || null,
         plant: plantsMap[String(r.plant_id)] || null,
       }))
 


### PR DESCRIPTION
Enable users to view and update plant health status in the garden plant edit dialog.

The plant edit dialog now displays the current health status, allows users to select a new status, and logs status changes to the garden activity feed, ensuring the database is updated and providing better visibility into plant health.

---
<a href="https://cursor.com/background-agent?bcId=bc-afc241c9-6f17-4950-857d-123fc87b5c59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-afc241c9-6f17-4950-857d-123fc87b5c59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

