### PR TITLE
Request page plant details

### DIFF
--- a/plant-swipe/src/pages/AdminPage.tsx
+++ b/plant-swipe/src/pages/AdminPage.tsx
@@ -4287,6 +4287,18 @@ export const AdminPage: React.FC = () => {
     plantDashboardLoading,
     loadPlantDashboard,
   ]);
+
+  // Auto-navigate to the new plant when duplication succeeds from the plant list (not via dialog)
+  React.useEffect(() => {
+    if (addFromDuplicateSuccess && !addFromDialogOpen) {
+      const { id, originalName } = addFromDuplicateSuccess;
+      // Clear the success state before navigating
+      setAddFromDuplicateSuccess(null);
+      // Navigate to the new plant's edit page
+      navigate(`/create/${id}?duplicatedFrom=${encodeURIComponent(originalName)}`);
+    }
+  }, [addFromDuplicateSuccess, addFromDialogOpen, navigate]);
+
   const membersView: "search" | "list" | "reports" = React.useMemo(() => {
     if (currentPath.includes("/admin/members/reports")) return "reports";
     if (currentPath.includes("/admin/members/list")) return "list";
@@ -8106,6 +8118,18 @@ export const AdminPage: React.FC = () => {
                                           />
                                           {PLANT_STATUS_LABELS[plant.status]}
                                         </span>
+                                        <button
+                                          type="button"
+                                          onClick={(e) => {
+                                            e.stopPropagation();
+                                            handleSelectPlantForPrefill(plant.id, plant.name);
+                                          }}
+                                          className="p-1.5 rounded-lg opacity-0 group-hover:opacity-100 hover:bg-emerald-100 dark:hover:bg-emerald-900/30 text-stone-400 hover:text-emerald-600 dark:hover:text-emerald-400 transition-all"
+                                          title="Duplicate plant (Add From)"
+                                          disabled={addFromDuplicating}
+                                        >
+                                          <Copy className="h-4 w-4" />
+                                        </button>
                                         <button
                                           type="button"
                                           onClick={(e) => {


### PR DESCRIPTION
Enhance 'Add From' functionality in Admin / Plants / Requests to ensure comprehensive plant data duplication.

Previously, the 'Add From' feature omitted several key details: the scientific name was incorrectly cleared, translatable fields (like given names and overview) were not properly duplicated due to `id` conflicts, and `plant_pro_advices` were entirely missing. This update ensures all relevant information is copied for a complete plant record.

---
<a href="https://cursor.com/background-agent?bcId=bc-a91e614c-dde0-47c4-b4e0-e2d814d1bede"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a91e614c-dde0-47c4-b4e0-e2d814d1bede"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

