### PR TITLE
Fix link preview display

### DIFF
--- a/plant-swipe/index.html
+++ b/plant-swipe/index.html
@@ -6,6 +6,24 @@
       <meta name="application-name" content="Aphylia" />
       <meta name="description" content="Discover, swipe and manage the perfect plants for every garden." />
       <meta name="theme-color" content="#052e16" />
+      
+      <!-- Open Graph / Facebook -->
+      <meta property="og:type" content="website" />
+      <meta property="og:site_name" content="Aphylia" />
+      <meta property="og:url" content="https://aphylia.app" />
+      <meta property="og:title" content="Aphylia - Discover & Grow Your Perfect Garden" />
+      <meta property="og:description" content="Discover, swipe and manage the perfect plants for every garden. Track growth, get care reminders, and build your dream garden." />
+      <meta property="og:image" content="https://aphylia.app/icons/icon-512x512.png" />
+      <meta property="og:image:width" content="512" />
+      <meta property="og:image:height" content="512" />
+      <meta property="og:image:alt" content="Aphylia - Plant Discovery App" />
+      
+      <!-- Twitter Card -->
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:url" content="https://aphylia.app" />
+      <meta name="twitter:title" content="Aphylia - Discover & Grow Your Perfect Garden" />
+      <meta name="twitter:description" content="Discover, swipe and manage the perfect plants for every garden. Track growth, get care reminders, and build your dream garden." />
+      <meta name="twitter:image" content="https://aphylia.app/icons/icon-512x512.png" />
       <meta name="apple-mobile-web-app-capable" content="yes" />
       <meta name="mobile-web-app-capable" content="yes" />
       <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />

--- a/plant-swipe/server.js
+++ b/plant-swipe/server.js
@@ -15295,6 +15295,19 @@ async function generateCrawlerHtml(req, pagePath) {
   const siteUrl = process.env.PLANTSWIPE_SITE_URL || process.env.SITE_URL || 'https://aphylia.app'
   const canonicalUrl = `${siteUrl.replace(/\/+$/, '')}${pagePath}`
   
+  // Helper to ensure image URLs are absolute (required for og:image)
+  const ensureAbsoluteUrl = (url) => {
+    if (!url) return null
+    // Already absolute
+    if (url.startsWith('http://') || url.startsWith('https://')) return url
+    // Protocol-relative URL
+    if (url.startsWith('//')) return `https:${url}`
+    // Relative URL - prepend site URL
+    if (url.startsWith('/')) return `${siteUrl.replace(/\/+$/, '')}${url}`
+    // No leading slash - treat as relative
+    return `${siteUrl.replace(/\/+$/, '')}/${url}`
+  }
+  
   // Default meta tags
   let title = 'Aphylia - Discover, Swipe and Manage Plants for Your Garden'
   let description = 'Discover, swipe and manage the perfect plants for every garden. Track growth, get care reminders, and build your dream garden.'
@@ -15756,11 +15769,11 @@ async function generateCrawlerHtml(req, pagePath) {
           const anyImg = images?.[0]
           
           if (primaryImg?.link) {
-            image = primaryImg.link
+            image = ensureAbsoluteUrl(primaryImg.link) || image
           } else if (discoveryImg?.link) {
-            image = discoveryImg.link
+            image = ensureAbsoluteUrl(discoveryImg.link) || image
           } else if (anyImg?.link) {
-            image = anyImg.link
+            image = ensureAbsoluteUrl(anyImg.link) || image
           }
           
           // Build structured content for the page
@@ -15847,7 +15860,7 @@ async function generateCrawlerHtml(req, pagePath) {
         
         description = descParts.join(' • ')
         
-        if (post.cover_image_url) image = post.cover_image_url
+        if (post.cover_image_url) image = ensureAbsoluteUrl(post.cover_image_url) || image
         
         // Use locale-specific date format
         const dateLocales = { en: 'en-US', fr: 'fr-FR', es: 'es-ES', de: 'de-DE', it: 'it-IT', pt: 'pt-BR', nl: 'nl-NL', pl: 'pl-PL', ru: 'ru-RU', ja: 'ja-JP', ko: 'ko-KR', zh: 'zh-CN' }
@@ -15937,7 +15950,7 @@ async function generateCrawlerHtml(req, pagePath) {
         
         description = descParts.join(' • ')
         
-        if (profile.avatar_url) image = profile.avatar_url
+        if (profile.avatar_url) image = ensureAbsoluteUrl(profile.avatar_url) || image
         
         pageContent = `
           <article itemscope itemtype="https://schema.org/Person">
@@ -15986,7 +15999,7 @@ async function generateCrawlerHtml(req, pagePath) {
               .maybeSingle()
             if (owner) {
               ownerName = owner.display_name
-              if (owner.avatar_url) gardenImage = owner.avatar_url
+              if (owner.avatar_url) gardenImage = ensureAbsoluteUrl(owner.avatar_url)
             }
           }
           
@@ -16010,7 +16023,7 @@ async function generateCrawlerHtml(req, pagePath) {
               .eq('plant_id', gardenPlants[0].plant_id)
               .eq('use', 'primary')
               .maybeSingle()
-            if (plantImg?.link) gardenImage = plantImg.link
+            if (plantImg?.link) gardenImage = ensureAbsoluteUrl(plantImg.link)
           }
         } catch {}
         
@@ -16118,7 +16131,7 @@ async function generateCrawlerHtml(req, pagePath) {
         if (posts?.length) {
           // Use the most recent post's cover image
           const latestWithImage = posts.find(p => p.cover_image_url)
-          if (latestWithImage) image = latestWithImage.cover_image_url
+          if (latestWithImage) image = ensureAbsoluteUrl(latestWithImage.cover_image_url) || image
           
           pageContent = `
             <article>
@@ -16339,7 +16352,7 @@ async function generateCrawlerHtml(req, pagePath) {
               .eq('plant_id', listPlants[0].plant_id)
               .eq('use', 'primary')
               .maybeSingle()
-            if (plantImg?.link) listImage = plantImg.link
+            if (plantImg?.link) listImage = ensureAbsoluteUrl(plantImg.link)
           }
         } catch {}
         

--- a/plant-swipe/src/constants/seo.ts
+++ b/plant-swipe/src/constants/seo.ts
@@ -1,4 +1,6 @@
 export const SEO_DEFAULT_TITLE = 'Aphylia'
 export const SEO_TITLE_SEPARATOR = ' · '
 export const SEO_DEFAULT_DESCRIPTION = 'Discover, swipe and manage the perfect plants for every garden.'
+export const SEO_DEFAULT_IMAGE = 'https://aphylia.app/icons/icon-512x512.png'
+export const SEO_DEFAULT_URL = 'https://aphylia.app'
 export const SEO_MAX_DESCRIPTION_LENGTH = 320

--- a/plant-swipe/src/hooks/usePageMetadata.ts
+++ b/plant-swipe/src/hooks/usePageMetadata.ts
@@ -2,6 +2,8 @@ import React from 'react'
 import {
   SEO_DEFAULT_DESCRIPTION,
   SEO_DEFAULT_TITLE,
+  SEO_DEFAULT_IMAGE,
+  SEO_DEFAULT_URL,
   SEO_MAX_DESCRIPTION_LENGTH,
   SEO_TITLE_SEPARATOR,
 } from '@/constants/seo'
@@ -22,6 +24,16 @@ const TITLE_TARGETS: MetaTarget[] = [
   { attr: 'name', key: 'twitter:title' },
 ]
 
+const IMAGE_TARGETS: MetaTarget[] = [
+  { attr: 'property', key: 'og:image' },
+  { attr: 'name', key: 'twitter:image' },
+]
+
+const URL_TARGETS: MetaTarget[] = [
+  { attr: 'property', key: 'og:url' },
+  { attr: 'name', key: 'twitter:url' },
+]
+
 const collapseWhitespace = (value?: string | null) => {
   if (!value) return ''
   return value.replace(/\s+/g, ' ').trim()
@@ -39,6 +51,23 @@ const normalizeTitle = (value?: string | null) => {
   if (!trimmed) return SEO_DEFAULT_TITLE
   if (trimmed.includes(SEO_DEFAULT_TITLE)) return trimmed
   return `${trimmed}${SEO_TITLE_SEPARATOR}${SEO_DEFAULT_TITLE}`
+}
+
+const normalizeImage = (value?: string | null) => {
+  if (!value) return SEO_DEFAULT_IMAGE
+  // Ensure the image URL is absolute
+  if (value.startsWith('http://') || value.startsWith('https://')) return value
+  if (value.startsWith('//')) return `https:${value}`
+  if (value.startsWith('/')) return `${SEO_DEFAULT_URL}${value}`
+  return `${SEO_DEFAULT_URL}/${value}`
+}
+
+const normalizeUrl = (value?: string | null) => {
+  if (!value) return SEO_DEFAULT_URL
+  // Ensure the URL is absolute
+  if (value.startsWith('http://') || value.startsWith('https://')) return value
+  if (value.startsWith('/')) return `${SEO_DEFAULT_URL}${value}`
+  return `${SEO_DEFAULT_URL}/${value}`
 }
 
 const ensureMetaElement = (target: MetaTarget) => {
@@ -72,14 +101,18 @@ type Snapshot = {
 export type PageMetadata = {
   title?: string | null
   description?: string | null
+  image?: string | null
+  url?: string | null
 }
 
-export function usePageMetadata({ title, description }: PageMetadata) {
+export function usePageMetadata({ title, description, image, url }: PageMetadata) {
   React.useEffect(() => {
     if (typeof document === 'undefined') return
 
     const resolvedTitle = normalizeTitle(title)
     const resolvedDescription = normalizeDescription(description)
+    const resolvedImage = normalizeImage(image)
+    const resolvedUrl = normalizeUrl(url)
     const previousTitle = document.title
     const snapshots = new Map<string, Snapshot>()
 
@@ -103,6 +136,8 @@ export function usePageMetadata({ title, description }: PageMetadata) {
     document.title = resolvedTitle
     TITLE_TARGETS.forEach((target) => applyTarget(target, resolvedTitle))
     DESCRIPTION_TARGETS.forEach((target) => applyTarget(target, resolvedDescription))
+    IMAGE_TARGETS.forEach((target) => applyTarget(target, resolvedImage))
+    URL_TARGETS.forEach((target) => applyTarget(target, resolvedUrl))
 
     return () => {
       document.title = previousTitle
@@ -118,5 +153,5 @@ export function usePageMetadata({ title, description }: PageMetadata) {
         }
       })
     }
-  }, [title, description])
+  }, [title, description, image, url])
 }

--- a/plant-swipe/src/pages/BlogPostPage.tsx
+++ b/plant-swipe/src/pages/BlogPostPage.tsx
@@ -76,7 +76,12 @@ export default function BlogPostPage() {
       date: publishedLabel,
       defaultValue: 'Stories from Aphylia.',
     })
-  usePageMetadata({ title: seoTitle, description: seoDescription })
+  usePageMetadata({ 
+    title: seoTitle, 
+    description: seoDescription,
+    image: post?.coverImageUrl ?? undefined,
+    url: slug ? `/blog/${slug}` : '/blog',
+  })
 
   return (
     <div className="max-w-4xl mx-auto mt-8 px-4 pb-20 space-y-8">

--- a/plant-swipe/src/pages/PlantInfoPage.tsx
+++ b/plant-swipe/src/pages/PlantInfoPage.tsx
@@ -351,7 +351,21 @@ const PlantInfoPage: React.FC = () => {
           defaultValue: `${plant.name} care tips, meaning, and highlights.`,
         })
       : fallbackDescription)
-  usePageMetadata({ title: resolvedTitle, description: resolvedDescription })
+  
+  // Get the primary image for SEO/link previews
+  const primaryImage = React.useMemo(() => {
+    if (!plant?.images?.length) return undefined
+    const primary = plant.images.find((img) => img.use === 'primary')
+    const discovery = plant.images.find((img) => img.use === 'discovery')
+    return primary?.link || discovery?.link || plant.images[0]?.link
+  }, [plant?.images])
+  
+  usePageMetadata({ 
+    title: resolvedTitle, 
+    description: resolvedDescription,
+    image: primaryImage,
+    url: id ? `/plants/${id}` : undefined,
+  })
 
   React.useEffect(() => {
     const arr = Array.isArray((profile as any)?.liked_plant_ids)

--- a/plant-swipe/src/pages/PublicProfilePage.tsx
+++ b/plant-swipe/src/pages/PublicProfilePage.tsx
@@ -114,7 +114,12 @@ export default function PublicProfilePage() {
           defaultValue: `See shared gardens, stats, and activity from ${preferredDisplayName}.`,
         })
       : fallbackProfileDescription)
-  usePageMetadata({ title: seoTitle, description: seoDescription })
+  usePageMetadata({ 
+    title: seoTitle, 
+    description: seoDescription,
+    image: pp?.avatar_url ?? undefined,
+    url: preferredDisplayName ? `/u/${encodeURIComponent(preferredDisplayName)}` : undefined,
+  })
 
 
   const formatLastSeen = React.useCallback((iso: string | null | undefined) => {


### PR DESCRIPTION
Improve link previews and SEO metadata by adding default meta tags, ensuring absolute image/URL paths for social crawlers, and extending the metadata hook.

Link previews and SEO titles were not displaying correct information due to:
1.  Missing Open Graph and Twitter Card meta tags in `index.html`.
2.  Relative image URLs being used in server-side rendering for `og:image`.
3.  The `usePageMetadata` hook not supporting `og:image` or `og:url`.

---
<a href="https://cursor.com/background-agent?bcId=bc-4553b2b2-cb02-485b-94cc-c11d170c1952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4553b2b2-cb02-485b-94cc-c11d170c1952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

