### PR TITLE
Legal document access

### DIFF
--- a/plant-swipe/public/locales/en/common.json
+++ b/plant-swipe/public/locales/en/common.json
@@ -3068,7 +3068,10 @@
       "goBack": "Go Back & Accept",
       "confirmDecline": "I Understand, Decline",
       "blockingAccount": "Blocking account...",
-      "declinedMessage": "Your account has been blocked because you declined the updated terms. Contact support if you wish to reactivate your account."
+      "declinedMessage": "Your account has been blocked because you declined the updated terms. Contact support if you wish to reactivate your account.",
+      "termsVersion": "Version {{version}} - Updated {{date}}",
+      "privacyVersion": "Version {{version}} - Updated {{date}}",
+      "backToReview": "Back to Review"
     }
   }
 }

--- a/plant-swipe/public/locales/fr/common.json
+++ b/plant-swipe/public/locales/fr/common.json
@@ -3068,7 +3068,10 @@
       "goBack": "Revenir & Accepter",
       "confirmDecline": "Je Comprends, Refuser",
       "blockingAccount": "Blocage du compte...",
-      "declinedMessage": "Votre compte a été bloqué car vous avez refusé les conditions mises à jour. Contactez le support si vous souhaitez réactiver votre compte."
+      "declinedMessage": "Votre compte a été bloqué car vous avez refusé les conditions mises à jour. Contactez le support si vous souhaitez réactiver votre compte.",
+      "termsVersion": "Version {{version}} - Mis à jour le {{date}}",
+      "privacyVersion": "Version {{version}} - Mis à jour le {{date}}",
+      "backToReview": "Retour à la Révision"
     }
   }
 }


### PR DESCRIPTION
Add inline document viewing to the legal update modal, allowing users to read terms and privacy policies without being blocked.

Previously, clicking "Read Terms of Service" or "Read Privacy Policy" would open a new tab, but the legal update modal would also appear in the new tab, preventing users from ever accessing the document content. This change introduces an inline document viewer within the modal flow, resolving the loop.

---
<a href="https://cursor.com/background-agent?bcId=bc-441d9b68-cd27-4622-8257-5f8abd6a2890"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-441d9b68-cd27-4622-8257-5f8abd6a2890"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

