### PR TITLE
Ai fill popup inconsistencies

### DIFF
--- a/plant-swipe/src/pages/CreatePlantPage.tsx
+++ b/plant-swipe/src/pages/CreatePlantPage.tsx
@@ -1114,7 +1114,7 @@ export const CreatePlantPage: React.FC<{ onCancel: () => void; onSaved?: (id: st
     })
   }
 
-    const savePlant = async (plantOverride?: Plant) => {
+    const savePlant = async (plantOverride?: Plant, options?: { skipOnSaved?: boolean }) => {
       const saveLanguage = language
       const plantToSave = plantOverride || plant
       const trimmedName = plantToSave.name && typeof plantToSave.name === 'string' ? plantToSave.name.trim() : ''
@@ -1423,7 +1423,10 @@ export const CreatePlantPage: React.FC<{ onCancel: () => void; onSaved?: (id: st
             setLoadedLanguages(prev => new Set(prev).add(saveLanguage))
           }
         if (isEnglish && !existingLoaded) setExistingLoaded(true)
-        onSaved?.(savedId)
+        // Only call onSaved if not explicitly skipped (e.g., during AI fill auto-save)
+        if (!options?.skipOnSaved) {
+          onSaved?.(savedId)
+        }
         } catch (e: any) {
           // Use parseSupabaseError for user-friendly messages
           const userFriendlyError = parseSupabaseError(e, 'Please check the plant details.')
@@ -1670,7 +1673,9 @@ export const CreatePlantPage: React.FC<{ onCancel: () => void; onSaved?: (id: st
         setAiSectionLog([])
       }
       const targetPlant = finalPlant || plant
-      if (targetPlant) await savePlant(targetPlant)
+      // Auto-save after AI fill but skip onSaved to prevent popup from closing
+      // User can review the AI-filled data and manually save/close when ready
+      if (targetPlant) await savePlant(targetPlant, { skipOnSaved: true })
     }
   }
 


### PR DESCRIPTION
Prevent the Plant Admin Request popup from closing immediately after AI Fill, allowing users to review AI-generated content and visible name updates.

The AI Fill's auto-save was prematurely triggering the `onSaved` callback, which closed the dialog before users could review the AI-filled data. This change modifies `savePlant` to accept a `skipOnSaved` option, which is now used during AI Fill's auto-save to keep the dialog open.

---
<a href="https://cursor.com/background-agent?bcId=bc-f194d4d3-7656-43dc-afc8-f625b3ecac93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f194d4d3-7656-43dc-afc8-f625b3ecac93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

