### PR TITLE
⚡ Bolt: Optimize plant preview data fetching

### DIFF
--- a/plant-swipe/src/lib/plantTranslationLoader.ts
+++ b/plant-swipe/src/lib/plantTranslationLoader.ts
@@ -663,10 +663,25 @@ export async function loadPlantPreviews(language: SupportedLanguage): Promise<Pl
     }
 
     // Load translations for ALL languages (including English)
+    // ⚡ Bolt: Select only used columns to reduce payload size
+    const translationColumns = [
+      'plant_id',
+      'name',
+      'scientific_name',
+      'meaning',
+      'identity',
+      'usage',
+      'ecology',
+      'given_names',
+      'advice_medicinal',
+      'origin',
+      'overview',
+    ].join(',')
+
     const plantIds = plants.map((p) => p.id)
     const { data: translationsData } = await supabase
       .from('plant_translations')
-      .select('*')
+      .select(translationColumns)
       .eq('language', language)
       .in('plant_id', plantIds)
 


### PR DESCRIPTION
💡 What: Optimized `loadPlantPreviews` in `plantTranslationLoader.ts` to select specific columns instead of `*`.
🎯 Why: To reduce network payload and memory usage during initial app load and discovery view.
📊 Impact: Significantly reduces the size of the JSON response from Supabase for the plant list, as it no longer includes potentially large unused fields like full descriptions or HTML content.
🔬 Measurement: Verified that all used fields (`name`, `scientific_name`, `identity`, `usage`, `ecology`, `given_names`, `advice_medicinal`, `origin`, `overview`) are included in the selection. Validated types with `tsc`.

---
*PR created automatically by Jules for task [13042032221473937660](https://jules.google.com/task/13042032221473937660) started by @FrenchFive*