### PR TITLE
Google fonts CSP

### DIFF
--- a/plant-swipe.conf
+++ b/plant-swipe.conf
@@ -56,7 +56,7 @@ server {
     set $csp_policy "default-src 'self' *.aphylia.app; ";
     set $csp_policy "${csp_policy}script-src 'self' 'unsafe-inline' 'unsafe-eval' *.aphylia.app https://www.googletagmanager.com https://www.google.com https://www.gstatic.com https://recaptchaenterprise.googleapis.com; ";
     set $csp_policy "${csp_policy}style-src 'self' 'unsafe-inline' *.aphylia.app https://fonts.googleapis.com; ";
-    set $csp_policy "${csp_policy}connect-src 'self' *.aphylia.app wss://*.aphylia.app https://*.supabase.co wss://*.supabase.co https://www.google-analytics.com https://analytics.google.com https://region1.google-analytics.com https://recaptchaenterprise.googleapis.com https://*.sentry.io; ";
+    set $csp_policy "${csp_policy}connect-src 'self' *.aphylia.app wss://*.aphylia.app https://*.supabase.co wss://*.supabase.co https://www.google-analytics.com https://analytics.google.com https://region1.google-analytics.com https://recaptchaenterprise.googleapis.com https://*.sentry.io https://fonts.googleapis.com https://fonts.gstatic.com; ";
     set $csp_policy "${csp_policy}font-src 'self' *.aphylia.app https://fonts.gstatic.com data:; ";
     set $csp_policy "${csp_policy}frame-src 'self' *.aphylia.app https://www.google.com https://recaptcha.google.com; ";
     set $csp_policy "${csp_policy}img-src * data: blob:; ";

--- a/plant-swipe/server.js
+++ b/plant-swipe/server.js
@@ -3365,7 +3365,7 @@ const CSP_POLICY = [
   "default-src 'self' *.aphylia.app",
   "script-src 'self' 'unsafe-inline' 'unsafe-eval' *.aphylia.app https://www.googletagmanager.com https://www.google.com https://www.gstatic.com https://recaptchaenterprise.googleapis.com",
   "style-src 'self' 'unsafe-inline' *.aphylia.app https://fonts.googleapis.com",
-  "connect-src 'self' *.aphylia.app wss://*.aphylia.app https://*.supabase.co wss://*.supabase.co https://www.google-analytics.com https://analytics.google.com https://region1.google-analytics.com https://recaptchaenterprise.googleapis.com https://*.sentry.io",
+  "connect-src 'self' *.aphylia.app wss://*.aphylia.app https://*.supabase.co wss://*.supabase.co https://www.google-analytics.com https://analytics.google.com https://region1.google-analytics.com https://recaptchaenterprise.googleapis.com https://*.sentry.io https://fonts.googleapis.com https://fonts.gstatic.com",
   "font-src 'self' *.aphylia.app https://fonts.gstatic.com data:",
   "frame-src 'self' *.aphylia.app https://www.google.com https://recaptcha.google.com",
   "img-src * data: blob:",


### PR DESCRIPTION
Add Google Fonts domains to `connect-src` CSP to allow the service worker to fetch font stylesheets.

The service worker uses the Fetch API to retrieve Google Fonts CSS, which is governed by the `connect-src` Content Security Policy directive. Previously, `connect-src` did not include Google Fonts domains, causing the fetch requests to be blocked despite `style-src` and `font-src` already allowing them. This fix ensures the service worker can successfully load the necessary font resources.

---
<a href="https://cursor.com/background-agent?bcId=bc-60c4609f-defc-4e66-8c09-d22c8deb67a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-60c4609f-defc-4e66-8c09-d22c8deb67a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

