### PR TITLE
Unused constant removal

### DIFF
--- a/plant-swipe/src/lib/aiPlantFill.ts
+++ b/plant-swipe/src/lib/aiPlantFill.ts
@@ -2,7 +2,6 @@ import { supabase } from "@/lib/supabaseClient"
 
 // Retry configuration for handling timeouts and rate limits
 const MAX_RETRIES = 2 // Reduced from 3 since server already has 10min timeout
-const MAX_RETRIES_GATEWAY_TIMEOUT = 2 // Keep retries low to avoid long waits
 const INITIAL_RETRY_DELAY = 2000 // 2 seconds
 const INITIAL_RETRY_DELAY_GATEWAY_TIMEOUT = 3000 // 3 seconds for gateway timeouts
 


### PR DESCRIPTION
Remove unused `MAX_RETRIES_GATEWAY_TIMEOUT` constant to fix TS6133 error.

The `MAX_RETRIES_GATEWAY_TIMEOUT` constant was declared but never used, as the current retry logic utilizes `MAX_RETRIES` for all retry scenarios, including gateway timeouts.

---
<a href="https://cursor.com/background-agent?bcId=bc-9daf9667-6856-408d-80c6-ed453dbd2ac6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9daf9667-6856-408d-80c6-ed453dbd2ac6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

