### PR TITLE
Privacy TOS content gap

### DIFF
--- a/plant-swipe/src/content/privacy-policy.html
+++ b/plant-swipe/src/content/privacy-policy.html
@@ -5,12 +5,6 @@
     <h1>PRIVACY POLICY</h1>
     </span></span></strong></div>
 
-    <div><br></div>
-
-    <div><br></div>
-
-    <div><br></div>
-
     <div style="line-height: 1.5;"><span style="color: rgb(127, 127, 127);"><span style="color: rgb(89, 89, 89); font-size: 15px;"><span data-custom-class="body_text">This Privacy Notice for Aphylia ('<strong>we</strong>', '<strong>us</strong>', or '<strong>our</strong>'</span><span data-custom-class="body_text">), describes how and why we might access, collect, store, use, and/or share ('<strong>process</strong>') your personal information when you use our services ('<strong>Services</strong>'), including when you:</span></span></span><span style="font-size: 15px;"></span></div>
 
     <ul>

--- a/plant-swipe/src/content/terms-of-service.html
+++ b/plant-swipe/src/content/terms-of-service.html
@@ -6,10 +6,6 @@
       <h1>TERMS OF SERVICE</h1>
       </strong></span></div>
 
-      <div class="MsoNormal" style="line-height: 1.1;"><br></div>
-
-      <div style="line-height: 1.5;"><br></div>
-
       <div style="line-height: 1.5;"><strong><span data-custom-class="heading_1">
         <h2>AGREEMENT TO OUR LEGAL TERMS</h2>
         </span></strong></div>


### PR DESCRIPTION
Remove excessive spacing in Privacy Policy and Terms of Service HTML files to fix large gaps after titles.

---
<a href="https://cursor.com/background-agent?bcId=bc-491b6a51-ce5d-4aca-9401-ad9406025580"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-491b6a51-ce5d-4aca-9401-ad9406025580"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

