### PR TITLE
Plant display logic updates

### DIFF
--- a/plant-swipe/src/PlantSwipe.tsx
+++ b/plant-swipe/src/PlantSwipe.tsx
@@ -574,6 +574,17 @@ export default function PlantSwipe() {
     // shuffleEpoch is used to trigger a reshuffle when user completes a cycle
     void shuffleEpoch
     if (filtered.length === 0) return []
+    
+    // Filter out plants without images for Discovery page
+    const plantsWithImages = filtered.filter((p) => {
+      // Check for image in multiple locations
+      const hasLegacyImage = Boolean(p.image)
+      const hasImagesArray = Array.isArray(p.images) && p.images.some((img) => img?.link)
+      return hasLegacyImage || hasImagesArray
+    })
+    
+    if (plantsWithImages.length === 0) return []
+    
     const shuffleList = (list: Plant[]) => {
       const arr = list.slice()
       for (let i = arr.length - 1; i > 0; i--) {
@@ -585,7 +596,7 @@ export default function PlantSwipe() {
     const now = new Date()
     const promoted: Plant[] = []
     const regular: Plant[] = []
-    filtered.forEach((plant) => {
+    plantsWithImages.forEach((plant) => {
       if (isPlantOfTheMonth(plant, now)) {
         promoted.push(plant)
       } else {
@@ -593,7 +604,7 @@ export default function PlantSwipe() {
       }
     })
     if (promoted.length === 0) {
-      return shuffleList(filtered)
+      return shuffleList(plantsWithImages)
     }
     return [...shuffleList(promoted), ...shuffleList(regular)]
   }, [filtered, shuffleEpoch])

--- a/plant-swipe/src/pages/PlantInfoPage.tsx
+++ b/plant-swipe/src/pages/PlantInfoPage.tsx
@@ -47,6 +47,7 @@ import {
   ShieldCheck,
   User,
   PawPrint,
+  HardHat,
 } from 'lucide-react'
 import type { TooltipProps } from 'recharts'
 import {
@@ -595,14 +596,46 @@ const PlantInfoPage: React.FC = () => {
           )}
         </div>
       </div>
-      <PlantDetails 
-        plant={plant} 
-        liked={likedIds.includes(plant.id)} 
-        onToggleLike={toggleLiked} 
-        onBookmark={handleBookmark}
-        isBookmarked={isBookmarked}
-      />
-      <MoreInformationSection plant={plant} />
+      {/* Check if plant is "In Progress" - show construction message instead of detailed info */}
+      {(plant.meta?.status?.toLowerCase() === 'in progres' || plant.meta?.status?.toLowerCase() === 'in progress') ? (
+        <div className="rounded-3xl border border-amber-200 dark:border-amber-500/30 bg-gradient-to-br from-amber-50 via-white to-amber-100 dark:from-amber-900/20 dark:via-[#1e1e1e] dark:to-amber-900/10 p-8 sm:p-12 text-center space-y-6">
+          <div className="flex justify-center">
+            <div className="p-4 rounded-full bg-amber-100 dark:bg-amber-900/40">
+              <HardHat className="h-12 w-12 text-amber-600 dark:text-amber-400" />
+            </div>
+          </div>
+          <div className="space-y-3">
+            <h2 className="text-2xl sm:text-3xl font-bold text-amber-900 dark:text-amber-100">
+              {t('plantInfo.inConstruction.title', { defaultValue: 'Plant Info in Construction' })}
+            </h2>
+            <p className="text-amber-700 dark:text-amber-300 max-w-lg mx-auto">
+              {t('plantInfo.inConstruction.description', { 
+                defaultValue: 'We are currently verifying and completing the information for this plant. Check back soon for the full details!' 
+              })}
+            </p>
+          </div>
+          {/* Show basic info that we have */}
+          <div className="pt-4 space-y-4 max-w-md mx-auto">
+            <div className="text-left p-4 rounded-2xl bg-white/60 dark:bg-[#1f1f1f]/60 border border-amber-200/50 dark:border-amber-500/20">
+              <h3 className="font-semibold text-lg text-stone-900 dark:text-white">{plant.name}</h3>
+              {plant.identity?.scientificName && (
+                <p className="text-sm italic text-stone-600 dark:text-stone-400">{plant.identity.scientificName}</p>
+              )}
+            </div>
+          </div>
+        </div>
+      ) : (
+        <>
+          <PlantDetails 
+            plant={plant} 
+            liked={likedIds.includes(plant.id)} 
+            onToggleLike={toggleLiked} 
+            onBookmark={handleBookmark}
+            isBookmarked={isBookmarked}
+          />
+          <MoreInformationSection plant={plant} />
+        </>
+      )}
       
       {user?.id && plant && (
         <AddToBookmarkDialog 

--- a/plant-swipe/src/pages/SearchPage.tsx
+++ b/plant-swipe/src/pages/SearchPage.tsx
@@ -5,7 +5,7 @@ import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { useTranslation } from "react-i18next";
-import { Flame, PartyPopper, Sparkles, Loader2 } from "lucide-react";
+import { Flame, PartyPopper, Sparkles, Loader2, Sprout } from "lucide-react";
 import { isNewPlant, isPlantOfTheMonth, isPopularPlant } from "@/lib/plantHighlights";
 import { usePageMetadata } from "@/hooks/usePageMetadata";
 
@@ -129,7 +129,11 @@ export const SearchPage: React.FC<SearchPageProps> = ({
                       decoding="async"
                       className="absolute inset-0 h-full w-full object-cover object-center select-none transition-transform duration-300 group-hover:scale-105"
                     />
-                  ) : null}
+                  ) : (
+                    <div className="absolute inset-0 w-full h-full flex items-center justify-center">
+                      <Sprout className="h-12 w-12 text-emerald-400/50 dark:text-emerald-500/40" />
+                    </div>
+                  )}
                   {highlightBadges.length > 0 && (
                     <div className="absolute top-3 left-3 z-10 flex flex-col gap-2">
                       {highlightBadges.map((badge) => (


### PR DESCRIPTION
Implement 'Plant Info in Construction' for 'In Progress' plants, filter plants without images from the Discovery page, and add a placeholder for missing images in the Encyclopedia to prevent displaying unverified information and improve visual consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-796e69c4-22af-41d1-af26-f812679fa6e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-796e69c4-22af-41d1-af26-f812679fa6e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

