### PR TITLE
Plant type constraint error

### DIFF
--- a/plant-swipe/src/lib/applyAiField.ts
+++ b/plant-swipe/src/lib/applyAiField.ts
@@ -111,6 +111,14 @@ export function applyAiFieldToPlant(prev: Plant, fieldKey: string, data: unknown
       type IdentityComposition = NonNullable<NonNullable<Plant['identity']>['composition']>
       const payload = { ...(data as Record<string, unknown>) }
       delete (payload as any).colors
+      // Remove fields that belong at the top level, not in identity
+      delete (payload as any).plant_type
+      delete (payload as any).plantType
+      delete (payload as any).utility
+      delete (payload as any).comestible_part
+      delete (payload as any).comestiblePart
+      delete (payload as any).fruit_type
+      delete (payload as any).fruitType
       if ('composition' in payload) {
         const normalizedComposition = expandCompositionFromDb(
           payload.composition as string[] | null | undefined,

--- a/plant-swipe/src/lib/composition.ts
+++ b/plant-swipe/src/lib/composition.ts
@@ -198,13 +198,13 @@ function createEnumTools(configs: readonly EnumConfig[]): EnumTools {
 }
 
 export const plantTypeEnum = createEnumTools([
-  { dbValue: 'plant', uiValue: 'plant' },
-  { dbValue: 'flower', uiValue: 'flower' },
-  { dbValue: 'bamboo', uiValue: 'bamboo' },
-  { dbValue: 'shrub', uiValue: 'shrub' },
-  { dbValue: 'tree', uiValue: 'tree' },
-  { dbValue: 'cactus', uiValue: 'cactus' },
-  { dbValue: 'succulent', uiValue: 'succulent' },
+  { dbValue: 'plant', uiValue: 'plant', aliases: ['herb', 'grass', 'fern', 'vine', 'bulb', 'perennial', 'annual', 'herbaceous', 'foliage', 'groundcover', 'ground cover', 'climber', 'creeper', 'aquatic'] },
+  { dbValue: 'flower', uiValue: 'flower', aliases: ['flowering plant', 'flowering', 'blooming'] },
+  { dbValue: 'bamboo', uiValue: 'bamboo', aliases: ['bamboos'] },
+  { dbValue: 'shrub', uiValue: 'shrub', aliases: ['bush', 'bushes', 'shrubs', 'subshrub', 'sub-shrub'] },
+  { dbValue: 'tree', uiValue: 'tree', aliases: ['trees', 'palm', 'palms', 'conifer', 'conifers', 'evergreen', 'deciduous'] },
+  { dbValue: 'cactus', uiValue: 'cactus', aliases: ['cacti', 'cactuses'] },
+  { dbValue: 'succulent', uiValue: 'succulent', aliases: ['succulents'] },
 ])
 
 export const utilityEnum = createEnumTools([

--- a/plant-swipe/src/lib/plantSchema.ts
+++ b/plant-swipe/src/lib/plantSchema.ts
@@ -9,10 +9,6 @@ export const plantSchema = {
   description: 'longtext',
   identity: {
     name: 'text',
-    plant_type: 'enum',
-    utility: 'enum[]',
-    comestible_part: 'enum[]',
-    fruit_type: 'enum[]',
     given_names: 'tag[]',
     scientific_name: 'text',
     family: 'text',


### PR DESCRIPTION
Fixes AI FILL `plants_plant_type_check` constraint violation by normalizing AI-generated plant types and clarifying the schema.

The AI was generating plant type values (e.g., "herb", "palm") that didn't match the database's strict enum, leading to a constraint error. This PR adds aliases to map these common AI variations to valid database types and removes redundant schema fields that were confusing the AI.

---
<a href="https://cursor.com/background-agent?bcId=bc-b3b8d8ca-e258-44c0-adc7-410ed138a0ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b3b8d8ca-e258-44c0-adc7-410ed138a0ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

