### PR TITLE
AI garden information context

### DIFF
--- a/plant-swipe/src/types/aphyliaChat.ts
+++ b/plant-swipe/src/types/aphyliaChat.ts
@@ -66,6 +66,26 @@ export interface GardenPlantSummary {
   healthStatus?: string | null
   plantsOnHand?: number
   seedsPlanted?: number
+  taskCount?: number
+}
+
+export interface GardenTaskStats {
+  totalTasksToday: number
+  completedTasksToday: number
+  pendingTasksToday: number
+  totalTasksThisWeek: number
+  completedTasksThisWeek: number
+  tasksByType: Record<string, number>
+}
+
+export interface GardenTaskSummary {
+  taskId?: string
+  taskType?: string
+  plantName: string
+  dueAt: string
+  requiredCount?: number
+  completedCount?: number
+  isCompleted: boolean
 }
 
 export interface GardenContext {
@@ -78,6 +98,10 @@ export interface GardenContext {
   locationLon?: number | null
   plantCount?: number
   memberCount?: number
+  /** Total plants currently on hand */
+  totalPlantsOnHand?: number
+  /** Total seeds planted */
+  totalSeedsPlanted?: number
   /** Garden members with basic info */
   members?: GardenMemberContext[]
   /** Summary of plants in the garden */
@@ -90,6 +114,12 @@ export interface GardenContext {
   createdAt?: string
   /** Preferred language for advice */
   adviceLanguage?: string | null
+  /** Task statistics for today and this week */
+  taskStats?: GardenTaskStats
+  /** Today's tasks with details */
+  todayTasks?: GardenTaskSummary[]
+  /** This week's tasks (limited) */
+  weekTasks?: GardenTaskSummary[]
 }
 
 export interface PlantContext {


### PR DESCRIPTION
Enhance AI chat context in garden pages to provide comprehensive garden information.

The AI chat previously only received minimal garden context (`gardenId`, `gardenName`), leading to generic responses. This PR ensures the AI receives full garden details (members, plants, location, settings) directly from the frontend, with a backend fallback, for more accurate and relevant advice.

---
<a href="https://cursor.com/background-agent?bcId=bc-194fffda-9c8b-4c2b-a90b-be64fb1970af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-194fffda-9c8b-4c2b-a90b-be64fb1970af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

