### PR TITLE
Plant info page types

### DIFF
--- a/plant-swipe/src/pages/PlantInfoPage.tsx
+++ b/plant-swipe/src/pages/PlantInfoPage.tsx
@@ -1087,13 +1087,13 @@ const MoreInformationSection: React.FC<{ plant: Plant }> = ({ plant }) => {
           )
         }
         
-        const results = await Promise.all(queries)
+        const [plantsRes, imagesRes, translationsRes] = await Promise.all(queries)
         
         if (ignore) return
         
-        const plantsData = plantsRes.data
-        const imagesData = imagesRes.data
-        const translationsData = translationsRes.data
+        const plantsData = plantsRes?.data
+        const imagesData = imagesRes?.data
+        const translationsData = translationsRes?.data
         
         if (!plantsData?.length) {
           setCompanionPlants([])
@@ -1103,7 +1103,7 @@ const MoreInformationSection: React.FC<{ plant: Plant }> = ({ plant }) => {
         
         const imageMap = new Map<string, string>()
         if (imagesData) {
-          imagesData.forEach((img) => {
+          imagesData.forEach((img: { plant_id: string; link: string }) => {
             if (img.plant_id && img.link) {
               imageMap.set(img.plant_id, img.link)
             }
@@ -1119,7 +1119,7 @@ const MoreInformationSection: React.FC<{ plant: Plant }> = ({ plant }) => {
           })
         }
         
-        const companions = plantsData.map((p) => ({
+        const companions = plantsData.map((p: { id: string; name: string }) => ({
           id: p.id,
           name: nameTranslations[p.id] || p.name,
           imageUrl: imageMap.get(p.id),


### PR DESCRIPTION
Fix TypeScript errors in `PlantInfoPage.tsx` related to promise destructuring, undefined variables, and implicit `any` types.

The original code failed to correctly destructure the results of `Promise.all`, leading to `TS2304` errors for `plantsRes`, `imagesRes`, and `translationsRes`. Additionally, `TS7006` errors for implicit `any` types on `img` and `p` parameters were resolved by adding explicit type annotations. Optional chaining was also added for safer data access.

---
<a href="https://cursor.com/background-agent?bcId=bc-ad764396-ce9e-4429-8db1-41dbac76aeb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ad764396-ce9e-4429-8db1-41dbac76aeb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

