### PR TITLE
AI plant fill trim error

### DIFF
--- a/plant-swipe/src/lib/aiPrefillService.ts
+++ b/plant-swipe/src/lib/aiPrefillService.ts
@@ -163,7 +163,9 @@ async function upsertImages(plantId: string, images: Plant["images"]) {
   
   const seenLinks = new Set<string>()
   const filtered = list.filter((img) => {
-    const link = img.link?.trim()
+    // Ensure link is a string before calling trim() - AI might return objects
+    if (typeof img.link !== 'string') return false
+    const link = img.link.trim()
     if (!link) return false
     const linkLower = link.toLowerCase()
     if (seenLinks.has(linkLower)) return false

--- a/plant-swipe/src/lib/composition.ts
+++ b/plant-swipe/src/lib/composition.ts
@@ -60,7 +60,9 @@ export function expandCompositionFromDb(values?: string[] | null): CompositionUi
   if (!values?.length) return []
   const result: CompositionUiValue[] = []
   for (const raw of values) {
-    const trimmed = raw?.trim().toLowerCase()
+    // Ensure raw is a string before calling trim() - AI might return objects
+    if (typeof raw !== 'string') continue
+    const trimmed = raw.trim().toLowerCase()
     if (!trimmed) continue
     const uiValue = DB_TO_UI_MAP[trimmed as CompositionDbValue]
     if (uiValue && !result.includes(uiValue)) {

--- a/plant-swipe/src/lib/plantTranslationLoader.ts
+++ b/plant-swipe/src/lib/plantTranslationLoader.ts
@@ -407,9 +407,12 @@ export async function loadPlantsWithTranslations(language: SupportedLanguage): P
 
         const infusionMixRows = ((basePlant.plant_infusion_mixes as any[]) || [])
         const infusionMix = infusionMixRows.reduce((acc: Record<string, string>, row) => {
-          const key = row?.mix_name?.trim()
+          // Ensure mix_name is a string before calling trim()
+          if (typeof row?.mix_name !== 'string') return acc
+          const key = row.mix_name.trim()
           if (!key) return acc
-          acc[key] = row?.benefit?.trim() || ''
+          // Ensure benefit is a string before calling trim()
+          acc[key] = typeof row?.benefit === 'string' ? row.benefit.trim() : ''
           return acc
         }, {} as Record<string, string>)
 


### PR DESCRIPTION
Fixes "a?.trim is not a function" errors by adding type checks before calling `.trim()` on AI-generated data.

The AI fill functionality was occasionally returning objects instead of strings, causing runtime errors when `.trim()` was called on these non-string values.

---
<a href="https://cursor.com/background-agent?bcId=bc-5312e6d7-f888-4dec-badd-60db6f68c8aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5312e6d7-f888-4dec-badd-60db6f68c8aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

