### PR TITLE
Admin page broken fix

### DIFF
--- a/plant-swipe/src/pages/AdminPage.tsx
+++ b/plant-swipe/src/pages/AdminPage.tsx
@@ -10407,11 +10407,15 @@ export const AdminPage: React.FC = () => {
 };
 
 // --- Broadcast controls (Overview tab) ---
-const BroadcastControls: React.FC<{
+function BroadcastControls({
+  inline = false,
+  onExpired,
+  onActive,
+}: {
   inline?: boolean;
   onExpired?: () => void;
   onActive?: () => void;
-}> = ({ inline = false, onExpired, onActive }) => {
+}) {
   const [active, setActive] = React.useState<BroadcastRecord | null>(() =>
     loadPersistedBroadcast(),
   );
@@ -10843,7 +10847,7 @@ const BroadcastControls: React.FC<{
       <CardContent className="p-4">{content}</CardContent>
     </Card>
   );
-};
+}
 
 // parseDurationToMs removed
 


### PR DESCRIPTION
Fix `ReferenceError: Cannot access 'Pe' before initialization` on the Admin Page by converting `BroadcastControls` to a function declaration.

The `BroadcastControls` component was defined as a `const` arrow function after its usage in the `AdminPage` component. Since `const` declarations are not hoisted, this led to a `ReferenceError`. Changing it to a regular `function` declaration allows it to be hoisted, resolving the initialization error.

---
<a href="https://cursor.com/background-agent?bcId=bc-83e14ac4-0333-4ca8-b0e8-baaeb193eca8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-83e14ac4-0333-4ca8-b0e8-baaeb193eca8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

