### PR TITLE
Sentry beforeSend types

### DIFF
--- a/plant-swipe/src/lib/sentry.ts
+++ b/plant-swipe/src/lib/sentry.ts
@@ -64,7 +64,7 @@ export function hasTrackingConsent(): boolean {
  * Scrub PII from event before sending to Sentry
  * GDPR compliance: Remove or hash personally identifiable information
  */
-function scrubPII(event: Sentry.Event): Sentry.Event {
+function scrubPII<T extends Sentry.Event>(event: T): T {
   // Remove or hash email addresses in event data
   if (event.user) {
     // Keep only anonymous ID, remove PII


### PR DESCRIPTION
Make `scrubPII` function generic to resolve a TypeScript type incompatibility in Sentry's `beforeSend` callback.

The `beforeSend` callback expected an `ErrorEvent` but `scrubPII` was returning a generic `Sentry.Event`, leading to a type error. By making `scrubPII` generic, it now correctly preserves the input `ErrorEvent` type.

---
<a href="https://cursor.com/background-agent?bcId=bc-cddc913e-ffca-44ba-8922-fe07a75f0d5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cddc913e-ffca-44ba-8922-fe07a75f0d5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

