### PR TITLE
Plant page layout adjustment

### DIFF
--- a/plant-swipe/src/pages/PlantInfoPage.tsx
+++ b/plant-swipe/src/pages/PlantInfoPage.tsx
@@ -975,9 +975,12 @@ const MoreInformationSection: React.FC<{ plant: Plant }> = ({ plant }) => {
   ].filter(Boolean) as string[]
     const palette = plant.identity?.colors?.length ? plant.identity.colors : []
     const showPalette = palette.length > 0
-    const dimensionColClass = showPalette ? 'col-span-1' : 'col-span-1 sm:col-span-2 lg:col-span-2'
+    const gridClass = showPalette 
+      ? 'grid gap-3 sm:gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,0.6fr)_minmax(0,2fr)] items-stretch'
+      : 'grid gap-3 sm:gap-4 grid-cols-1 sm:grid-cols-2 items-stretch'
+    const dimensionColClass = showPalette ? 'col-span-1' : 'col-span-1 sm:col-span-2 lg:col-span-1'
     const paletteColClass = showPalette ? 'col-span-1' : ''
-    const timelineColClass = showPalette ? 'col-span-2 lg:col-span-1' : 'col-span-1 sm:col-span-2 lg:col-span-2'
+    const timelineColClass = showPalette ? 'col-span-2 lg:col-span-1' : 'col-span-1 sm:col-span-2 lg:col-span-1'
     const formatWaterPlans = (schedules: PlantWateringSchedule[] = []) => {
       if (!schedules.length) return t('moreInfo.values.flexible')
       return schedules
@@ -1243,7 +1246,7 @@ const MoreInformationSection: React.FC<{ plant: Plant }> = ({ plant }) => {
         </div>
       
         {/* Dynamic Grid Layout */}
-        <div className="grid gap-3 sm:gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,0.6fr)_minmax(0,2fr)] items-stretch">
+        <div className={gridClass}>
           {(height !== null || wingspan !== null || spacing !== null) && (
             <section
               className={`${dimensionColClass} rounded-2xl border border-emerald-500/25 bg-gradient-to-br from-emerald-50/70 via-white/60 to-white/10 p-3 sm:p-5 dark:border-emerald-500/30 dark:from-emerald-500/10 dark:via-transparent dark:to-transparent`}


### PR DESCRIPTION
Adjust the 'More Information' section layout to display 'Seasonal Timeline' and 'Dimensions' side-by-side on desktop when the 'Color' section is absent.

Previously, when the color palette was missing, both 'Dimensions' and 'Seasonal Timeline' sections would span two columns each on desktop, causing them to stack vertically. This PR modifies the grid template and column spans to ensure they appear next to each other in a two-column layout.

---
<a href="https://cursor.com/background-agent?bcId=bc-896740ea-f57c-41ee-b98a-83c0f3e92cea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-896740ea-f57c-41ee-b98a-83c0f3e92cea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

