### PR TITLE
🎨 Palette: Add keyboard shortcut (⌘K/Ctrl+K) for search

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,7 @@
 ## 2025-05-25 - Contextual Accessibility Labels
 **Learning:** Generic "Complete All" buttons are ambiguous for screen reader users when multiple lists (e.g., plants) appear on the same page. Adding the plant or garden name to `aria-label` provides necessary context.
 **Action:** Always interpolate the specific object name (Plant, Garden) into the `aria-label` of generic action buttons.
+
+## 2025-05-26 - Search Keyboard Shortcut
+**Learning:** Adding a global search shortcut (⌘K/Ctrl+K) significantly improves navigation speed for power users. Visual hints in the search bar are essential for discoverability.
+**Action:** When implementing search, always include a keyboard shortcut and a visual badge (e.g., `<kbd>⌘K</kbd>`) when the input is empty.

--- a/plant-swipe/src/PlantSwipe.tsx
+++ b/plant-swipe/src/PlantSwipe.tsx
@@ -6,6 +6,7 @@ import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { executeRecaptcha } from "@/lib/recaptcha";
 import { useMotionValue, animate } from "framer-motion";
 import { ChevronDown, ChevronUp, ListFilter, MessageSquarePlus, Plus, Loader2 } from "lucide-react";
+import { useHotkeys } from "react-hotkeys-hook";
 import { useDebounce } from "@/hooks/useDebounce";
 import { SearchInput } from "@/components/ui/search-input";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
@@ -169,6 +170,21 @@ export default function PlantSwipe() {
   const [searchSort, setSearchSort] = useState<SearchSortMode>("default")
   const [searchBarVisible, setSearchBarVisible] = useState(true)
   const lastScrollY = React.useRef(0)
+
+  // Search shortcut
+  const searchInputRef = React.useRef<HTMLInputElement>(null)
+  useHotkeys(['meta+k', 'ctrl+k'], (e) => {
+    e.preventDefault()
+    searchInputRef.current?.focus()
+  })
+
+  const [shortcutLabel, setShortcutLabel] = useState<string | undefined>(undefined)
+  React.useEffect(() => {
+    if (typeof navigator !== 'undefined') {
+      const isMac = navigator.platform.toLowerCase().includes('mac')
+      setShortcutLabel(isMac ? '⌘K' : 'Ctrl+K')
+    }
+  }, [])
 
   const [index, setIndex] = useState(0)
   const [likedIds, setLikedIds] = useState<string[]>([])
@@ -1572,6 +1588,7 @@ export default function PlantSwipe() {
                       </Label>
                       <SearchInput
                         id="plant-search-main"
+                        ref={searchInputRef}
                         variant="lg"
                         className="rounded-2xl"
                         placeholder={t("plant.searchPlaceholder")}
@@ -1580,6 +1597,7 @@ export default function PlantSwipe() {
                           setQuery(e.target.value)
                         }}
                         onClear={() => setQuery("")}
+                        shortcut={shortcutLabel}
                       />
                     </div>
                     <div className="flex flex-col gap-2 sm:flex-row lg:flex-row lg:items-end lg:gap-2 w-full lg:w-auto">

--- a/plant-swipe/src/components/ui/search-input.tsx
+++ b/plant-swipe/src/components/ui/search-input.tsx
@@ -14,6 +14,8 @@ export interface SearchInputProps
   wrapperClassName?: string
   /** Callback to clear the input. If provided, a clear button will appear when there is text. */
   onClear?: () => void
+  /** Keyboard shortcut hint to display (e.g., "⌘K") */
+  shortcut?: string
 }
 
 /**
@@ -45,7 +47,7 @@ export interface SearchInputProps
  * />
  */
 const SearchInput = React.forwardRef<HTMLInputElement, SearchInputProps>(
-  ({ className, loading, icon, variant = "default", wrapperClassName, onClear, ...props }, ref) => {
+  ({ className, loading, icon, variant = "default", wrapperClassName, onClear, shortcut, ...props }, ref) => {
     const showIcon = icon !== null
     const isSmall = variant === "sm"
     const isLarge = variant === "lg"
@@ -54,6 +56,8 @@ const SearchInput = React.forwardRef<HTMLInputElement, SearchInputProps>(
     // Only show if onClear is provided, we have a value, and we're not loading (spinner takes precedence)
     const hasValue = props.value !== undefined && props.value !== null && String(props.value).length > 0
     const showClear = !!onClear && hasValue && !loading
+    // Show shortcut if provided, no value, and not loading
+    const showShortcut = !!shortcut && !hasValue && !loading
 
     // Calculate padding based on icon visibility and size
     const getLeftPadding = () => {
@@ -97,8 +101,8 @@ const SearchInput = React.forwardRef<HTMLInputElement, SearchInputProps>(
                 : "h-10 rounded-xl pr-4 text-sm md:h-9",
             // Dynamic left padding based on icon
             getLeftPadding(),
-            // Loading/Clear state - add right padding for spinner or clear button
-            (loading || showClear) && (isLarge ? "pr-11" : isSmall ? "pr-8" : "pr-10"),
+            // Loading/Clear/Shortcut state - add right padding for spinner, clear button, or shortcut
+            (loading || showClear || showShortcut) && (isLarge ? "pr-11" : isSmall ? "pr-8" : "pr-10"),
             className
           )}
           {...props}
@@ -117,6 +121,18 @@ const SearchInput = React.forwardRef<HTMLInputElement, SearchInputProps>(
           >
             <X className={cn(isLarge ? "h-5 w-5" : isSmall ? "h-3.5 w-3.5" : "h-4 w-4")} />
           </button>
+        )}
+
+        {/* Shortcut Hint */}
+        {showShortcut && (
+          <kbd
+            className={cn(
+              "pointer-events-none absolute top-1/2 -translate-y-1/2 select-none opacity-50 font-mono font-medium text-stone-500 dark:text-stone-400 bg-stone-100 dark:bg-stone-800 border border-stone-200 dark:border-stone-700 rounded px-1.5 flex items-center justify-center",
+              isLarge ? "right-4 text-xs h-6" : isSmall ? "right-2.5 text-[10px] h-4" : "right-3 text-[10px] h-5"
+            )}
+          >
+            {shortcut}
+          </kbd>
         )}
 
         {/* Loading spinner */}


### PR DESCRIPTION
*   💡 **What:** Added global `Cmd+K` / `Ctrl+K` shortcut to focus the main search bar, with a visual hint.
*   🎯 **Why:** Allows power users to quickly access search without leaving the keyboard, a standard pattern in modern web apps.
*   ♿ **Accessibility:** Improved keyboard navigation efficiency. Added `kbd` element which is semantically correct for keyboard input.
*   **Verification:** Verified via Playwright script that the shortcut focuses the input and the hint is visible.

---
*PR created automatically by Jules for task [10609742203187845268](https://jules.google.com/task/10609742203187845268) started by @FrenchFive*