### PR TITLE
Notification type correction

### DIFF
--- a/plant-swipe/src/lib/notifications.ts
+++ b/plant-swipe/src/lib/notifications.ts
@@ -128,7 +128,8 @@ export async function getNotificationCounts(userId: string): Promise<Notificatio
         total: (unreadCount || 0) + (friendRequestCount || 0),
         unread: unreadCount || 0,
         friendRequests: friendRequestCount || 0,
-        gardenInvites: 0
+        gardenInvites: 0,
+        unreadMessages: 0
       }
     }
 


### PR DESCRIPTION
Fix TypeScript error by adding `unreadMessages: 0` to an early return in `getNotificationCounts` to satisfy the `NotificationCounts` type.

---
<a href="https://cursor.com/background-agent?bcId=bc-97d6f529-bcf5-4bbf-b594-0a686dc3278f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-97d6f529-bcf5-4bbf-b594-0a686dc3278f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

