### PR TITLE
Copilot/add notification for requests

### DIFF
--- a/plant-swipe/src/PlantSwipe.tsx
+++ b/plant-swipe/src/PlantSwipe.tsx
@@ -57,6 +57,7 @@ const BlogPostPageLazy = lazy(() => import("@/pages/BlogPostPage"))
 const BlogComposerPageLazy = lazy(() => import("@/pages/BlogComposerPage"))
 const BookmarkPageLazy = lazy(() => import("@/pages/BookmarkPage").then(module => ({ default: module.BookmarkPage })))
 const LandingPageLazy = lazy(() => import("@/pages/LandingPage"))
+const NotificationsPageLazy = lazy(() => import("@/pages/NotificationsPage"))
 
 type SearchSortMode = "default" | "newest" | "popular" | "favorites"
 
@@ -1457,6 +1458,16 @@ export default function PlantSwipe() {
               element={user ? (
                 <Suspense fallback={routeLoadingFallback}>
                   <MessagesPageLazy />
+                </Suspense>
+              ) : (
+                <Navigate to="/" replace />
+              )}
+            />
+            <Route
+              path="/notifications"
+              element={user ? (
+                <Suspense fallback={routeLoadingFallback}>
+                  <NotificationsPageLazy />
                 </Suspense>
               ) : (
                 <Navigate to="/" replace />

--- a/plant-swipe/src/components/layout/MobileNavBar.tsx
+++ b/plant-swipe/src/components/layout/MobileNavBar.tsx
@@ -2,10 +2,11 @@ import React from "react"
 import { createPortal } from "react-dom"
 import { Link } from "@/components/i18n/Link"
 import { usePathWithoutLanguage, useLanguageNavigate } from "@/lib/i18nRouting"
-import { Sparkles, Sprout, Search, Plus, User, Shield, HeartHandshake, MessageSquare, Settings, LogOut, Crown, LayoutGrid, HelpCircle, LogIn, UserPlus } from "lucide-react"
+import { Sparkles, Sprout, Search, Plus, User, Shield, HeartHandshake, MessageSquare, Settings, LogOut, Crown, LayoutGrid, HelpCircle, LogIn, UserPlus, Bell } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { useAuth } from "@/context/AuthContext"
 import { useTaskNotification } from "@/hooks/useTaskNotification"
+import { useNotifications } from "@/hooks/useNotifications"
 import { useTranslation } from "react-i18next"
 import { checkEditorAccess } from "@/constants/userRoles"
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet"
@@ -73,6 +74,7 @@ const MobileNavBarComponent: React.FC<MobileNavBarProps> = ({ canCreate, onProfi
   const navigate = useLanguageNavigate()
   const { user, profile } = useAuth()
   const { hasUnfinished } = useTaskNotification(user?.id ?? null, { channelKey: "mobile" })
+  const { unseenCount } = useNotifications()
   const { t } = useTranslation("common")
   const [profileMenuOpen, setProfileMenuOpen] = React.useState(false)
   const [guestMenuOpen, setGuestMenuOpen] = React.useState(false)
@@ -220,6 +222,21 @@ const MobileNavBarComponent: React.FC<MobileNavBarProps> = ({ canCreate, onProfi
             >
               <User className="h-5 w-5" />
               <span>{t("common.profile")}</span>
+            </button>
+            <button
+              onClick={() => {
+                setProfileMenuOpen(false)
+                navigate("/notifications")
+              }}
+              className="w-full text-left px-4 py-3 rounded-2xl hover:bg-stone-100 dark:hover:bg-[#2d2d30] flex items-center gap-3"
+            >
+              <div className="relative">
+                <Bell className="h-5 w-5" />
+                {unseenCount > 0 && (
+                  <span className="absolute -top-1 -right-1 w-2.5 h-2.5 bg-red-600 rounded-full ring-2 ring-white dark:ring-[#2d2d30]" />
+                )}
+              </div>
+              <span>{t("notifications.title", { defaultValue: "Notifications" })}</span>
             </button>
             <button
               onClick={() => {

--- a/plant-swipe/src/components/layout/TopBar.tsx
+++ b/plant-swipe/src/components/layout/TopBar.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { createPortal } from "react-dom"
 import { Link } from "@/components/i18n/Link"
-import { Sprout, Sparkles, Search, LogIn, UserPlus, User, LogOut, ChevronDown, Shield, HeartHandshake, Settings, Crown, CreditCard, LayoutGrid, Route, HelpCircle, MessageSquare } from "lucide-react"
+import { Sprout, Sparkles, Search, LogIn, UserPlus, User, LogOut, ChevronDown, Shield, HeartHandshake, Settings, Crown, CreditCard, LayoutGrid, Route, HelpCircle, MessageSquare, Bell } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { useTranslation } from "react-i18next"
 
@@ -16,6 +16,7 @@ interface TopBarProps {
 
 import { useAuth } from "@/context/AuthContext"
 import { useTaskNotification } from "@/hooks/useTaskNotification"
+import { useNotifications } from "@/hooks/useNotifications"
 import { usePathWithoutLanguage, useLanguageNavigate } from "@/lib/i18nRouting"
 import { checkEditorAccess } from "@/constants/userRoles"
 
@@ -29,6 +30,7 @@ export const TopBar: React.FC<TopBarProps> = ({ openLogin, openSignup, user, dis
   const menuRef = React.useRef<HTMLDivElement | null>(null)
   const [menuPosition, setMenuPosition] = React.useState<{ top: number; right: number } | null>(null)
   const { hasUnfinished } = useTaskNotification(user?.id ?? null, { channelKey: "topbar" })
+  const { unseenCount } = useNotifications()
 
   const recomputeMenuPosition = React.useCallback(() => {
     const anchor = anchorRef.current
@@ -128,13 +130,27 @@ export const TopBar: React.FC<TopBarProps> = ({ openLogin, openSignup, user, dis
             </Button>
           </>
         ) : (
-          <div className="relative" ref={anchorRef}>
-            <Button className="rounded-2xl" variant="secondary" onClick={(e: React.MouseEvent<HTMLButtonElement>) => { e.stopPropagation(); setMenuOpen((o) => !o); }} aria-label="Profile menu" aria-haspopup="menu" aria-expanded={menuOpen}>
-              <User className="h-4 w-4 mr-2 shrink-0" />
-              <span className="hidden sm:inline max-w-[40vw] truncate min-w-0">{label}</span>
-              <ChevronDown className="h-4 w-4 ml-2 opacity-70" />
-            </Button>
-            {menuOpen && menuPosition && createPortal(
+          <>
+            <div className="relative">
+              <Button asChild className="rounded-full w-10 h-10 p-0 bg-transparent hover:bg-stone-100 dark:hover:bg-[#2d2d30] border-0" variant="ghost">
+                <Link to="/notifications" aria-label="Notifications">
+                  <Bell className="h-5 w-5 text-stone-600 dark:text-stone-300" />
+                </Link>
+              </Button>
+              {unseenCount > 0 && (
+                <span
+                  className="pointer-events-none absolute top-2 right-2.5 h-2.5 w-2.5 rounded-full bg-red-600 dark:bg-red-500 ring-2 ring-white dark:ring-[#252526]"
+                  aria-hidden="true"
+                />
+              )}
+            </div>
+            <div className="relative" ref={anchorRef}>
+              <Button className="rounded-2xl" variant="secondary" onClick={(e: React.MouseEvent<HTMLButtonElement>) => { e.stopPropagation(); setMenuOpen((o) => !o); }} aria-label="Profile menu" aria-haspopup="menu" aria-expanded={menuOpen}>
+                <User className="h-4 w-4 mr-2 shrink-0" />
+                <span className="hidden sm:inline max-w-[40vw] truncate min-w-0">{label}</span>
+                <ChevronDown className="h-4 w-4 ml-2 opacity-70" />
+              </Button>
+              {menuOpen && menuPosition && createPortal(
               <div
                 ref={menuRef}
                 className="w-40 rounded-xl border bg-white dark:bg-[#252526] dark:border-[#3e3e42] shadow z-[60] p-1"
@@ -166,8 +182,9 @@ export const TopBar: React.FC<TopBarProps> = ({ openLogin, openSignup, user, dis
                 </button>
               </div>,
               document.body
-            )}
-          </div>
+              )}
+            </div>
+          </>
         )}
       </div>
     </header>

--- a/plant-swipe/src/hooks/useNotifications.ts
+++ b/plant-swipe/src/hooks/useNotifications.ts
@@ -1,0 +1,103 @@
+import React from "react"
+import { useAuth } from "@/context/AuthContext"
+
+export type Notification = {
+  id: string
+  title: string
+  message: string
+  delivery_status: string
+  delivered_at: string | null
+  scheduled_for: string
+  seen_at: string | null
+  cta_url: string | null
+  payload: any
+}
+
+export function useNotifications() {
+  const { user } = useAuth()
+  const [notifications, setNotifications] = React.useState<Notification[]>([])
+  const [loading, setLoading] = React.useState(true)
+  const [error, setError] = React.useState<string | null>(null)
+
+  // Track unseen count
+  const unseenCount = React.useMemo(() => {
+    return notifications.filter(n => !n.seen_at).length
+  }, [notifications])
+
+  const fetchNotifications = React.useCallback(async () => {
+    if (!user) {
+      setNotifications([])
+      setLoading(false)
+      return
+    }
+
+    try {
+      setLoading(true)
+      const res = await fetch('/api/notifications')
+      if (!res.ok) {
+        throw new Error('Failed to fetch notifications')
+      }
+      const data = await res.json()
+      setNotifications(Array.isArray(data.notifications) ? data.notifications : [])
+      setError(null)
+    } catch (err: any) {
+      console.error('Error fetching notifications:', err)
+      setError(err.message)
+    } finally {
+      setLoading(false)
+    }
+  }, [user])
+
+  const markAsRead = React.useCallback(async (id: string) => {
+    // Optimistic update
+    setNotifications(prev => prev.map(n => n.id === id ? { ...n, seen_at: new Date().toISOString() } : n))
+
+    try {
+      await fetch(`/api/notifications/${encodeURIComponent(id)}/read`, {
+        method: 'POST'
+      })
+    } catch (err) {
+      console.error('Error marking notification as read:', err)
+      // Revert if needed, but usually fine to just log
+    }
+  }, [])
+
+  const markAllAsRead = React.useCallback(async () => {
+    const unseenIds = notifications.filter(n => !n.seen_at).map(n => n.id)
+    if (unseenIds.length === 0) return
+
+    // Optimistic update
+    setNotifications(prev => prev.map(n => ({ ...n, seen_at: n.seen_at || new Date().toISOString() })))
+
+    try {
+      // We don't have a bulk read endpoint yet, so we loop or could add one.
+      // For now, let's just do it individually in parallel (limit concurrency if needed)
+      // Or better, assume the server handles it if we refresh.
+      // But let's try to send requests.
+      await Promise.all(unseenIds.map(id =>
+        fetch(`/api/notifications/${encodeURIComponent(id)}/read`, { method: 'POST' })
+      ))
+    } catch (err) {
+      console.error('Error marking all as read:', err)
+    }
+  }, [notifications])
+
+  // Initial fetch
+  React.useEffect(() => {
+    fetchNotifications()
+
+    // Poll every minute
+    const interval = setInterval(fetchNotifications, 60000)
+    return () => clearInterval(interval)
+  }, [fetchNotifications])
+
+  return {
+    notifications,
+    loading,
+    error,
+    unseenCount,
+    refresh: fetchNotifications,
+    markAsRead,
+    markAllAsRead
+  }
+}

--- a/plant-swipe/src/pages/NotificationsPage.tsx
+++ b/plant-swipe/src/pages/NotificationsPage.tsx
@@ -1,0 +1,177 @@
+import React from "react"
+import { useTranslation } from "react-i18next"
+import { useNotifications } from "@/hooks/useNotifications"
+import { format, formatDistanceToNow } from "date-fns"
+import { enUS, fr } from "date-fns/locale"
+import { useLanguage } from "@/lib/i18nRouting"
+import { Bell, Check, ExternalLink, Calendar, Info, BellOff } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Card } from "@/components/ui/card"
+import { Link } from "@/components/i18n/Link"
+
+export default function NotificationsPage() {
+  const { t } = useTranslation('common')
+  const { notifications, loading, error, markAsRead, markAllAsRead, refresh } = useNotifications()
+  const currentLang = useLanguage()
+  const dateLocale = currentLang === 'fr' ? fr : enUS
+
+  const { newNotifications, earlierNotifications } = React.useMemo(() => {
+    const newItems = []
+    const earlierItems = []
+
+    // Group by seen_at
+    // "New" = unseen
+    // "Earlier" = seen
+
+    for (const n of notifications) {
+      if (!n.seen_at) {
+        newItems.push(n)
+      } else {
+        earlierItems.push(n)
+      }
+    }
+    return { newNotifications: newItems, earlierNotifications: earlierItems }
+  }, [notifications])
+
+  if (loading && notifications.length === 0) {
+    return (
+      <div className="max-w-2xl mx-auto p-4 md:p-8 text-center opacity-60">
+        {t('common.loading')}
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="max-w-2xl mx-auto p-4 md:p-8 text-center text-red-600">
+        {t('common.error')}: {error}
+        <Button onClick={refresh} variant="outline" className="mt-4">
+          {t('common.retry', { defaultValue: 'Retry' })}
+        </Button>
+      </div>
+    )
+  }
+
+  const NotificationItem = ({ notification }: { notification: any }) => {
+    const isUnread = !notification.seen_at
+
+    const handleClick = () => {
+      if (isUnread) {
+        markAsRead(notification.id)
+      }
+    }
+
+    // Parse date
+    const date = new Date(notification.delivered_at || notification.scheduled_for || notification.created_at)
+    const timeAgo = formatDistanceToNow(date, { addSuffix: true, locale: dateLocale })
+
+    // Determine link
+    const link = notification.cta_url || notification.payload?.ctaUrl
+
+    const Content = (
+      <div className={`relative flex gap-4 p-4 rounded-2xl transition-colors ${isUnread ? 'bg-emerald-50/50 dark:bg-emerald-900/10 border border-emerald-100 dark:border-emerald-800/30' : 'bg-white dark:bg-[#252526] border border-stone-100 dark:border-[#3e3e42]'}`}>
+        <div className="shrink-0 mt-1">
+          <div className={`w-10 h-10 rounded-full flex items-center justify-center ${isUnread ? 'bg-emerald-100 text-emerald-600 dark:bg-emerald-900/30 dark:text-emerald-400' : 'bg-stone-100 text-stone-500 dark:bg-[#2d2d30] dark:text-stone-400'}`}>
+            <Bell className="w-5 h-5" />
+          </div>
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex justify-between items-start gap-2">
+            <h3 className={`text-base font-semibold ${isUnread ? 'text-black dark:text-white' : 'text-stone-700 dark:text-stone-300'}`}>
+              {notification.title}
+            </h3>
+            <span className="text-xs text-stone-400 whitespace-nowrap shrink-0">
+              {timeAgo}
+            </span>
+          </div>
+          <div className="mt-1 text-sm text-stone-600 dark:text-stone-400 break-words" dangerouslySetInnerHTML={{ __html: notification.message }} />
+
+          {link && (
+            <div className="mt-3">
+              <span className="text-sm font-medium text-emerald-600 dark:text-emerald-400 flex items-center gap-1">
+                {t('common.view', { defaultValue: 'View' })} <ExternalLink className="w-3 h-3" />
+              </span>
+            </div>
+          )}
+        </div>
+        {isUnread && (
+          <div className="absolute top-4 right-4 w-2 h-2 rounded-full bg-emerald-500" />
+        )}
+      </div>
+    )
+
+    if (link) {
+      // Check if external link
+      const isExternal = link.startsWith('http')
+      if (isExternal) {
+        return (
+          <a href={link} target="_blank" rel="noopener noreferrer" className="block no-underline" onClick={handleClick}>
+            {Content}
+          </a>
+        )
+      }
+      return (
+        <Link to={link} className="block no-underline" onClick={handleClick}>
+          {Content}
+        </Link>
+      )
+    }
+
+    return (
+      <div onClick={handleClick} className="cursor-pointer">
+        {Content}
+      </div>
+    )
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto p-4 md:p-8 pb-24">
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-2xl font-bold">{t('notifications.title', { defaultValue: 'Notifications' })}</h1>
+        {newNotifications.length > 0 && (
+          <Button variant="ghost" size="sm" onClick={markAllAsRead} className="text-emerald-600 dark:text-emerald-400">
+            <Check className="w-4 h-4 mr-1" />
+            {t('notifications.markAllRead', { defaultValue: 'Mark all as read' })}
+          </Button>
+        )}
+      </div>
+
+      {notifications.length === 0 ? (
+        <div className="text-center py-12 opacity-60">
+          <div className="w-16 h-16 bg-stone-100 dark:bg-[#2d2d30] rounded-full flex items-center justify-center mx-auto mb-4">
+            <BellOff className="w-8 h-8 text-stone-400" />
+          </div>
+          <p>{t('notifications.empty', { defaultValue: 'No notifications yet' })}</p>
+        </div>
+      ) : (
+        <div className="space-y-8">
+          {newNotifications.length > 0 && (
+            <div className="space-y-4">
+              <h2 className="text-sm font-medium text-stone-500 uppercase tracking-wider pl-1">
+                {t('notifications.new', { defaultValue: 'New' })}
+              </h2>
+              <div className="space-y-3">
+                {newNotifications.map(n => (
+                  <NotificationItem key={n.id} notification={n} />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {earlierNotifications.length > 0 && (
+            <div className="space-y-4">
+              <h2 className="text-sm font-medium text-stone-500 uppercase tracking-wider pl-1">
+                {t('notifications.earlier', { defaultValue: 'Earlier' })}
+              </h2>
+              <div className="space-y-3">
+                {earlierNotifications.map(n => (
+                  <NotificationItem key={n.id} notification={n} />
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/plant-swipe/src/pages/SettingsPage.tsx
+++ b/plant-swipe/src/pages/SettingsPage.tsx
@@ -510,7 +510,7 @@ export default function SettingsPage() {
   // Tab configuration
   const tabs: { id: SettingsTab; icon: React.ReactNode; label: string }[] = [
     { id: 'account', icon: <User className="h-4 w-4" />, label: t('settings.tabs.account', { defaultValue: 'Account' }) },
-    { id: 'notifications', icon: <Bell className="h-4 w-4" />, label: t('settings.tabs.notifications', { defaultValue: 'Notifications' }) },
+    { id: 'notifications', icon: <Bell className="h-4 w-4" />, label: t('settings.tabs.notifications', { defaultValue: 'Notification Settings' }) },
     { id: 'privacy', icon: <Shield className="h-4 w-4" />, label: t('settings.tabs.privacy', { defaultValue: 'Privacy' }) },
     { id: 'preferences', icon: <Settings className="h-4 w-4" />, label: t('settings.tabs.preferences', { defaultValue: 'Preferences' }) },
     { id: 'danger', icon: <AlertTriangle className="h-4 w-4" />, label: t('settings.tabs.danger', { defaultValue: 'Danger Zone' }) },


### PR DESCRIPTION
This pull request introduces a complete user notifications feature to the application. It adds a new notifications page, a reusable notifications hook, and integrates notification indicators into both the mobile and desktop navigation bars. Users can now view, mark as read, and manage notifications, with real-time unseen notification counts displayed in the UI.

**Notifications Feature Implementation**

* Added a new `NotificationsPage` (`plant-swipe/src/pages/NotificationsPage.tsx`) that displays user notifications, allows marking them as read, and groups them as "New" and "Earlier" for better organization.
* Introduced the `useNotifications` hook (`plant-swipe/src/hooks/useNotifications.ts`) to fetch notifications, track unseen counts, and provide methods to mark notifications as read (individually or all at once).
* Added a new route for `/notifications` and lazy-loaded the notifications page in the main app router (`plant-swipe/src/PlantSwipe.tsx`). [[1]](diffhunk://#diff-e6244a4e08b3f03a9d2eb3050f8dea3f3267bcbcbd1d9f50315be45dc296b684R60) [[2]](diffhunk://#diff-e6244a4e08b3f03a9d2eb3050f8dea3f3267bcbcbd1d9f50315be45dc296b684R1466-R1475)

**UI Integration and Navigation**

* Updated the top bar and mobile navigation bar to include a notifications bell icon with a real-time unseen count indicator, linking to the notifications page. [[1]](diffhunk://#diff-a6a44b9d818330655400e5b8e1dbb332e9aab1c6085dada379a96848b0aee06dL4-R4) [[2]](diffhunk://#diff-a6a44b9d818330655400e5b8e1dbb332e9aab1c6085dada379a96848b0aee06dR19) [[3]](diffhunk://#diff-a6a44b9d818330655400e5b8e1dbb332e9aab1c6085dada379a96848b0aee06dR33) [[4]](diffhunk://#diff-a6a44b9d818330655400e5b8e1dbb332e9aab1c6085dada379a96848b0aee06dR133-R146) [[5]](diffhunk://#diff-a6a44b9d818330655400e5b8e1dbb332e9aab1c6085dada379a96848b0aee06dR187) [[6]](diffhunk://#diff-d2350d3657503c1fc96ce754ff8cc00c96e94fe19c0c01b6089696cce418dcbcL5-R9) [[7]](diffhunk://#diff-d2350d3657503c1fc96ce754ff8cc00c96e94fe19c0c01b6089696cce418dcbcR77) [[8]](diffhunk://#diff-d2350d3657503c1fc96ce754ff8cc00c96e94fe19c0c01b6089696cce418dcbcR226-R240)

**Minor Text Update**

* Adjusted the label for the notifications tab in settings for clarity ("Notification Settings" instead of just "Notifications").