### PR TITLE
Load runtime env before app init

### DIFF
--- a/plant-swipe/index.html
+++ b/plant-swipe/index.html
@@ -120,6 +120,9 @@
       <!-- For dev/preview where src is served: -->
       <noscript><link rel="stylesheet" href="/src/index.scss" /></noscript>
       <title>Aphylia</title>
+
+      <!-- Ensure runtime environment variables load before the app initializes -->
+      <script src="/env-loader.js" data-base="/" crossorigin="anonymous"></script>
     </head>
     <body>
       <div id="root">


### PR DESCRIPTION
## Summary
- ensure runtime environment variables load before the app initializes by adding env-loader to index.html

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694482f148e48326b6a27bda8009936d)