### PR TITLE
Add professional advice section to plant info

### DIFF
--- a/plant-swipe/public/locales/en/common.json
+++ b/plant-swipe/public/locales/en/common.json
@@ -2600,6 +2600,37 @@
       "banned": "Banned",
       "bannedDescription": "Banned from platform"
     },
+    "proAdvice": {
+      "eyebrow": "Trusted by pros",
+      "title": "Pro insights",
+      "subtitle": "Professional notes can be pinned here without changing the plant data.",
+      "contentLabel": "Advice",
+      "referenceLabel": "Reference link (optional)",
+      "imageLabel": "Attach image (optional)",
+      "pickImage": "Upload image",
+      "clearImage": "Remove image",
+      "placeholder": "Share what growers should know about {{plant}}...",
+      "helper": "Keep it concise and actionable. Sources are encouraged.",
+      "uploading": "Uploading image...",
+      "submit": "Post advice",
+      "loading": "Loading professional advice...",
+      "empty": "No professional advice has been shared for this plant yet.",
+      "noAccess": "Only Admins, Editors, or Pros can add professional advice.",
+      "signIn": "Sign in to share",
+      "success": "Advice added",
+      "deleted": "Advice removed",
+      "delete": "Remove advice",
+      "deleteError": "Failed to delete advice",
+      "submitError": "Unable to add advice. Please try again.",
+      "loadError": "Failed to load pro advice.",
+      "unknownAuthor": "Unknown author",
+      "referenceLink": "Reference link",
+      "goToProfile": "View {{name}}'s profile",
+      "postedAt": "Posted on {{date}}",
+      "validation": {
+        "missingContent": "Add a few words to share your advice."
+      }
+    },
     "admin": {
       "reports": "Reports",
       "reportsDescription": "Manage user reports",

--- a/plant-swipe/public/locales/fr/common.json
+++ b/plant-swipe/public/locales/fr/common.json
@@ -2600,6 +2600,37 @@
       "banned": "Banni",
       "bannedDescription": "Banni de la plateforme"
     },
+    "proAdvice": {
+      "eyebrow": "Conseil pro",
+      "title": "Conseils professionnels",
+      "subtitle": "Des notes professionnelles peuvent être épinglées ici sans modifier la fiche de la plante.",
+      "contentLabel": "Conseil",
+      "referenceLabel": "Lien de référence (optionnel)",
+      "imageLabel": "Joindre une image (optionnel)",
+      "pickImage": "Téléverser une image",
+      "clearImage": "Retirer l'image",
+      "placeholder": "Partage ce qu'il faut savoir sur {{plant}}...",
+      "helper": "Reste bref et actionnable. Les sources sont les bienvenues.",
+      "uploading": "Téléversement de l'image...",
+      "submit": "Publier le conseil",
+      "loading": "Chargement des conseils pro...",
+      "empty": "Aucun conseil professionnel n'a encore été partagé pour cette plante.",
+      "noAccess": "Seuls les Admins, Éditeurs ou Pros peuvent ajouter un conseil professionnel.",
+      "signIn": "Se connecter pour contribuer",
+      "success": "Conseil ajouté",
+      "deleted": "Conseil supprimé",
+      "delete": "Supprimer le conseil",
+      "deleteError": "Impossible de supprimer le conseil",
+      "submitError": "Impossible d'ajouter le conseil. Réessaie.",
+      "loadError": "Impossible de charger les conseils pro.",
+      "unknownAuthor": "Auteur inconnu",
+      "referenceLink": "Lien de référence",
+      "goToProfile": "Voir le profil de {{name}}",
+      "postedAt": "Publié le {{date}}",
+      "validation": {
+        "missingContent": "Ajoute quelques mots pour partager ton conseil."
+      }
+    },
     "admin": {
       "reports": "Signalements",
       "reportsDescription": "Gérer les signalements d'utilisateurs",

--- a/plant-swipe/src/components/plant/ProAdviceSection.tsx
+++ b/plant-swipe/src/components/plant/ProAdviceSection.tsx
@@ -1,0 +1,389 @@
+import React from "react"
+import { Card, CardContent, CardHeader } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import { Badge } from "@/components/ui/badge"
+import { useAuth } from "@/context/AuthContext"
+import { useAuthActions } from "@/context/AuthActionsContext"
+import { hasAnyRole, USER_ROLES, checkEditorAccess } from "@/constants/userRoles"
+import { useTranslation } from "react-i18next"
+import { Image as ImageIcon, Plus, Upload, X, ExternalLink, ShieldCheck, CalendarClock, User, Sparkles, Megaphone } from "lucide-react"
+import { useLanguageNavigate } from "@/lib/i18nRouting"
+import { cn } from "@/lib/utils"
+import { createPlantProAdvice, deletePlantProAdvice, fetchPlantProAdvices, uploadProAdviceImage } from "@/lib/proAdvice"
+import type { PlantProAdvice } from "@/types/proAdvice"
+
+type ProAdviceSectionProps = {
+  plantId: string
+  plantName: string
+}
+
+const formatDate = (iso: string) => {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return iso
+  return d.toLocaleString(undefined, { year: "numeric", month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" })
+}
+
+const Avatar: React.FC<{ name?: string | null; src?: string | null }> = ({ name, src }) => {
+  const initial = (name || "").trim().charAt(0).toUpperCase() || "P"
+  return (
+    <div className="h-10 w-10 rounded-full bg-emerald-100 text-emerald-700 flex items-center justify-center overflow-hidden border border-emerald-200 shadow-sm dark:bg-emerald-950/40 dark:text-emerald-200 dark:border-emerald-800">
+      {src ? (
+        <img src={src} alt={name || ""} className="h-full w-full object-cover" referrerPolicy="no-referrer" />
+      ) : (
+        <span className="text-sm font-semibold">{initial}</span>
+      )}
+    </div>
+  )
+}
+
+const AdviceBadge: React.FC<{ roles?: string[] | null }> = ({ roles }) => {
+  if (!roles || roles.length === 0) return null
+  if (roles.includes(USER_ROLES.ADMIN)) {
+    return <Badge className="rounded-full bg-purple-100 text-purple-700 border-purple-200 dark:bg-purple-900/30 dark:text-purple-200 dark:border-purple-700">Admin</Badge>
+  }
+  if (roles.includes(USER_ROLES.EDITOR)) {
+    return <Badge className="rounded-full bg-blue-100 text-blue-700 border-blue-200 dark:bg-blue-900/30 dark:text-blue-200 dark:border-blue-700">Editor</Badge>
+  }
+  if (roles.includes(USER_ROLES.PRO)) {
+    return <Badge className="rounded-full bg-emerald-100 text-emerald-700 border-emerald-200 dark:bg-emerald-900/30 dark:text-emerald-200 dark:border-emerald-700">Pro</Badge>
+  }
+  return null
+}
+
+export const ProAdviceSection: React.FC<ProAdviceSectionProps> = ({ plantId, plantName }) => {
+  const { t } = useTranslation("common")
+  const { user, profile } = useAuth()
+  const { openLogin } = useAuthActions()
+  const navigate = useLanguageNavigate()
+
+  const [advices, setAdvices] = React.useState<PlantProAdvice[]>([])
+  const [loading, setLoading] = React.useState(true)
+  const [error, setError] = React.useState<string | null>(null)
+
+  const [content, setContent] = React.useState("")
+  const [referenceUrl, setReferenceUrl] = React.useState("")
+  const [file, setFile] = React.useState<File | null>(null)
+  const [uploading, setUploading] = React.useState(false)
+  const [submitting, setSubmitting] = React.useState(false)
+  const [formNotice, setFormNotice] = React.useState<{ type: "success" | "error"; text: string } | null>(null)
+
+  const canModerate = React.useMemo(() => checkEditorAccess(profile), [profile])
+  const canContribute = React.useMemo(() => {
+    if (!profile) return false
+    if (profile.is_admin) return true
+    const roles = (profile.roles || []) as string[]
+    return hasAnyRole(roles, [USER_ROLES.ADMIN, USER_ROLES.EDITOR, USER_ROLES.PRO])
+  }, [profile])
+
+  React.useEffect(() => {
+    let cancelled = false
+    const run = async () => {
+      setLoading(true)
+      setError(null)
+      try {
+        const rows = await fetchPlantProAdvices(plantId)
+        if (!cancelled) setAdvices(rows)
+      } catch (err: any) {
+        if (!cancelled) setError(err?.message || t("proAdvice.loadError"))
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    run()
+    return () => {
+      cancelled = true
+    }
+  }, [plantId, t])
+
+  const resetForm = () => {
+    setContent("")
+    setReferenceUrl("")
+    setFile(null)
+  }
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault()
+    if (!user) {
+      openLogin()
+      return
+    }
+    if (!canContribute) {
+      setFormNotice({ type: "error", text: t("proAdvice.noAccess") })
+      return
+    }
+    const trimmed = content.trim()
+    if (!trimmed) {
+      setFormNotice({ type: "error", text: t("proAdvice.validation.missingContent") })
+      return
+    }
+
+    let imageUrl: string | null = null
+    setSubmitting(true)
+    try {
+      if (file) {
+        setUploading(true)
+        imageUrl = await uploadProAdviceImage(file, { folder: plantId })
+      }
+      const advice = await createPlantProAdvice({
+        plantId,
+        authorId: user.id,
+        content: trimmed,
+        imageUrl,
+        referenceUrl: referenceUrl.trim() || null,
+        metadata: referenceUrl.trim() ? { reference_url: referenceUrl.trim() } : {},
+        authorDisplayName: profile?.display_name || null,
+        authorUsername: (profile as any)?.username || null,
+        authorAvatarUrl: profile?.avatar_url || null,
+        authorRoles: (profile?.roles as string[] | undefined) || [],
+      })
+      setAdvices((prev) => [advice, ...prev])
+      setFormNotice({ type: "success", text: t("proAdvice.success") })
+      resetForm()
+    } catch (err: any) {
+      setFormNotice({
+        type: "error",
+        text: err?.message || t("proAdvice.submitError"),
+      })
+    } finally {
+      setUploading(false)
+      setSubmitting(false)
+    }
+  }
+
+  const handleDelete = async (id: string) => {
+    if (!user) {
+      openLogin()
+      return
+    }
+    const advice = advices.find((a) => a.id === id)
+    const canDelete = advice && (canModerate || advice.authorId === user.id)
+    if (!canDelete) return
+    try {
+      await deletePlantProAdvice(id)
+      setAdvices((prev) => prev.filter((a) => a.id !== id))
+      setFormNotice({ type: "success", text: t("proAdvice.deleted") })
+    } catch (err: any) {
+      setFormNotice({
+        type: "error",
+        text: err?.message || t("proAdvice.deleteError"),
+      })
+    }
+  }
+
+  const handleProfileClick = (advice: PlantProAdvice) => {
+    const slug = advice.authorDisplayName || advice.authorUsername
+    if (slug) {
+      navigate(`/u/${encodeURIComponent(slug)}`)
+    }
+  }
+
+  const hasAdvice = advices.length > 0
+
+  if (!canContribute && !loading && !hasAdvice) {
+    // Hide the entire section for viewers without permissions when no advice exists
+    return null
+  }
+
+  return (
+    <section className="space-y-4 sm:space-y-5">
+      <div className="relative overflow-hidden rounded-3xl border border-emerald-200/80 bg-gradient-to-br from-emerald-50 via-white to-emerald-100 p-4 sm:p-6 shadow-lg dark:border-emerald-800/60 dark:from-[#04281f] dark:via-[#0b1b1a] dark:to-[#0e2f28]">
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_20%_20%,rgba(16,185,129,0.18),transparent_45%),radial-gradient(circle_at_80%_0%,rgba(59,130,246,0.12),transparent_40%)]" />
+        <div className="relative flex items-start justify-between gap-3">
+          <div className="space-y-1">
+            <div className="inline-flex items-center gap-2 rounded-full bg-white/80 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.22em] text-emerald-700 shadow-sm ring-1 ring-emerald-200/70 dark:bg-white/5 dark:text-emerald-200 dark:ring-emerald-700/40">
+              <Sparkles className="h-3.5 w-3.5" />
+              {t("proAdvice.eyebrow")}
+            </div>
+            <h3 className="text-xl sm:text-2xl font-bold text-stone-900 dark:text-white">{t("proAdvice.title")}</h3>
+            <p className="text-sm text-stone-600 dark:text-stone-300 max-w-2xl">
+              {t("proAdvice.subtitle")}
+            </p>
+            <div className="mt-2 flex flex-wrap gap-2 text-xs text-emerald-800 dark:text-emerald-200">
+              <Badge className="rounded-full bg-emerald-600 text-white hover:bg-emerald-700 border-emerald-500 shadow">
+                <ShieldCheck className="h-3.5 w-3.5 mr-1" />
+                {t("proAdvice.title")}
+              </Badge>
+              <Badge className="rounded-full bg-amber-100 text-amber-800 border-amber-200 dark:bg-amber-900/30 dark:text-amber-100 dark:border-amber-700">
+                <Megaphone className="h-3.5 w-3.5 mr-1" />
+                {t("proAdvice.helper")}
+              </Badge>
+            </div>
+          </div>
+          <ShieldCheck className="h-10 w-10 text-emerald-500 drop-shadow-md" />
+        </div>
+
+        {canContribute && (
+          <form className="relative mt-5 space-y-3 rounded-2xl border border-emerald-200/70 bg-white/80 p-3 sm:p-4 shadow-inner dark:border-emerald-700/50 dark:bg-[#0f1f1f]/80" onSubmit={handleSubmit}>
+            <div className="space-y-1.5">
+              <label className="flex items-center gap-2 text-xs font-semibold text-stone-700 dark:text-stone-100">
+                <Megaphone className="h-4 w-4 text-emerald-600" />
+                {t("proAdvice.contentLabel")}
+              </label>
+              <Textarea
+                value={content}
+                onChange={(e) => {
+                  setContent(e.target.value)
+                  setFormNotice(null)
+                }}
+                placeholder={t("proAdvice.placeholder", { plant: plantName })}
+                rows={4}
+                className="rounded-xl border-emerald-200/70 focus:ring-emerald-400 dark:border-emerald-700/60 dark:bg-[#0f1816]"
+              />
+            </div>
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div className="space-y-1">
+                <label className="text-xs font-medium text-stone-700 dark:text-stone-200">{t("proAdvice.referenceLabel")}</label>
+                <Input
+                  value={referenceUrl}
+                  onChange={(e) => {
+                    setReferenceUrl(e.target.value)
+                    setFormNotice(null)
+                  }}
+                  placeholder="https://"
+                  type="url"
+                  className="rounded-xl border-emerald-200/70 focus:ring-emerald-400 dark:border-emerald-700/60 dark:bg-[#0f1816]"
+                />
+              </div>
+              <div className="space-y-1">
+                <label className="text-xs font-medium text-stone-700 dark:text-stone-200">{t("proAdvice.imageLabel")}</label>
+                <div className="flex items-center gap-2">
+                  <label className="flex items-center gap-2 rounded-lg border border-dashed border-emerald-300 bg-emerald-50 px-3 py-2 text-sm font-medium text-emerald-800 shadow-sm cursor-pointer transition hover:-translate-y-[1px] hover:shadow dark:border-emerald-700 dark:bg-emerald-900/20 dark:text-emerald-100">
+                    <Upload className="h-4 w-4" />
+                    <span>{file ? file.name : t("proAdvice.pickImage")}</span>
+                    <input
+                      type="file"
+                      accept="image/*"
+                      className="hidden"
+                      onChange={(e) => {
+                        setFile(e.target.files?.[0] || null)
+                        setFormNotice(null)
+                      }}
+                    />
+                  </label>
+                  {file && (
+                    <Button type="button" variant="ghost" size="icon" onClick={() => setFile(null)} aria-label={t("proAdvice.clearImage")}>
+                      <X className="h-4 w-4" />
+                    </Button>
+                  )}
+                </div>
+              </div>
+            </div>
+            {formNotice && (
+              <div
+                className={cn(
+                  "text-xs rounded-lg px-3 py-2",
+                  formNotice.type === "success"
+                    ? "bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-200"
+                    : "bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-200"
+                )}
+              >
+                {formNotice.text}
+              </div>
+            )}
+            <div className="flex items-center justify-between">
+              <div className="text-xs text-stone-500 dark:text-stone-400">
+                {uploading ? t("proAdvice.uploading") : t("proAdvice.helper")}
+              </div>
+              <Button type="submit" disabled={submitting || uploading} className="rounded-full bg-emerald-600 hover:bg-emerald-700 text-white shadow-md">
+                <Plus className="h-4 w-4 mr-2" />
+                {t("proAdvice.submit")}
+              </Button>
+            </div>
+          </form>
+        )}
+      </div>
+
+      <div className="space-y-3 sm:space-y-4">
+        {loading && (
+          <Card className="rounded-xl border-stone-200 dark:border-stone-700">
+            <CardContent className="p-4 text-sm text-stone-500 dark:text-stone-400">{t("proAdvice.loading")}</CardContent>
+          </Card>
+        )}
+        {error && (
+          <Card className="rounded-xl border-red-200 bg-red-50 dark:border-red-800 dark:bg-red-950/30">
+            <CardContent className="p-4 text-sm text-red-700 dark:text-red-200">{error}</CardContent>
+          </Card>
+        )}
+        {!loading && !error && advices.length === 0 && canContribute && (
+          <Card className="rounded-xl border-dashed border-emerald-200 bg-emerald-50/60 dark:border-emerald-800 dark:bg-emerald-950/20">
+            <CardContent className="p-4 text-sm text-stone-700 dark:text-stone-200 flex items-center gap-2">
+              <ImageIcon className="h-4 w-4 text-emerald-500" />
+              {t("proAdvice.empty")}
+            </CardContent>
+          </Card>
+        )}
+
+        {advices.map((advice) => {
+          const canDelete = user && (canModerate || advice.authorId === user.id)
+          return (
+            <Card key={advice.id} className="overflow-hidden rounded-2xl border border-emerald-200/60 bg-gradient-to-br from-white via-emerald-50 to-white shadow-md transition hover:-translate-y-1 hover:shadow-lg dark:border-emerald-800/40 dark:from-[#0c1615] dark:via-[#0f201d] dark:to-[#0d1818]">
+              <CardHeader className="p-4 pb-2">
+                <div className="flex items-start gap-3">
+                  <button
+                    type="button"
+                    onClick={() => handleProfileClick(advice)}
+                    className="focus:outline-none focus:ring-2 focus:ring-emerald-500 rounded-full"
+                    aria-label={t("proAdvice.goToProfile", { name: advice.authorDisplayName || advice.authorUsername || "" })}
+                  >
+                    <Avatar name={advice.authorDisplayName || advice.authorUsername} src={advice.authorAvatarUrl} />
+                  </button>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <button
+                        type="button"
+                        onClick={() => handleProfileClick(advice)}
+                        className="text-sm font-semibold text-stone-900 hover:text-emerald-700 dark:text-stone-100 dark:hover:text-emerald-300"
+                      >
+                        {advice.authorDisplayName || advice.authorUsername || t("proAdvice.unknownAuthor")}
+                      </button>
+                      <AdviceBadge roles={advice.authorRoles || []} />
+                    </div>
+                    <p className="text-[11px] text-stone-500 dark:text-stone-400 flex items-center gap-1">
+                      <CalendarClock className="h-3.5 w-3.5" />
+                      {t("proAdvice.postedAt", { date: formatDate(advice.createdAt) })}
+                    </p>
+                  </div>
+                  {canDelete && (
+                    <Button type="button" variant="ghost" size="icon" onClick={() => handleDelete(advice.id)} aria-label={t("proAdvice.delete")}>
+                      <X className="h-4 w-4" />
+                    </Button>
+                  )}
+                </div>
+              </CardHeader>
+              <CardContent className="p-4 pt-1 space-y-3">
+                <p className="text-sm text-stone-800 whitespace-pre-line leading-relaxed dark:text-stone-100">
+                  <span className="inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-[0.18em] text-amber-700 dark:bg-amber-900/30 dark:text-amber-100 mr-2">
+                    <Sparkles className="h-3 w-3 mr-1" />
+                    {t("proAdvice.title")}
+                  </span>
+                  {advice.content}
+                </p>
+                {advice.imageUrl && (
+                  <div className="overflow-hidden rounded-xl border border-stone-200 bg-stone-50 dark:border-stone-700 dark:bg-[#1c1c1c]">
+                    <img src={advice.imageUrl} alt={`${plantName} pro advice`} className="w-full max-h-80 object-cover" loading="lazy" />
+                  </div>
+                )}
+                {advice.referenceUrl && (
+                  <a
+                    className={cn(
+                      "inline-flex items-center gap-1 text-sm text-emerald-700 hover:text-emerald-800 hover:underline",
+                      "dark:text-emerald-300 dark:hover:text-emerald-200"
+                    )}
+                    href={advice.referenceUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    <ExternalLink className="h-4 w-4" />
+                    {t("proAdvice.referenceLink")}
+                  </a>
+                )}
+              </CardContent>
+            </Card>
+          )
+        })}
+      </div>
+    </section>
+  )
+}

--- a/plant-swipe/src/lib/proAdvice.ts
+++ b/plant-swipe/src/lib/proAdvice.ts
@@ -1,0 +1,129 @@
+import { supabase } from "@/lib/supabaseClient"
+import type { PlantProAdvice } from "@/types/proAdvice"
+import type { UserRole } from "@/constants/userRoles"
+
+const ADVICE_SELECT = `
+  id,
+  plant_id,
+  author_id,
+  author_display_name,
+  author_username,
+  author_avatar_url,
+  author_roles,
+  content,
+  image_url,
+  reference_url,
+  metadata,
+  created_at
+`
+
+const mapAdviceRow = (row: any): PlantProAdvice => ({
+  id: row.id,
+  plantId: row.plant_id,
+  authorId: row.author_id,
+  authorDisplayName: row.author_display_name ?? null,
+  authorUsername: row.author_username ?? null,
+  authorAvatarUrl: row.author_avatar_url ?? null,
+  authorRoles: (row.author_roles as UserRole[] | null | undefined) ?? null,
+  content: row.content,
+  imageUrl: row.image_url ?? null,
+  referenceUrl: row.reference_url ?? null,
+  metadata: row.metadata ?? null,
+  createdAt: row.created_at,
+})
+
+export async function fetchPlantProAdvices(plantId: string): Promise<PlantProAdvice[]> {
+  const { data, error } = await supabase
+    .from("plant_pro_advices")
+    .select(ADVICE_SELECT)
+    .eq("plant_id", plantId)
+    .order("created_at", { ascending: false })
+
+  if (error) throw new Error(error.message)
+  return (data || []).map(mapAdviceRow)
+}
+
+type CreatePlantProAdviceInput = {
+  plantId: string
+  authorId: string
+  content: string
+  imageUrl?: string | null
+  referenceUrl?: string | null
+  metadata?: Record<string, unknown> | null
+  authorDisplayName?: string | null
+  authorUsername?: string | null
+  authorAvatarUrl?: string | null
+  authorRoles?: UserRole[] | null
+}
+
+export async function createPlantProAdvice(input: CreatePlantProAdviceInput): Promise<PlantProAdvice> {
+  const payload = {
+    plant_id: input.plantId,
+    author_id: input.authorId,
+    author_display_name: input.authorDisplayName ?? null,
+    author_username: input.authorUsername ?? null,
+    author_avatar_url: input.authorAvatarUrl ?? null,
+    author_roles: input.authorRoles ?? [],
+    content: input.content,
+    image_url: input.imageUrl ?? null,
+    reference_url: input.referenceUrl ?? null,
+    metadata: input.metadata ?? {},
+  }
+
+  const { data, error } = await supabase
+    .from("plant_pro_advices")
+    .insert(payload)
+    .select(ADVICE_SELECT)
+    .maybeSingle()
+
+  if (error) throw new Error(error.message)
+  if (!data) throw new Error("Pro advice could not be saved.")
+  return mapAdviceRow(data)
+}
+
+export async function deletePlantProAdvice(id: string): Promise<void> {
+  const { error } = await supabase.from("plant_pro_advices").delete().eq("id", id)
+  if (error) throw new Error(error.message)
+}
+
+type UploadOptions = {
+  folder?: string
+  signal?: AbortSignal
+}
+
+export async function uploadProAdviceImage(file: File, options?: UploadOptions): Promise<string> {
+  if (!file) throw new Error("Missing file to upload.")
+  if (!file.type.startsWith("image/")) throw new Error("Only image uploads are supported.")
+
+  const session = await supabase.auth.getSession()
+  const token = session?.data?.session?.access_token
+  if (!token) {
+    throw new Error("You must be signed in to upload an image.")
+  }
+
+  const form = new FormData()
+  form.append("file", file)
+  if (options?.folder) {
+    form.append("folder", options.folder)
+  }
+
+  const response = await fetch("/api/pro-advice/upload-image", {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}` },
+    body: form,
+    credentials: "same-origin",
+    signal: options?.signal,
+  })
+
+  const payload = await response.json().catch(() => ({} as any))
+  if (!response.ok) {
+    const message = payload?.error || "Failed to upload image."
+    throw new Error(message)
+  }
+
+  const url = payload?.url || payload?.publicUrl
+  if (!url) {
+    throw new Error("Upload succeeded but no public URL was returned.")
+  }
+  return url as string
+}

--- a/plant-swipe/src/pages/PlantInfoPage.tsx
+++ b/plant-swipe/src/pages/PlantInfoPage.tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom'
 import { PlantDetails } from '@/components/plant/PlantDetails'
 import { DimensionCube } from '@/components/plant/DimensionCube'
 import { Card, CardContent, CardHeader } from '@/components/ui/card'
+import { ProAdviceSection } from '@/components/plant/ProAdviceSection'
 import type { Plant, PlantImage, PlantWateringSchedule, PlantColor, PlantSource } from '@/types/plant'
 import { useAuth } from '@/context/AuthContext'
 import { useAuthActions } from '@/context/AuthActionsContext'
@@ -602,6 +603,7 @@ const PlantInfoPage: React.FC = () => {
         isBookmarked={isBookmarked}
       />
       <MoreInformationSection plant={plant} />
+      <ProAdviceSection plantId={plant.id} plantName={plant.name} />
       
       {user?.id && plant && (
         <AddToBookmarkDialog 

--- a/plant-swipe/src/types/proAdvice.ts
+++ b/plant-swipe/src/types/proAdvice.ts
@@ -1,0 +1,16 @@
+import type { UserRole } from "@/constants/userRoles"
+
+export type PlantProAdvice = {
+  id: string
+  plantId: string
+  authorId: string
+  authorDisplayName: string | null
+  authorUsername: string | null
+  authorAvatarUrl?: string | null
+  authorRoles?: UserRole[] | null
+  content: string
+  imageUrl?: string | null
+  referenceUrl?: string | null
+  metadata?: Record<string, unknown> | null
+  createdAt: string
+}

--- a/plant-swipe/supabase/000_sync_schema.sql
+++ b/plant-swipe/supabase/000_sync_schema.sql
@@ -82,6 +82,7 @@ do $$ declare
     'plant_watering_schedules',
     'plant_sources',
     'plant_infusion_mixes',
+    'plant_pro_advices',
     'plant_images',
     'colors',
     'plant_colors',
@@ -214,6 +215,37 @@ drop index if exists public.profiles_username_unique;
 
 -- Unique index on display_name (case-insensitive)
 create unique index if not exists profiles_display_name_lower_unique on public.profiles ((lower(display_name)));
+
+-- Role helper functions for policy checks
+create or replace function public.has_role(_user_id uuid, _role text)
+returns boolean
+language sql
+stable
+security definer
+as $$
+  select exists (
+    select 1 from public.profiles
+    where id = _user_id
+      and _role = any(coalesce(roles, '{}'))
+  );
+$$;
+
+create or replace function public.has_any_role(_user_id uuid, _roles text[])
+returns boolean
+language sql
+stable
+security definer
+as $$
+  select exists (
+    select 1 from public.profiles
+    where id = _user_id
+      and coalesce(roles, '{}') && _roles
+  );
+$$;
+
+grant execute on function public.has_role(uuid, text) to anon, authenticated;
+grant execute on function public.has_any_role(uuid, text[]) to anon, authenticated;
+
 alter table public.profiles enable row level security;
 -- Helper to avoid RLS self-recursion when checking admin
 -- Uses SECURITY DEFINER to bypass RLS on public.profiles
@@ -763,6 +795,66 @@ do $$ begin
     drop policy plant_infusion_mixes_all on public.plant_infusion_mixes;
   end if;
   create policy plant_infusion_mixes_all on public.plant_infusion_mixes for all to authenticated using (true) with check (true);
+end $$;
+
+-- ========== Plant professional advice (Pro/Admin/Editor contributions) ==========
+create table if not exists public.plant_pro_advices (
+  id uuid primary key default gen_random_uuid(),
+  plant_id text not null references public.plants(id) on delete cascade,
+  author_id uuid not null references public.profiles(id) on delete cascade,
+  author_display_name text,
+  author_username text,
+  author_avatar_url text,
+  author_roles text[] not null default '{}'::text[],
+  content text not null,
+  image_url text,
+  reference_url text,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  constraint plant_pro_advices_content_not_blank check (char_length(btrim(content)) > 0),
+  constraint plant_pro_advices_metadata_object check (metadata is null or jsonb_typeof(metadata) = 'object')
+);
+create index if not exists plant_pro_advices_plant_created_idx on public.plant_pro_advices (plant_id, created_at desc);
+alter table public.plant_pro_advices enable row level security;
+do $$ begin
+  if exists (select 1 from pg_policies where schemaname='public' and tablename='plant_pro_advices' and policyname='plant_pro_advices_select_all') then
+    drop policy plant_pro_advices_select_all on public.plant_pro_advices;
+  end if;
+  create policy plant_pro_advices_select_all on public.plant_pro_advices for select to authenticated, anon using (true);
+end $$;
+do $$ begin
+  if exists (select 1 from pg_policies where schemaname='public' and tablename='plant_pro_advices' and policyname='plant_pro_advices_insert_authorized') then
+    drop policy plant_pro_advices_insert_authorized on public.plant_pro_advices;
+  end if;
+  create policy plant_pro_advices_insert_authorized on public.plant_pro_advices for insert to authenticated
+    with check (
+      author_id = auth.uid()
+      and coalesce(public.has_any_role(auth.uid(), array['admin','editor','pro']), false)
+    );
+end $$;
+do $$ begin
+  if exists (select 1 from pg_policies where schemaname='public' and tablename='plant_pro_advices' and policyname='plant_pro_advices_update_moderate') then
+    drop policy plant_pro_advices_update_moderate on public.plant_pro_advices;
+  end if;
+  create policy plant_pro_advices_update_moderate on public.plant_pro_advices for update to authenticated
+    using (
+      author_id = auth.uid()
+      or coalesce(public.has_any_role(auth.uid(), array['admin','editor']), false)
+    )
+    with check (
+      author_id = auth.uid()
+      or coalesce(public.has_any_role(auth.uid(), array['admin','editor']), false)
+    );
+end $$;
+do $$ begin
+  if exists (select 1 from pg_policies where schemaname='public' and tablename='plant_pro_advices' and policyname='plant_pro_advices_delete_moderate') then
+    drop policy plant_pro_advices_delete_moderate on public.plant_pro_advices;
+  end if;
+  create policy plant_pro_advices_delete_moderate on public.plant_pro_advices for delete to authenticated
+    using (
+      author_id = auth.uid()
+      or coalesce(public.has_any_role(auth.uid(), array['admin','editor']), false)
+    );
 end $$;
 
 -- ========== Plant images ==========

--- a/plant-swipe/supabase/migrations/202502091200_add_plant_pro_advices.sql
+++ b/plant-swipe/supabase/migrations/202502091200_add_plant_pro_advices.sql
@@ -1,0 +1,97 @@
+-- Ensure role helper functions exist for policy checks
+create or replace function public.has_role(_user_id uuid, _role text)
+returns boolean
+language sql
+stable
+security definer
+as $$
+  select exists (
+    select 1 from public.profiles
+    where id = _user_id
+      and _role = any(coalesce(roles, '{}'))
+  );
+$$;
+
+create or replace function public.has_any_role(_user_id uuid, _roles text[])
+returns boolean
+language sql
+stable
+security definer
+as $$
+  select exists (
+    select 1 from public.profiles
+    where id = _user_id
+      and coalesce(roles, '{}') && _roles
+  );
+$$;
+
+grant execute on function public.has_role(uuid, text) to authenticated;
+grant execute on function public.has_any_role(uuid, text[]) to authenticated;
+
+-- Professional advice posted by Admin/Editor/Pro users on plant pages
+create table if not exists public.plant_pro_advices (
+  id uuid primary key default gen_random_uuid(),
+  plant_id text not null references public.plants(id) on delete cascade,
+  author_id uuid not null references public.profiles(id) on delete cascade,
+  author_display_name text,
+  author_username text,
+  author_avatar_url text,
+  author_roles text[] not null default '{}'::text[],
+  content text not null,
+  image_url text,
+  reference_url text,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  constraint plant_pro_advices_content_not_blank check (char_length(btrim(content)) > 0),
+  constraint plant_pro_advices_metadata_object check (metadata is null or jsonb_typeof(metadata) = 'object')
+);
+
+create index if not exists plant_pro_advices_plant_created_idx on public.plant_pro_advices (plant_id, created_at desc);
+alter table public.plant_pro_advices enable row level security;
+
+-- Allow anyone to read pro advice attached to plants
+do $$ begin
+  if exists (select 1 from pg_policies where schemaname='public' and tablename='plant_pro_advices' and policyname='plant_pro_advices_select_all') then
+    drop policy plant_pro_advices_select_all on public.plant_pro_advices;
+  end if;
+  create policy plant_pro_advices_select_all on public.plant_pro_advices for select to authenticated, anon using (true);
+end $$;
+
+-- Only Admin/Editor/Pro users can post, and the author_id must match the caller
+do $$ begin
+  if exists (select 1 from pg_policies where schemaname='public' and tablename='plant_pro_advices' and policyname='plant_pro_advices_insert_authorized') then
+    drop policy plant_pro_advices_insert_authorized on public.plant_pro_advices;
+  end if;
+  create policy plant_pro_advices_insert_authorized on public.plant_pro_advices for insert to authenticated
+    with check (
+      author_id = auth.uid()
+      and coalesce(public.has_any_role(auth.uid(), array['admin','editor','pro']), false)
+    );
+end $$;
+
+-- Allow authors to update/delete their own advice; Admin/Editor can moderate everything
+do $$ begin
+  if exists (select 1 from pg_policies where schemaname='public' and tablename='plant_pro_advices' and policyname='plant_pro_advices_update_moderate') then
+    drop policy plant_pro_advices_update_moderate on public.plant_pro_advices;
+  end if;
+  create policy plant_pro_advices_update_moderate on public.plant_pro_advices for update to authenticated
+    using (
+      author_id = auth.uid()
+      or coalesce(public.has_any_role(auth.uid(), array['admin','editor']), false)
+    )
+    with check (
+      author_id = auth.uid()
+      or coalesce(public.has_any_role(auth.uid(), array['admin','editor']), false)
+    );
+end $$;
+
+do $$ begin
+  if exists (select 1 from pg_policies where schemaname='public' and tablename='plant_pro_advices' and policyname='plant_pro_advices_delete_moderate') then
+    drop policy plant_pro_advices_delete_moderate on public.plant_pro_advices;
+  end if;
+  create policy plant_pro_advices_delete_moderate on public.plant_pro_advices for delete to authenticated
+    using (
+      author_id = auth.uid()
+      or coalesce(public.has_any_role(auth.uid(), array['admin','editor']), false)
+    );
+end $$;


### PR DESCRIPTION
## Summary
- add Supabase pro advice table with role-checked RLS helpers and migration
- expose pro-advice image upload endpoint plus translations and UI strings
- surface a Pro Advice section on the plant info page with add/delete flows for admins, editors, and pros
- hide the pro advice block from non-privileged viewers when empty, polish the UI, and confine creation controls to eligible roles

## Testing
- npm run lint *(fails: pre-existing lint warnings in unrelated files)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69442d0870508326860ff91c7ee1bad9)