### PR TITLE
Garden notification delivery

### DIFF
--- a/plant-swipe/src/components/admin/AdminNotificationsPanel.tsx
+++ b/plant-swipe/src/components/admin/AdminNotificationsPanel.tsx
@@ -94,6 +94,7 @@ type NotificationAutomation = {
   lastRunAt: string | null
   lastRunSummary: Record<string, unknown> | null
   recipientCount: number
+  sentTodayCount: number
   createdAt: string
   updatedAt: string
 }
@@ -1043,7 +1044,12 @@ export function AdminNotificationsPanel() {
                 {automations.map((automation) => (
                   <div
                     key={automation.id}
-                    className="rounded-xl sm:rounded-2xl border border-stone-200 dark:border-[#3e3e42] bg-white dark:bg-[#1e1e20] p-5 sm:p-6"
+                    className={cn(
+                      "rounded-xl sm:rounded-2xl border p-5 sm:p-6 transition-all",
+                      automation.sentTodayCount > 0
+                        ? "border-emerald-200 dark:border-emerald-800 bg-emerald-50/50 dark:bg-emerald-900/10"
+                        : "border-stone-200 dark:border-[#3e3e42] bg-white dark:bg-[#1e1e20]"
+                    )}
                   >
                     <div className="flex flex-col sm:flex-row sm:items-start gap-4">
                       {/* Icon and Info */}
@@ -1063,7 +1069,7 @@ export function AdminNotificationsPanel() {
                         </div>
 
                         <div className="flex-1 min-w-0">
-                          <div className="flex items-center gap-2 mb-1">
+                          <div className="flex items-center gap-2 mb-1 flex-wrap">
                             <h3 className="font-semibold text-stone-900 dark:text-white text-base sm:text-lg">
                               {automation.displayName}
                             </h3>
@@ -1075,6 +1081,12 @@ export function AdminNotificationsPanel() {
                             )}>
                               {automation.isEnabled ? "Active" : "Disabled"}
                             </span>
+                            {automation.sentTodayCount > 0 && (
+                              <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-400 flex items-center gap-1">
+                                <CheckCircle2 className="h-3 w-3" />
+                                {automation.sentTodayCount} sent today
+                              </span>
+                            )}
                           </div>
 
                           {automation.description && (


### PR DESCRIPTION
Update notification automation queries to use the server's local timezone as a default fallback instead of UTC, fixing undelivered notifications for users without a set timezone.

The previous implementation defaulted to UTC when a user's `timezone` profile field was `NULL`. This caused issues for time-based automations (e.g., "send at 3 PM local time") because the system would compare the automation's `sendHour` with the current UTC hour, not the user's local time. By defaulting to the server's system timezone, notifications will now be correctly triggered for users whose timezone is not explicitly set but are in the same timezone as the server. Added logging will help diagnose future timing issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-1c387d22-c62c-4505-a203-8f16ffb55ec0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1c387d22-c62c-4505-a203-8f16ffb55ec0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

