### PR TITLE
Bun availability for translations

### DIFF
--- a/.github/workflows/check-translations.yml
+++ b/.github/workflows/check-translations.yml
@@ -23,6 +23,11 @@ jobs:
           cache: 'npm'
           cache-dependency-path: plant-swipe/package-lock.json
       
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      
       - name: Install dependencies
         working-directory: plant-swipe
         run: npm ci


### PR DESCRIPTION
Add Bun setup to the `check-translations` GitHub Actions workflow because the script now uses Bun, which was previously unavailable in CI.

---
<a href="https://cursor.com/background-agent?bcId=bc-b3eeae8e-9c22-40c4-ac71-a91dfd68a7ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b3eeae8e-9c22-40c4-ac71-a91dfd68a7ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

