### PR TITLE
Plant type constraint error

### DIFF
--- a/plant-swipe/src/lib/applyAiField.ts
+++ b/plant-swipe/src/lib/applyAiField.ts
@@ -77,7 +77,15 @@ export function applyAiFieldToPlant(prev: Plant, fieldKey: string, data: unknown
       return { ...next, id: typeof data === 'string' ? data : next.id }
     case 'plantType': {
       const result = normalizeEnumValueInput(plantTypeEnum as EnumTools, data)
-      if (!result.shouldUpdate) return next
+      if (!result.shouldUpdate) {
+        // If AI returned an unrecognized value but data was provided, default to 'plant'
+        // This prevents database constraint violations when an unrecognized type is returned
+        if (data !== undefined && data !== null && typeof data === 'string' && data.trim()) {
+          console.warn(`[applyAiField] Unrecognized plantType "${data}", defaulting to "plant"`)
+          return { ...next, plantType: 'plant' }
+        }
+        return next
+      }
       return { ...next, plantType: result.value as Plant['plantType'] | undefined }
     }
     case 'utility': {

--- a/plant-swipe/src/lib/composition.ts
+++ b/plant-swipe/src/lib/composition.ts
@@ -198,13 +198,13 @@ function createEnumTools(configs: readonly EnumConfig[]): EnumTools {
 }
 
 export const plantTypeEnum = createEnumTools([
-  { dbValue: 'plant', uiValue: 'plant', aliases: ['herb', 'grass', 'fern', 'vine', 'bulb', 'perennial', 'annual', 'herbaceous', 'foliage', 'groundcover', 'ground cover', 'climber', 'creeper', 'aquatic'] },
-  { dbValue: 'flower', uiValue: 'flower', aliases: ['flowering plant', 'flowering', 'blooming'] },
-  { dbValue: 'bamboo', uiValue: 'bamboo', aliases: ['bamboos'] },
-  { dbValue: 'shrub', uiValue: 'shrub', aliases: ['bush', 'bushes', 'shrubs', 'subshrub', 'sub-shrub'] },
-  { dbValue: 'tree', uiValue: 'tree', aliases: ['trees', 'palm', 'palms', 'conifer', 'conifers', 'evergreen', 'deciduous'] },
-  { dbValue: 'cactus', uiValue: 'cactus', aliases: ['cacti', 'cactuses'] },
-  { dbValue: 'succulent', uiValue: 'succulent', aliases: ['succulents'] },
+  { dbValue: 'plant', uiValue: 'plant', aliases: ['herb', 'grass', 'fern', 'vine', 'bulb', 'perennial', 'annual', 'herbaceous', 'foliage', 'groundcover', 'ground cover', 'climber', 'creeper', 'aquatic', 'tropical', 'tropical plant', 'indoor', 'indoor plant', 'outdoor plant', 'ornamental plant', 'herbaceous plant', 'perennial plant', 'annual plant', 'houseplant', 'house plant', 'vegetable', 'vegetables', 'leafy', 'leafy plant', 'moss', 'mosses', 'lichen', 'lichens', 'epiphyte', 'epiphytes'] },
+  { dbValue: 'flower', uiValue: 'flower', aliases: ['flowering plant', 'flowering', 'blooming', 'blossom', 'flowers', 'ornamental flower', 'wildflower', 'wild flower'] },
+  { dbValue: 'bamboo', uiValue: 'bamboo', aliases: ['bamboos', 'bamboo plant'] },
+  { dbValue: 'shrub', uiValue: 'shrub', aliases: ['bush', 'bushes', 'shrubs', 'subshrub', 'sub-shrub', 'woody shrub', 'flowering shrub'] },
+  { dbValue: 'tree', uiValue: 'tree', aliases: ['trees', 'palm', 'palms', 'conifer', 'conifers', 'evergreen', 'deciduous', 'evergreen tree', 'deciduous tree', 'fruit tree', 'flowering tree', 'shade tree', 'ornamental tree'] },
+  { dbValue: 'cactus', uiValue: 'cactus', aliases: ['cacti', 'cactuses', 'desert plant', 'desert cactus'] },
+  { dbValue: 'succulent', uiValue: 'succulent', aliases: ['succulents', 'succulent plant', 'fat plant', 'fat plants'] },
 ])
 
 export const utilityEnum = createEnumTools([

--- a/plant-swipe/src/lib/plantSchema.ts
+++ b/plant-swipe/src/lib/plantSchema.ts
@@ -1,7 +1,10 @@
 // Structured schema definition used for AI fill requests.
 // This mirrors the columnar plant model (no legacy JSON) with categories and fields.
 export const plantSchema = {
-  plantType: 'enum',
+  plantType: {
+    type: 'enum',
+    options: ['plant', 'flower', 'bamboo', 'shrub', 'tree', 'cactus', 'succulent'],
+  },
   utility: 'enum[]',
   comestiblePart: 'enum[]',
   fruitType: 'enum[]',


### PR DESCRIPTION
Fixes `plants_plant_type_check` constraint violation by improving AI plant type handling.

The AI was generating unrecognized plant types, leading to `undefined` values that violated the database check constraint. This PR adds explicit schema options, expands aliases, and implements a fallback to 'plant' to prevent this.

---
<a href="https://cursor.com/background-agent?bcId=bc-4f711852-1073-4678-a233-64b511b124cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4f711852-1073-4678-a233-64b511b124cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

