### PR TITLE
Fix footer download translation

### DIFF
--- a/plant-swipe/public/locales/en/common.json
+++ b/plant-swipe/public/locales/en/common.json
@@ -39,6 +39,7 @@
       "about": "About",
       "blog": "Blog",
       "contactUs": "Contact Us",
+      "downloadApp": "Download",
       "termsOfServices": "Terms of Services"
     },
     "share": "Share"

--- a/plant-swipe/public/locales/fr/common.json
+++ b/plant-swipe/public/locales/fr/common.json
@@ -39,6 +39,7 @@
       "about": "À propos",
       "blog": "Blog",
       "contactUs": "Nous contacter",
+      "downloadApp": "Télécharger",
       "termsOfServices": "Conditions d'utilisation"
     },
     "share": "Partager"


### PR DESCRIPTION
Add missing `downloadApp` translation keys to ensure the "Download" link in the footer is properly localized.

---
<a href="https://cursor.com/background-agent?bcId=bc-0dddd4dc-36e4-4b0a-83af-6dbd7978375c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0dddd4dc-36e4-4b0a-83af-6dbd7978375c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

