### PR TITLE
App manifest images

### DIFF
--- a/plant-swipe.conf
+++ b/plant-swipe.conf
@@ -77,7 +77,9 @@ server {
     }
 
     # Proxy API requests to the Node server (Express)
-    location /api/ {
+    # Use ^~ to give this priority over regex matches (like the static file regex below)
+    # This ensures /api/manifest.webmanifest goes to Node.js instead of being treated as a static file
+    location ^~ /api/ {
         proxy_pass http://127.0.0.1:3000;
         proxy_http_version 1.1;
         proxy_set_header Host $host;


### PR DESCRIPTION
Fix 404 for `/api/manifest.webmanifest` by adding `^~` to the `/api/` nginx location block, ensuring it takes precedence over static file regex.

---
<a href="https://cursor.com/background-agent?bcId=bc-1bf481a3-9d28-47a3-8dd7-857295589518"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1bf481a3-9d28-47a3-8dd7-857295589518"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

