### PR TITLE
🎨 Palette: Add contextual ARIA labels to garden buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -21,3 +21,7 @@
 ## 2025-05-24 - Invisible Focusable Elements
 **Learning:** The "Remove Photo" button in the journal upload section was only visible on hover (`opacity-0`), making it invisible to keyboard users even when focused.
 **Action:** Always ensure interactive elements that are hidden by default become fully visible on focus (`focus:opacity-100`) to support keyboard navigation.
+
+## 2025-05-25 - Contextual Accessibility Labels
+**Learning:** Generic "Complete All" buttons are ambiguous for screen reader users when multiple lists (e.g., plants) appear on the same page. Adding the plant or garden name to `aria-label` provides necessary context.
+**Action:** Always interpolate the specific object name (Plant, Garden) into the `aria-label` of generic action buttons.

--- a/plant-swipe/src/components/garden/GardenListSidebar.tsx
+++ b/plant-swipe/src/components/garden/GardenListSidebar.tsx
@@ -175,6 +175,7 @@ const GardenListSidebarComponent: React.FC<GardenListSidebarProps> = ({
               className="rounded-2xl w-full"
               onClick={onMarkAllCompleted}
               disabled={markingAllCompleted}
+              aria-label={t("garden.markAllCompletedLabel", { defaultValue: "Mark all tasks in all gardens as completed" })}
             >
               {markingAllCompleted ? (
                 <span className="flex items-center gap-2">
@@ -240,6 +241,7 @@ const GardenListSidebarComponent: React.FC<GardenListSidebarProps> = ({
                     className="rounded-xl flex-shrink-0"
                     onClick={() => onCompleteAllForGarden(gw.gardenId)}
                     disabled={completingGardenIds.has(gw.gardenId)}
+                    aria-label={t("garden.completeAllFor", { defaultValue: "Complete all tasks for {{name}}", name: gw.gardenName })}
                   >
                     {completingGardenIds.has(gw.gardenId) ? (
                       <span className="flex items-center gap-1">

--- a/plant-swipe/src/components/garden/GardenTasksSection.tsx
+++ b/plant-swipe/src/components/garden/GardenTasksSection.tsx
@@ -486,6 +486,7 @@ export const GardenTasksSection: React.FC<GardenTasksSectionProps> = ({
                           className="rounded-xl text-xs h-8 px-3 flex-shrink-0 border-2 border-emerald-400 dark:border-emerald-500 text-emerald-600 dark:text-emerald-400 hover:bg-emerald-50 dark:hover:bg-emerald-900/30 font-semibold transition-all"
                           onClick={() => completeAllTodayForPlant(plant.id)}
                           disabled={isCompleting}
+                          aria-label={t("garden.completeAllFor", { defaultValue: "Complete all tasks for {{name}}", name: plant.nickname || plant.plant?.name || "Plant" })}
                         >
                           {isCompleting ? (
                             <Loader2 className="w-3.5 h-3.5 animate-spin" />
@@ -560,6 +561,7 @@ export const GardenTasksSection: React.FC<GardenTasksSectionProps> = ({
                               className={`rounded-xl h-9 px-4 text-xs font-semibold flex-shrink-0 border-2 transition-all ${config.buttonOutline}`}
                               onClick={() => onProgressOccurrence(occ.id, remaining)}
                               disabled={isProgressing}
+                              aria-label={`${t("garden.complete", "Complete")} ${t(`garden.taskTypes.${taskType}`, taskType)} ${t("garden.activity.for", "for")} ${plant.nickname || plant.plant?.name || "Plant"}`}
                             >
                               {isProgressing ? (
                                 <Loader2 className="w-4 h-4 animate-spin" />

--- a/plant-swipe/src/components/garden/TodaysTasksWidget.tsx
+++ b/plant-swipe/src/components/garden/TodaysTasksWidget.tsx
@@ -194,6 +194,7 @@ export const TodaysTasksWidget: React.FC<TodaysTasksWidgetProps> = ({
                     className="h-6 md:h-7 text-[10px] md:text-xs rounded-lg px-2 border-2 border-emerald-400 dark:border-emerald-500 text-emerald-600 dark:text-emerald-400 hover:bg-emerald-50 dark:hover:bg-emerald-900/30 font-semibold transition-all"
                     onClick={() => completeAllTodayForPlant(plant.id)}
                     disabled={isCompleting}
+                    aria-label={t("garden.completeAllFor", { defaultValue: "Complete all tasks for {{name}}", name: plant.nickname || plant.plant?.name || "Plant" })}
                   >
                     {isCompleting ? (
                       <Loader2 className="w-3 h-3 animate-spin" />

--- a/plant-swipe/src/pages/GardenDashboardPage.tsx
+++ b/plant-swipe/src/pages/GardenDashboardPage.tsx
@@ -2920,6 +2920,7 @@ export const GardenDashboardPage: React.FC = () => {
                                       onTouchStart={(e: React.TouchEvent) => e.stopPropagation()}
                                       disabled={completingPlantIds.has(gp.id)}
                                       onClick={() => completeAllTodayForPlant(gp.id)}
+                                      aria-label={t("garden.completeAllFor", { defaultValue: "Complete all tasks for {{name}}", name: gp.nickname || gp.plant?.name || "Plant" })}
                                     >
                                       {completingPlantIds.has(gp.id) ? (
                                         <span className="animate-pulse">...</span>
@@ -3911,6 +3912,7 @@ function RoutineSection({
                       className="rounded-xl"
                       onClick={() => completeAllTodayForPlant(gp.id)}
                       disabled={completingPlantIds.has(gp.id)}
+                      aria-label={t("garden.completeAllFor", { defaultValue: "Complete all tasks for {{name}}", name: gp.nickname || gp.plant?.name || "Plant" })}
                     >
                       {completingPlantIds.has(gp.id) ? (
                         <span className="flex items-center gap-1">


### PR DESCRIPTION
This PR improves accessibility by adding contextual `aria-label` attributes to "Complete All" and "Complete" buttons in the garden dashboard and sidebar. Previously, these buttons only had generic text or icons, making them ambiguous for screen reader users when multiple plants or tasks were listed. Now, the labels explicitly state which plant or garden the action applies to (e.g., "Complete all tasks for Monstera").

---
*PR created automatically by Jules for task [12334931445863969967](https://jules.google.com/task/12334931445863969967) started by @FrenchFive*