### PR TITLE
Update sass imports

### DIFF
--- a/plant-swipe/src/index.scss
+++ b/plant-swipe/src/index.scss
@@ -1,5 +1,5 @@
-@import "./styles/_variables.scss";
-@import "./styles/_keyframe-animations.scss";
+@use "./styles/_variables.scss";
+@use "./styles/_keyframe-animations.scss";
 
 @font-face {
   font-family: "Lavonte";


### PR DESCRIPTION
Update Sass `@import` rules to `@use` in `index.scss` to resolve deprecation warnings.

---
<a href="https://cursor.com/background-agent?bcId=bc-46af8d8b-b2db-46b9-8594-d60ec2bf9f14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-46af8d8b-b2db-46b9-8594-d60ec2bf9f14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

