### PR TITLE
Sitemap blog links

### DIFF
--- a/plant-swipe/scripts/generate-sitemap.js
+++ b/plant-swipe/scripts/generate-sitemap.js
@@ -437,9 +437,10 @@ async function loadBlogRoutes() {
     return []
   }
 
+  // Select id instead of slug - frontend blog links use /blog/{id} format
   const { data, error } = await client
     .from('blog_posts')
-    .select('slug, updated_at, created_at, published_at')
+    .select('id, updated_at, created_at, published_at')
     .eq('is_published', true)
     .order('published_at', { ascending: false })
 
@@ -453,10 +454,11 @@ async function loadBlogRoutes() {
   // The most recent post gets priority 0.95 (second only to homepage)
   // Other posts get standard priority 0.8
   return data.map((post, index) => {
-    if (!post.slug) return null
+    if (!post.id) return null
     const isLatestPost = index === 0
+    const normalizedId = encodeURIComponent(String(post.id))
     return {
-      path: `/blog/${post.slug}`,
+      path: `/blog/${normalizedId}`,
       changefreq: isLatestPost ? 'daily' : 'weekly',
       priority: isLatestPost ? 0.95 : 0.8,
       lastmod: pickLastmod(post),


### PR DESCRIPTION
Correct sitemap blog post URLs to use `id` instead of `slug` to match frontend routing.

---
<a href="https://cursor.com/background-agent?bcId=bc-e3483e33-90bc-4fb7-8c81-9920d031ab64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e3483e33-90bc-4fb7-8c81-9920d031ab64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

