### PR TITLE
Return button redirection logic

### DIFF
--- a/plant-swipe/src/hooks/useNavigationHistory.ts
+++ b/plant-swipe/src/hooks/useNavigationHistory.ts
@@ -1,0 +1,156 @@
+import { useEffect, useRef, useCallback } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
+import { removeLanguagePrefix } from '@/lib/i18nRouting'
+
+/**
+ * Storage key for navigation history in sessionStorage
+ * Using sessionStorage ensures history is cleared when the browser tab is closed
+ */
+const NAVIGATION_HISTORY_KEY = 'plantswipe.navigation_history'
+
+/**
+ * Maximum number of history entries to keep
+ * This prevents the history from growing too large
+ */
+const MAX_HISTORY_SIZE = 50
+
+/**
+ * Get the path without language prefix and without query params
+ * This is used to compare if two pages are "different"
+ */
+function getNormalizedPath(pathname: string): string {
+  const withoutLang = removeLanguagePrefix(pathname)
+  // Remove trailing slashes for consistent comparison
+  return withoutLang.replace(/\/+$/, '') || '/'
+}
+
+/**
+ * Load navigation history from sessionStorage
+ */
+function loadHistory(): string[] {
+  try {
+    const stored = sessionStorage.getItem(NAVIGATION_HISTORY_KEY)
+    if (stored) {
+      const parsed = JSON.parse(stored)
+      if (Array.isArray(parsed)) {
+        return parsed
+      }
+    }
+  } catch {
+    // Ignore storage errors
+  }
+  return []
+}
+
+/**
+ * Save navigation history to sessionStorage
+ */
+function saveHistory(history: string[]): void {
+  try {
+    sessionStorage.setItem(NAVIGATION_HISTORY_KEY, JSON.stringify(history))
+  } catch {
+    // Ignore storage errors
+  }
+}
+
+/**
+ * Hook that tracks navigation history and provides a function to navigate
+ * back to the last page that was different from the current one.
+ * 
+ * This solves the issue where clicking "back" multiple times is needed when
+ * the user has navigated to the same page multiple times (e.g., creating
+ * multiple plants in a row).
+ * 
+ * @param fallbackPath - The path to navigate to if no distinct previous page exists
+ * @returns Object with navigateBack function and hasHistory boolean
+ */
+export function useNavigationHistory(fallbackPath: string = '/') {
+  const location = useLocation()
+  const navigate = useNavigate()
+  const historyRef = useRef<string[]>([])
+  const currentNormalizedPath = getNormalizedPath(location.pathname)
+
+  // Initialize history from storage on mount
+  useEffect(() => {
+    historyRef.current = loadHistory()
+  }, [])
+
+  // Track page visits
+  useEffect(() => {
+    const fullPath = location.pathname + location.search
+    const history = historyRef.current
+    
+    // Don't add duplicate consecutive entries
+    if (history.length > 0 && history[history.length - 1] === fullPath) {
+      return
+    }
+    
+    // Add current page to history
+    history.push(fullPath)
+    
+    // Trim history if it exceeds max size
+    if (history.length > MAX_HISTORY_SIZE) {
+      history.splice(0, history.length - MAX_HISTORY_SIZE)
+    }
+    
+    historyRef.current = history
+    saveHistory(history)
+  }, [location.pathname, location.search])
+
+  /**
+   * Navigate back to the last page that has a different normalized path
+   * than the current page. This skips over consecutive visits to the same page.
+   * 
+   * @returns true if navigation was performed, false if falling back
+   */
+  const navigateBack = useCallback(() => {
+    const history = historyRef.current
+    
+    // Find the last entry with a different normalized path
+    // Start from the second-to-last entry (skip current page)
+    for (let i = history.length - 2; i >= 0; i--) {
+      const entryPath = history[i].split('?')[0] // Remove query params for path comparison
+      const normalizedEntryPath = getNormalizedPath(entryPath)
+      
+      if (normalizedEntryPath !== currentNormalizedPath) {
+        // Found a different page - navigate to it
+        const targetPath = history[i]
+        
+        // Remove all entries after this point (including current page)
+        historyRef.current = history.slice(0, i + 1)
+        saveHistory(historyRef.current)
+        
+        // Navigate to the found page
+        navigate(targetPath)
+        return true
+      }
+    }
+    
+    // No different page found in history - use fallback
+    navigate(fallbackPath)
+    return false
+  }, [currentNormalizedPath, fallbackPath, navigate])
+
+  /**
+   * Check if there's a distinct previous page in history
+   */
+  const hasDistinctHistory = useCallback(() => {
+    const history = historyRef.current
+    
+    for (let i = history.length - 2; i >= 0; i--) {
+      const entryPath = history[i].split('?')[0]
+      const normalizedEntryPath = getNormalizedPath(entryPath)
+      
+      if (normalizedEntryPath !== currentNormalizedPath) {
+        return true
+      }
+    }
+    
+    return false
+  }, [currentNormalizedPath])
+
+  return {
+    navigateBack,
+    hasDistinctHistory: hasDistinctHistory(),
+  }
+}

--- a/plant-swipe/src/pages/CreatePlantPage.tsx
+++ b/plant-swipe/src/pages/CreatePlantPage.tsx
@@ -10,6 +10,7 @@ import { useAuth } from "@/context/AuthContext"
 import { useTranslation } from "react-i18next"
 import { SUPPORTED_LANGUAGES, type SupportedLanguage } from "@/lib/i18n"
 import { useLanguageNavigate, useLanguage } from "@/lib/i18nRouting"
+import { useNavigationHistory } from "@/hooks/useNavigationHistory"
 import { applyAiFieldToPlant, getCategoryForField } from "@/lib/applyAiField"
 import { translateArray, translateText } from "@/lib/deepl"
 import { buildCategoryProgress, createEmptyCategoryProgress, plantFormCategoryOrder, type CategoryProgress, type PlantFormCategory } from "@/lib/plantFormCategories"
@@ -821,6 +822,7 @@ export const CreatePlantPage: React.FC<{ onCancel: () => void; onSaved?: (id: st
   const initialNameFromUrl = searchParams.get('name')
   const effectiveInitialName = initialName || initialNameFromUrl || ""
   const languageNavigate = useLanguageNavigate()
+  const { navigateBack } = useNavigationHistory('/search')
   const { profile } = useAuth()
   // Get the language from the URL path (e.g., /fr/admin/plants/create -> 'fr')
   const urlLanguage = useLanguage()
@@ -1877,12 +1879,11 @@ export const CreatePlantPage: React.FC<{ onCancel: () => void; onSaved?: (id: st
   }
 
   const handleBackClick = React.useCallback(() => {
-    if (typeof window !== 'undefined' && window.history.length > 1) {
-      languageNavigate(-1)
-      return
-    }
-    onCancel()
-  }, [languageNavigate, onCancel])
+    // Use navigateBack to go to the last distinct page
+    // This fixes the issue where clicking back multiple times was needed
+    // when the user navigated to the same page multiple times
+    navigateBack()
+  }, [navigateBack])
 
   const handleViewPlantInfo = React.useCallback(() => {
     if (!id) return


### PR DESCRIPTION
Update the Plant Create Page's return button to navigate to the last distinct page, resolving issues where users had to click back multiple times.

The previous implementation used `history.back()`, which would go back one step in the browser history. If a user visited the same page multiple times (e.g., creating several plants), they would have to click back multiple times to reach a different page. This PR introduces a custom `useNavigationHistory` hook that tracks unique page paths and allows navigating directly to the last *different* page, improving user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-f0017bf6-7c32-4692-ae0e-3d59f1eacb5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f0017bf6-7c32-4692-ae0e-3d59f1eacb5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

