### PR TITLE
Github actions cache error

### DIFF
--- a/.github/workflows/check-translations.yml
+++ b/.github/workflows/check-translations.yml
@@ -20,8 +20,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: plant-swipe/package-lock.json
       
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -30,7 +28,7 @@ jobs:
       
       - name: Install dependencies
         working-directory: plant-swipe
-        run: npm ci
+        run: bun install --frozen-lockfile
       
       - name: Check translation consistency
         working-directory: plant-swipe


### PR DESCRIPTION
Fix GitHub Actions workflow by removing npm caching and using `bun install` because the project uses Bun, not npm.

The workflow was failing with "Error: Some specified paths were not resolved, unable to cache dependencies" because it was configured to cache npm dependencies using `package-lock.json`, which does not exist in this Bun-based project. This PR resolves the error by removing the incorrect npm caching setup and updating the dependency installation command to `bun install --frozen-lockfile` to correctly use Bun.

---
<a href="https://cursor.com/background-agent?bcId=bc-15af9929-065e-4ee8-a6a5-1411c120d210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-15af9929-065e-4ee8-a6a5-1411c120d210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

