### PR TITLE
Scan page syntax errors

### DIFF
--- a/plant-swipe/src/pages/ScanPage.tsx
+++ b/plant-swipe/src/pages/ScanPage.tsx
@@ -477,6 +477,7 @@ export const ScanPage: React.FC = () => {
           </p>
         </Card>
       ) : (
+        <>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           {scans.map((scan) => {
             const confidence = scan.topMatchProbability 
@@ -586,6 +587,7 @@ export const ScanPage: React.FC = () => {
             </Button>
           </div>
         )}
+        </>
       )}
       
       {/* Camera Dialog */}


### PR DESCRIPTION
Wrap adjacent JSX elements in a React Fragment to fix TypeScript syntax errors.

The ternary expression in `ScanPage.tsx` was returning two sibling elements (the grid `<div>` and the "Load More Button" block), which is not allowed in JSX. Wrapping them in a React Fragment resolves the TS1005 and TS1381 errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-5666a92e-9b50-4400-b837-c31a97c6fed0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5666a92e-9b50-4400-b837-c31a97c6fed0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

