### PR TITLE
Plant name search link

### DIFF
--- a/plant-swipe/src/PlantSwipe.tsx
+++ b/plant-swipe/src/PlantSwipe.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState, lazy, Suspense } from "react";
-import { Routes, Route, useLocation } from "react-router-dom";
+import { Routes, Route, useLocation, useSearchParams } from "react-router-dom";
 import { useLanguageNavigate, usePathWithoutLanguage, addLanguagePrefix } from "@/lib/i18nRouting";
 import { Navigate } from "@/components/i18n/Navigate";
 import { executeRecaptcha } from "@/lib/recaptcha";
@@ -147,6 +147,7 @@ export default function PlantSwipe() {
   const initialCardBoostRef = React.useRef(true)
 
   const location = useLocation()
+  const [searchParams, setSearchParams] = useSearchParams()
   const navigate = useLanguageNavigate()
   const pathWithoutLang = usePathWithoutLanguage()
   const currentView: "landing" | "discovery" | "gardens" | "search" | "profile" | "create" =
@@ -249,6 +250,18 @@ export default function PlantSwipe() {
     const arr = Array.isArray(profile?.liked_plant_ids) ? profile.liked_plant_ids.map(String) : []
     setLikedIds(arr)
   }, [profile])
+
+  // Read search query from URL parameters when on search page
+  React.useEffect(() => {
+    if (pathWithoutLang.startsWith("/search")) {
+      const urlQuery = searchParams.get("q")
+      if (urlQuery && urlQuery !== query) {
+        setQuery(urlQuery)
+        // Clear the URL parameter after setting the query to keep URL clean
+        setSearchParams({}, { replace: true })
+      }
+    }
+  }, [pathWithoutLang, searchParams, setSearchParams]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const loadPlants = React.useCallback(async () => {
     // Only show loading if we don't have plants

--- a/plant-swipe/src/pages/ScanPage.tsx
+++ b/plant-swipe/src/pages/ScanPage.tsx
@@ -27,7 +27,8 @@ import {
   ScanLine,
   Sparkles,
   History,
-  Image as ImageIcon
+  Image as ImageIcon,
+  Search
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { CameraCapture } from '@/components/messaging/CameraCapture'
@@ -485,9 +486,13 @@ export const ScanPage: React.FC = () => {
                       <p className="text-xs font-medium text-emerald-600 dark:text-emerald-400 mb-1">
                         {t('scan.topMatch', { defaultValue: 'Best Match' })}
                       </p>
-                      <h3 className="text-xl font-bold text-stone-900 dark:text-white">
+                      <button
+                        onClick={() => navigate(`/search?q=${encodeURIComponent(currentResult.topMatchName!)}`)}
+                        className="text-xl font-bold text-stone-900 dark:text-white hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors text-left underline decoration-dotted underline-offset-2 cursor-pointer"
+                        title={t('scan.searchForPlant', { defaultValue: 'Search for this plant in our encyclopedia' })}
+                      >
                         {currentResult.topMatchName}
-                      </h3>
+                      </button>
                     </div>
                     {currentResult.topMatchProbability && (
                       <Badge 
@@ -505,11 +510,21 @@ export const ScanPage: React.FC = () => {
                     )}
                   </div>
                   
-                  {/* Link to database plant */}
+                  {/* Search in encyclopedia */}
+                  <Button 
+                    onClick={() => navigate(`/search?q=${encodeURIComponent(currentResult.topMatchName!)}`)}
+                    variant="outline"
+                    className="w-full mt-4 rounded-full gap-2 border-emerald-300 dark:border-emerald-700 hover:bg-emerald-100 dark:hover:bg-emerald-900/30"
+                  >
+                    <Search className="h-4 w-4" />
+                    {t('scan.searchInEncyclopedia', { defaultValue: 'Search in Encyclopedia' })}
+                  </Button>
+                  
+                  {/* Link to database plant (if exact match found) */}
                   {currentResult.matchedPlant && (
                     <Button 
                       onClick={() => goToPlantInfo(currentResult.matchedPlant!.id)}
-                      className="w-full mt-4 rounded-full bg-emerald-600 hover:bg-emerald-700 text-white gap-2"
+                      className="w-full mt-2 rounded-full bg-emerald-600 hover:bg-emerald-700 text-white gap-2"
                     >
                       <ExternalLink className="h-4 w-4" />
                       {t('scan.viewInDatabase', { defaultValue: 'View in Our Database' })}
@@ -526,17 +541,22 @@ export const ScanPage: React.FC = () => {
                   </h4>
                   <div className="space-y-2">
                     {currentResult.suggestions.slice(1, 5).map((suggestion, idx) => (
-                      <div 
+                      <button 
                         key={suggestion.id || idx}
-                        className="flex items-center justify-between p-3 rounded-xl bg-stone-50 dark:bg-stone-800/50"
+                        onClick={() => navigate(`/search?q=${encodeURIComponent(suggestion.name)}`)}
+                        className="flex items-center justify-between p-3 rounded-xl bg-stone-50 dark:bg-stone-800/50 w-full text-left hover:bg-stone-100 dark:hover:bg-stone-700/50 transition-colors cursor-pointer group"
+                        title={t('scan.searchForPlant', { defaultValue: 'Search for this plant in our encyclopedia' })}
                       >
-                        <span className="text-sm text-stone-700 dark:text-stone-300">
+                        <span className="text-sm text-stone-700 dark:text-stone-300 group-hover:text-emerald-600 dark:group-hover:text-emerald-400 transition-colors">
                           {suggestion.name}
                         </span>
-                        <Badge variant="outline" className="rounded-full text-xs">
-                          {formatProbability(suggestion.probability)}
-                        </Badge>
-                      </div>
+                        <div className="flex items-center gap-2">
+                          <Badge variant="outline" className="rounded-full text-xs">
+                            {formatProbability(suggestion.probability)}
+                          </Badge>
+                          <Search className="h-3.5 w-3.5 text-stone-400 opacity-0 group-hover:opacity-100 transition-opacity" />
+                        </div>
+                      </button>
                     ))}
                   </div>
                 </div>


### PR DESCRIPTION
Add clickable links from plant scan results to the encyclopedia search page.

This allows users to easily search for the identified plant or its suggestions within the encyclopedia by pre-filling the search query from the scan result.

---
<a href="https://cursor.com/background-agent?bcId=bc-5149656e-6468-450d-b085-c9862294bdb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5149656e-6468-450d-b085-c9862294bdb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

