### PR TITLE
Plant advice management feature

### DIFF
--- a/plant-swipe/src/components/plant/ProAdviceSection.tsx
+++ b/plant-swipe/src/components/plant/ProAdviceSection.tsx
@@ -6,7 +6,7 @@ import { Textarea } from "@/components/ui/textarea"
 import { Badge } from "@/components/ui/badge"
 import { useAuth } from "@/context/AuthContext"
 import { useAuthActions } from "@/context/AuthActionsContext"
-import { hasAnyRole, USER_ROLES, checkEditorAccess } from "@/constants/userRoles"
+import { hasAnyRole, USER_ROLES } from "@/constants/userRoles"
 import type { UserRole } from "@/constants/userRoles"
 import { useTranslation } from "react-i18next"
 import { Image as ImageIcon, Plus, Upload, X, ExternalLink, ShieldCheck, CalendarClock, Sparkles, Megaphone, ChevronDown, ChevronUp } from "lucide-react"
@@ -77,7 +77,12 @@ export const ProAdviceSection: React.FC<ProAdviceSectionProps> = ({ plantId, pla
     return roles.filter((role): role is UserRole => Object.values(USER_ROLES).includes(role as UserRole))
   }, [])
 
-  const canModerate = React.useMemo(() => checkEditorAccess(profile), [profile])
+  const canModerate = React.useMemo(() => {
+    if (!profile) return false
+    if (profile.is_admin) return true
+    const roles = normalizeRoles(profile.roles)
+    return hasAnyRole(roles, [USER_ROLES.ADMIN, USER_ROLES.EDITOR, USER_ROLES.PRO])
+  }, [normalizeRoles, profile])
   const canContribute = React.useMemo(() => {
     if (!profile) return false
     if (profile.is_admin) return true

--- a/plant-swipe/supabase/migrations/202502091201_update_pro_advice_delete_policy.sql
+++ b/plant-swipe/supabase/migrations/202502091201_update_pro_advice_delete_policy.sql
@@ -1,0 +1,29 @@
+-- Update the delete policy to allow Pro users to delete any pro advice (moderation)
+-- This extends the previous policy that only allowed admin/editor to moderate
+
+do $$ begin
+  if exists (select 1 from pg_policies where schemaname='public' and tablename='plant_pro_advices' and policyname='plant_pro_advices_delete_moderate') then
+    drop policy plant_pro_advices_delete_moderate on public.plant_pro_advices;
+  end if;
+  create policy plant_pro_advices_delete_moderate on public.plant_pro_advices for delete to authenticated
+    using (
+      author_id = auth.uid()
+      or coalesce(public.has_any_role(auth.uid(), array['admin','editor','pro']), false)
+    );
+end $$;
+
+-- Also update the update policy to allow Pro users to update any advice
+do $$ begin
+  if exists (select 1 from pg_policies where schemaname='public' and tablename='plant_pro_advices' and policyname='plant_pro_advices_update_moderate') then
+    drop policy plant_pro_advices_update_moderate on public.plant_pro_advices;
+  end if;
+  create policy plant_pro_advices_update_moderate on public.plant_pro_advices for update to authenticated
+    using (
+      author_id = auth.uid()
+      or coalesce(public.has_any_role(auth.uid(), array['admin','editor','pro']), false)
+    )
+    with check (
+      author_id = auth.uid()
+      or coalesce(public.has_any_role(auth.uid(), array['admin','editor','pro']), false)
+    );
+end $$;


### PR DESCRIPTION
Allow Pro users to moderate (delete and update) Pro Advices to align with task requirements.

Previously, Pro users could only delete their own advice, but the task required Pro/Editor/Admin to be able to delete any advice. This PR updates both frontend logic and backend RLS policies to grant Pro users moderation capabilities.

---
<a href="https://cursor.com/background-agent?bcId=bc-6ce4a8e7-536f-4d3e-abc8-a4fad97527e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6ce4a8e7-536f-4d3e-abc8-a4fad97527e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

