### PR TITLE
Remove unused normalizeUsername variable

### DIFF
--- a/plant-swipe/src/context/AuthContext.tsx
+++ b/plant-swipe/src/context/AuthContext.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { supabase, type ProfileRow } from '@/lib/supabaseClient'
 import { applyAccentByKey } from '@/lib/accent'
-import { validateUsername, normalizeUsername } from '@/lib/username'
+import { validateUsername } from '@/lib/username'
 
 // Default timezone for users who haven't set one
 const DEFAULT_TIMEZONE = 'Europe/London'


### PR DESCRIPTION
Remove unused `normalizeUsername` import to fix TypeScript error TS6133.

---
<a href="https://cursor.com/background-agent?bcId=bc-22d09b58-1e05-4778-a355-176fcf687f9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-22d09b58-1e05-4778-a355-176fcf687f9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

