### PR TITLE
Landing page data erasure

### DIFF
--- a/plant-swipe/supabase/000_sync_schema.sql
+++ b/plant-swipe/supabase/000_sync_schema.sql
@@ -9371,6 +9371,11 @@ create policy "Admins can manage landing stats" on public.landing_stats for all 
   exists (select 1 from public.profiles where id = auth.uid() and is_admin = true)
 );
 
+-- Insert default stats row if not exists
+insert into public.landing_stats (id)
+select gen_random_uuid()
+where not exists (select 1 from public.landing_stats limit 1);
+
 alter table public.landing_stats_translations enable row level security;
 drop policy if exists "Landing stats translations are publicly readable" on public.landing_stats_translations;
 create policy "Landing stats translations are publicly readable" on public.landing_stats_translations for select using (true);


### PR DESCRIPTION
Add a default INSERT statement for `landing_stats` to prevent data loss during `000_sync_sql` operations.

The `landing_stats` table, unlike other single-row landing tables, lacked a default row. This meant if the table became empty, related `landing_stats_translations` data (which has `ON DELETE CASCADE`) could be lost. This change ensures the table is always initialized, preserving data integrity.

---
<a href="https://cursor.com/background-agent?bcId=bc-99d51663-0c53-48be-8ea8-3153ee7df87a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-99d51663-0c53-48be-8ea8-3153ee7df87a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

