### PR TITLE
GDPR marketing consent defaults

### DIFF
--- a/plant-swipe/src/PlantSwipe.tsx
+++ b/plant-swipe/src/PlantSwipe.tsx
@@ -205,7 +205,7 @@ export default function PlantSwipe() {
   const [authPassword2, setAuthPassword2] = useState("")
   const [authDisplayName, setAuthDisplayName] = useState("")
   const [authAcceptedTerms, setAuthAcceptedTerms] = useState(false)
-  const [authMarketingConsent, setAuthMarketingConsent] = useState(true) // Default to checked
+  const [authMarketingConsent, setAuthMarketingConsent] = useState(false) // GDPR: Must be unchecked by default - pre-ticked boxes don't constitute valid consent (Recital 32)
   
   const [authSubmitting, setAuthSubmitting] = useState(false)
   const termsPath = React.useMemo(() => addLanguagePrefix('/terms', currentLang), [currentLang])
@@ -1327,7 +1327,7 @@ export default function PlantSwipe() {
   React.useEffect(() => {
     if (!authOpen) {
       setAuthAcceptedTerms(false)
-      setAuthMarketingConsent(true) // Reset to default (checked)
+      setAuthMarketingConsent(false) // Reset to default (unchecked - GDPR compliant)
       setAuthSubmitting(false)
       setAuthError(null)
       setAuthEmail("")
@@ -1340,7 +1340,7 @@ export default function PlantSwipe() {
   React.useEffect(() => {
     if (authMode !== 'signup') {
       setAuthAcceptedTerms(false)
-      setAuthMarketingConsent(true) // Reset to default (checked)
+      setAuthMarketingConsent(false) // Reset to default (unchecked - GDPR compliant)
     }
   }, [authMode])
 

--- a/plant-swipe/src/context/AuthContext.tsx
+++ b/plant-swipe/src/context/AuthContext.tsx
@@ -188,7 +188,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     return () => { sub.subscription.unsubscribe() }
   }, [loadSession, refreshProfile])
 
-  const signUp: AuthContextValue['signUp'] = async ({ email, password, displayName, recaptchaToken, marketingConsent = true }) => {
+  const signUp: AuthContextValue['signUp'] = async ({ email, password, displayName, recaptchaToken, marketingConsent = false }) => {
     // Verify reCAPTCHA token before attempting signup
     if (recaptchaToken) {
       try {

--- a/plant-swipe/supabase/functions/email-campaign-runner/index.ts
+++ b/plant-swipe/supabase/functions/email-campaign-runner/index.ts
@@ -583,7 +583,7 @@ async function collectRecipients(
       if (profile?.notifyEmail === false) continue
 
       // For marketing emails, skip users who haven't given marketing consent
-      // marketing_consent defaults to true for new users (signup checkbox is checked by default)
+      // GDPR: marketing_consent defaults to false - users must actively opt-in (pre-ticked boxes don't constitute valid consent)
       // but users can uncheck it during signup or later in Settings
       if (isMarketing && profile?.marketingConsent === false) {
         continue


### PR DESCRIPTION
Update marketing consent default to `false` for GDPR compliance.

GDPR Recital 32 explicitly states that "Silence, pre-ticked boxes or inactivity should not therefore constitute consent." This change ensures users must actively opt-in to marketing communications, fulfilling the requirement for a clear affirmative act of consent.

---
<a href="https://cursor.com/background-agent?bcId=bc-ef62defb-0a3b-48cf-a51f-21398c8d2bbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ef62defb-0a3b-48cf-a51f-21398c8d2bbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

