### PR TITLE
Admin media uploads RLS

### DIFF
--- a/plant-swipe/supabase/000_sync_schema.sql
+++ b/plant-swipe/supabase/000_sync_schema.sql
@@ -6334,7 +6334,10 @@ GRANT EXECUTE ON FUNCTION refresh_garden_task_cache(uuid, date) TO authenticated
 GRANT EXECUTE ON FUNCTION cleanup_old_garden_task_cache() TO authenticated;
 
 -- Create a view for easy querying of today's cache
-CREATE OR REPLACE VIEW garden_task_cache_today AS
+-- Use security_invoker to enforce RLS policies of the querying user, not the view owner
+CREATE OR REPLACE VIEW garden_task_cache_today
+WITH (security_invoker = true)
+AS
 SELECT
   c.garden_id,
   c.cache_date,


### PR DESCRIPTION
Enable RLS for `admin_media_uploads` and ensure `garden_task_cache_today` view respects RLS to fix security issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-b31b6f20-28ea-4d39-8dad-bc0ccfa90cd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b31b6f20-28ea-4d39-8dad-bc0ccfa90cd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

