### PR TITLE
Add threat level to profile row type

### DIFF
--- a/plant-swipe/src/lib/supabaseClient.ts
+++ b/plant-swipe/src/lib/supabaseClient.ts
@@ -72,6 +72,7 @@ export type ProfileRow = {
   disable_friend_requests?: boolean | null
   notify_push?: boolean | null
   notify_email?: boolean | null
+  threat_level?: number | null
 }
 
 export type BlogPostRow = {
@@ -153,4 +154,3 @@ export type PlantStockRow = {
   updated_by: string | null
   created_at: string
 }
-


### PR DESCRIPTION
## Summary
- add the threat_level attribute to the ProfileRow type to align with profile queries
- allow AuthContext to type-check ban enforcement logic

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69440bbd871c8326a48265c7a58d4ba6)