### PR TITLE
Message date display error

### DIFF
--- a/plant-swipe/src/components/admin/AdminUserMessagesDialog.tsx
+++ b/plant-swipe/src/components/admin/AdminUserMessagesDialog.tsx
@@ -263,13 +263,14 @@ export const AdminUserMessagesDialog: React.FC<AdminUserMessagesDialogProps> = (
   const isImageMessage = (content: string) => content.startsWith('[image:')
   const parseImageUrl = (content: string) => content.match(/\[image:(.*?)\]/)?.[1] || ''
 
-  // Group messages by date
+  // Group messages by date (using ISO date string YYYY-MM-DD for reliable grouping)
   const groupedMessages = React.useMemo(() => {
     const groups: { date: string; messages: AdminMessage[] }[] = []
     let currentDate = ''
     
     messages.forEach(msg => {
-      const msgDate = new Date(msg.createdAt).toLocaleDateString()
+      // Use ISO date format (YYYY-MM-DD) for grouping to avoid locale parsing issues
+      const msgDate = new Date(msg.createdAt).toISOString().split('T')[0]
       if (msgDate !== currentDate) {
         currentDate = msgDate
         groups.push({ date: msgDate, messages: [] })
@@ -280,9 +281,10 @@ export const AdminUserMessagesDialog: React.FC<AdminUserMessagesDialogProps> = (
     return groups
   }, [messages])
 
-  // Format date separator
+  // Format date separator (expects ISO date string YYYY-MM-DD)
   const formatDateSeparator = (dateStr: string) => {
-    const date = new Date(dateStr)
+    // Parse ISO date string reliably by appending time component
+    const date = new Date(dateStr + 'T12:00:00')
     const today = new Date()
     const yesterday = new Date(today)
     yesterday.setDate(yesterday.getDate() - 1)

--- a/plant-swipe/src/components/messaging/ConversationView.tsx
+++ b/plant-swipe/src/components/messaging/ConversationView.tsx
@@ -642,13 +642,14 @@ export const ConversationView: React.FC<ConversationViewProps> = ({
     textareaRef.current?.focus()
   }
   
-  // Group messages by date
+  // Group messages by date (using ISO date string YYYY-MM-DD for reliable grouping)
   const groupedMessages = React.useMemo(() => {
     const groups: { date: string; messages: Message[] }[] = []
     let currentDate = ''
     
     messages.forEach(msg => {
-      const msgDate = new Date(msg.createdAt).toLocaleDateString()
+      // Use ISO date format (YYYY-MM-DD) for grouping to avoid locale parsing issues
+      const msgDate = new Date(msg.createdAt).toISOString().split('T')[0]
       if (msgDate !== currentDate) {
         currentDate = msgDate
         groups.push({ date: msgDate, messages: [] })
@@ -659,9 +660,10 @@ export const ConversationView: React.FC<ConversationViewProps> = ({
     return groups
   }, [messages])
   
-  // Format date for separator
+  // Format date for separator (expects ISO date string YYYY-MM-DD)
   const formatDateSeparator = (dateStr: string) => {
-    const date = new Date(dateStr)
+    // Parse ISO date string reliably by appending time component
+    const date = new Date(dateStr + 'T12:00:00')
     const today = new Date()
     const yesterday = new Date(today)
     yesterday.setDate(yesterday.getDate() - 1)


### PR DESCRIPTION
Fixes incorrect message date display by using unambiguous ISO date format for grouping and parsing.

The previous implementation converted timestamps to locale date strings (e.g., "11/1/2025") and then re-parsed them with `new Date()`. This led to incorrect date interpretation (e.g., "11/1/2025" being parsed as November 1st instead of January 11th) due to JavaScript's `Date` constructor defaulting to US MM/DD/YYYY format for ambiguous strings. This PR ensures dates are correctly interpreted by using ISO date format (YYYY-MM-DD) for grouping and parsing.

---
<a href="https://cursor.com/background-agent?bcId=bc-95103c2d-604f-45ad-815e-e209163d6b54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-95103c2d-604f-45ad-815e-e209163d6b54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

