### PR TITLE
Legal document Aphylia conflict

### DIFF
--- a/plant-swipe/src/components/LegalUpdateModal.tsx
+++ b/plant-swipe/src/components/LegalUpdateModal.tsx
@@ -169,6 +169,8 @@ export function LegalUpdateModal({
         onPointerDownOutside={(e) => e.preventDefault()}
         onEscapeKeyDown={(e) => e.preventDefault()}
         hideCloseButton
+        // Use very high z-index to ensure legal modal appears above ServiceWorkerToast (z-9999)
+        priorityZIndex={10000}
       >
         {step === 'review' ? (
           <>

--- a/plant-swipe/src/components/ui/dialog.tsx
+++ b/plant-swipe/src/components/ui/dialog.tsx
@@ -17,13 +17,14 @@ const DialogClose = DialogPrimitive.Close
 const DialogOverlay = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Overlay>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
->(({ className, ...props }, ref) => (
+>(({ className, style, ...props }, ref) => (
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
       "fixed inset-0 z-[60] bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
+    style={style}
     {...props}
   />
 ))
@@ -31,14 +32,18 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
 
 interface DialogContentProps extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> {
   hideCloseButton?: boolean
+  /** Class name to apply to the overlay (useful for z-index overrides) */
+  overlayClassName?: string
+  /** Custom z-index for high-priority modals (applies to both overlay and content) */
+  priorityZIndex?: number
 }
 
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   DialogContentProps
->(({ className, children, hideCloseButton, ...props }, ref) => (
+>(({ className, children, hideCloseButton, overlayClassName, priorityZIndex, style, ...props }, ref) => (
   <DialogPortal>
-    <DialogOverlay />
+    <DialogOverlay className={overlayClassName} style={priorityZIndex ? { zIndex: priorityZIndex } : undefined} />
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
@@ -46,7 +51,7 @@ const DialogContent = React.forwardRef<
         className
       )}
       // Ensure content always stays on top of other overlays
-      style={{ zIndex: 80 }}
+      style={{ zIndex: priorityZIndex ? priorityZIndex + 1 : 80, ...style }}
       {...props}
     >
       {children}


### PR DESCRIPTION
Prioritize LegalUpdateModal over ServiceWorkerToast to resolve overlapping modal conflict.

The `ServiceWorkerToast` (update prompt) had a `z-index` of `9999`, which was higher than the `LegalUpdateModal`'s underlying Radix Dialog component (`z-index` 60 for overlay, 80 for content). This caused the update toast to appear on top of the legal document acceptance modal, making both unusable. This PR introduces a `priorityZIndex` prop to the `Dialog` component, allowing `LegalUpdateModal` to explicitly set a higher `z-index` (10000) to ensure it always appears on top.

---
<a href="https://cursor.com/background-agent?bcId=bc-ea6f3427-272a-4cfb-adee-6bbe24f84c56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ea6f3427-272a-4cfb-adee-6bbe24f84c56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

