### PR TITLE
Plant construction icon

### DIFF
--- a/plant-swipe/src/pages/PlantInfoPage.tsx
+++ b/plant-swipe/src/pages/PlantInfoPage.tsx
@@ -49,7 +49,7 @@ import {
   ShieldCheck,
   User,
   PawPrint,
-  HardHat,
+  FlaskConical,
   Clock,
   CalendarDays,
   FileText,
@@ -722,7 +722,7 @@ const PlantInfoPage: React.FC = () => {
           <div className="p-6 sm:p-8 text-center border-b border-amber-200/50 dark:border-amber-500/20 bg-amber-50/50 dark:bg-amber-900/10">
             <div className="flex justify-center mb-4">
               <div className="p-3 rounded-full bg-amber-100 dark:bg-amber-900/40">
-                <HardHat className="h-8 w-8 text-amber-600 dark:text-amber-400" />
+                <FlaskConical className="h-8 w-8 text-amber-600 dark:text-amber-400" />
               </div>
             </div>
             <h2 className="text-xl sm:text-2xl font-bold text-amber-900 dark:text-amber-100 mb-2">
@@ -951,7 +951,7 @@ const PlantInfoPage: React.FC = () => {
             <div className="rounded-3xl border border-amber-200 dark:border-amber-500/30 bg-gradient-to-br from-amber-50 via-white to-amber-100 dark:from-amber-900/20 dark:via-[#1e1e1e] dark:to-amber-900/10 p-8 sm:p-12 text-center space-y-6">
               <div className="flex justify-center">
                 <div className="p-4 rounded-full bg-amber-100 dark:bg-amber-900/40">
-                  <HardHat className="h-12 w-12 text-amber-600 dark:text-amber-400" />
+                  <FlaskConical className="h-12 w-12 text-amber-600 dark:text-amber-400" />
                 </div>
               </div>
               <div className="space-y-3">
@@ -983,7 +983,7 @@ const PlantInfoPage: React.FC = () => {
             {isInConstruction && hasPrivilegedAccess && (
               <div className="rounded-2xl border border-amber-300 dark:border-amber-500/40 bg-gradient-to-r from-amber-50 to-amber-100 dark:from-amber-900/30 dark:to-amber-800/20 p-4 sm:p-5 flex items-center gap-4">
                 <div className="shrink-0 p-2.5 rounded-full bg-amber-200 dark:bg-amber-800/50">
-                  <HardHat className="h-6 w-6 text-amber-700 dark:text-amber-300" />
+                  <FlaskConical className="h-6 w-6 text-amber-700 dark:text-amber-300" />
                 </div>
                 <div className="flex-1 min-w-0">
                   <h3 className="font-semibold text-amber-900 dark:text-amber-100">

--- a/plant-swipe/src/pages/SearchPage.tsx
+++ b/plant-swipe/src/pages/SearchPage.tsx
@@ -5,7 +5,7 @@ import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { useTranslation } from "react-i18next";
-import { Flame, PartyPopper, Sparkles, Loader2, Sprout, HardHat, ArrowUp } from "lucide-react";
+import { Flame, PartyPopper, Sparkles, Loader2, Sprout, FlaskConical, ArrowUp } from "lucide-react";
 import { isNewPlant, isPlantOfTheMonth, isPopularPlant } from "@/lib/plantHighlights";
 import { usePageMetadata } from "@/hooks/usePageMetadata";
 
@@ -174,7 +174,7 @@ export const SearchPage: React.FC<SearchPageProps> = ({
                   {isInProgress && (
                     <div className="absolute bottom-2 right-2 z-10">
                       <Badge className="rounded-full p-1.5 bg-amber-400 dark:bg-amber-500/80 text-amber-900 dark:text-amber-100">
-                        <HardHat className="h-3 w-3" />
+                        <FlaskConical className="h-3 w-3" />
                       </Badge>
                     </div>
                   )}
@@ -220,7 +220,7 @@ export const SearchPage: React.FC<SearchPageProps> = ({
                   {isInProgress && (
                     <div className="absolute bottom-3 right-3 z-10">
                       <Badge className="rounded-full p-2 bg-amber-400 dark:bg-amber-500/80 text-amber-900 dark:text-amber-100">
-                        <HardHat className="h-5 w-5" />
+                        <FlaskConical className="h-5 w-5" />
                       </Badge>
                     </div>
                   )}


### PR DESCRIPTION
Replace the `HardHat` icon with `FlaskConical` for plants under construction to improve clarity and understanding.

The `HardHat` icon was perceived as too complex and less intuitive for representing "work in progress" or "research" status compared to the `FlaskConical` icon.

---
<a href="https://cursor.com/background-agent?bcId=bc-4ca723a1-7282-4f41-8309-6109cdc7a608"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4ca723a1-7282-4f41-8309-6109cdc7a608"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

