### PR TITLE
Plant AI fill all error

### DIFF
--- a/plant-swipe/src/lib/composition.ts
+++ b/plant-swipe/src/lib/composition.ts
@@ -421,3 +421,9 @@ export const conservationStatusEnum = createEnumTools([
   { dbValue: 'critically endangered', uiValue: 'Critically Endangered', aliases: ['criticallyendangered'] },
   { dbValue: 'extinct', uiValue: 'Extinct' },
 ])
+
+export const timePeriodEnum = createEnumTools([
+  { dbValue: 'week', uiValue: 'week', aliases: ['weekly', 'per week', 'per-week', 'weeks', 'wk', 'wks'] },
+  { dbValue: 'month', uiValue: 'month', aliases: ['monthly', 'per month', 'per-month', 'months', 'mo', 'mos'] },
+  { dbValue: 'year', uiValue: 'year', aliases: ['yearly', 'annual', 'annually', 'per year', 'per-year', 'years', 'yr', 'yrs'] },
+])


### PR DESCRIPTION
Normalize plant watering schedule `time_period` values to prevent database constraint violations.

The `plant_watering_schedules.time_period` column has a database constraint allowing only 'week', 'month', 'year', or null. The AI and manual input sometimes provide variations like 'weekly', 'monthly', or 'yearly', leading to errors. This PR introduces a `timePeriodEnum` to map these variations to the accepted database values.

---
<a href="https://cursor.com/background-agent?bcId=bc-91e93fb2-2f69-4dd2-b348-59e649eb7f51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-91e93fb2-2f69-4dd2-b348-59e649eb7f51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

