### PR TITLE
Stop precaching runtime env assets

### DIFF
--- a/plant-swipe/vite.config.ts
+++ b/plant-swipe/vite.config.ts
@@ -40,8 +40,6 @@ export default defineConfig({
       filename: 'sw.ts',
       includeAssets: [
         'env-loader.js',
-        'env.js',
-        'api/env.js',
         'icons/plant-swipe-icon.svg',
         'icons/plant-swipe-icon-outline.svg',
         'icons/icon-192x192.png',
@@ -82,7 +80,9 @@ export default defineConfig({
       },
       injectManifest: {
         globPatterns: ['**/*.{js,css,html,ico,png,svg,webp,json,txt,woff,woff2,ttf}'],
-        globIgnores: ['**/*.map', '**/node_modules/**'],
+        // Never precache runtime env endpoints; they must come from the active host
+        // (often dynamic) rather than a baked fallback bundled at build time.
+        globIgnores: ['**/*.map', '**/node_modules/**', '**/env.js', '**/api/env.js'],
       },
       devOptions: {
         enabled: process.env.VITE_ENABLE_PWA === 'true',


### PR DESCRIPTION
## Summary
- remove /env.js and /api/env.js from the PWA pre-cache so the client always reads live runtime environment values
- ignore runtime env endpoints in the injectManifest glob so they are never cached by the service worker

## Testing
- npm run lint *(fails: existing lint warnings/errors in repository unrelated to this change)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694519ee4be8832685888bead1acd5b8)