### PR TITLE
Csp aphylia.app domains

### DIFF
--- a/plant-swipe.conf
+++ b/plant-swipe.conf
@@ -51,11 +51,29 @@ server {
     root /var/www/PlantSwipe/plant-swipe/dist;
     index index.html;
 
+    # Content Security Policy - Allow all *.aphylia.app subdomains EXCEPT for images
+    # img-src and media-src allow all sources; other directives restrict to aphylia.app domains
+    set $csp_policy "default-src 'self' *.aphylia.app; ";
+    set $csp_policy "${csp_policy}script-src 'self' 'unsafe-inline' 'unsafe-eval' *.aphylia.app https://www.googletagmanager.com https://www.google.com https://www.gstatic.com https://recaptchaenterprise.googleapis.com; ";
+    set $csp_policy "${csp_policy}style-src 'self' 'unsafe-inline' *.aphylia.app https://fonts.googleapis.com; ";
+    set $csp_policy "${csp_policy}connect-src 'self' *.aphylia.app wss://*.aphylia.app https://*.supabase.co wss://*.supabase.co https://www.google-analytics.com https://analytics.google.com https://region1.google-analytics.com https://recaptchaenterprise.googleapis.com; ";
+    set $csp_policy "${csp_policy}font-src 'self' *.aphylia.app https://fonts.gstatic.com data:; ";
+    set $csp_policy "${csp_policy}frame-src 'self' *.aphylia.app https://www.google.com https://recaptcha.google.com; ";
+    set $csp_policy "${csp_policy}img-src * data: blob:; ";
+    set $csp_policy "${csp_policy}media-src * data: blob:; ";
+    set $csp_policy "${csp_policy}object-src 'none'; ";
+    set $csp_policy "${csp_policy}base-uri 'self'; ";
+    set $csp_policy "${csp_policy}form-action 'self' *.aphylia.app; ";
+    set $csp_policy "${csp_policy}worker-src 'self' *.aphylia.app blob:; ";
+    set $csp_policy "${csp_policy}manifest-src 'self' *.aphylia.app";
+    add_header Content-Security-Policy $csp_policy always;
+
     location /assets/ {
         try_files $uri =404;
         access_log off;
         expires 7d;
         add_header Cache-Control "public, max-age=604800";
+        add_header Content-Security-Policy $csp_policy always;
     }
 
     # Proxy API requests to the Node server (Express)
@@ -162,6 +180,7 @@ server {
         access_log off;
         expires 7d;
         add_header Cache-Control "public, max-age=604800";
+        add_header Content-Security-Policy $csp_policy always;
     }
     
     # Locales and icons - serve directly

--- a/plant-swipe/server.js
+++ b/plant-swipe/server.js
@@ -2891,6 +2891,29 @@ app.options('/api/*', (_req, res) => {
   res.status(204).end()
 })
 
+// Content Security Policy - Allow all *.aphylia.app subdomains EXCEPT for images
+// img-src and media-src allow all sources; other directives restrict to aphylia.app domains
+const CSP_POLICY = [
+  "default-src 'self' *.aphylia.app",
+  "script-src 'self' 'unsafe-inline' 'unsafe-eval' *.aphylia.app https://www.googletagmanager.com https://www.google.com https://www.gstatic.com https://recaptchaenterprise.googleapis.com",
+  "style-src 'self' 'unsafe-inline' *.aphylia.app https://fonts.googleapis.com",
+  "connect-src 'self' *.aphylia.app wss://*.aphylia.app https://*.supabase.co wss://*.supabase.co https://www.google-analytics.com https://analytics.google.com https://region1.google-analytics.com https://recaptchaenterprise.googleapis.com",
+  "font-src 'self' *.aphylia.app https://fonts.gstatic.com data:",
+  "frame-src 'self' *.aphylia.app https://www.google.com https://recaptcha.google.com",
+  "img-src * data: blob:",
+  "media-src * data: blob:",
+  "object-src 'none'",
+  "base-uri 'self'",
+  "form-action 'self' *.aphylia.app",
+  "worker-src 'self' *.aphylia.app blob:",
+  "manifest-src 'self' *.aphylia.app"
+].join('; ')
+
+app.use((_req, res, next) => {
+  res.setHeader('Content-Security-Policy', CSP_POLICY)
+  next()
+})
+
 // Supabase service client disabled to avoid using service-role env vars
 const supabaseAdmin = null
 


### PR DESCRIPTION
Implement Content-Security-Policy (CSP) headers to authorize `*.aphylia.app` subdomains while allowing all sources for images and media.

---
<a href="https://cursor.com/background-agent?bcId=bc-d89f8858-9809-4ad7-990b-cb91e9260119"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d89f8858-9809-4ad7-990b-cb91e9260119"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

