### PR TITLE
Back button redirect

### DIFF
--- a/plant-swipe/src/PlantSwipe.tsx
+++ b/plant-swipe/src/PlantSwipe.tsx
@@ -8,6 +8,7 @@ import { useMotionValue, animate } from "framer-motion";
 import { ChevronDown, ChevronUp, ListFilter, MessageSquarePlus, Plus, Loader2 } from "lucide-react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { useDebounce } from "@/hooks/useDebounce";
+import { useGlobalNavigationTracker } from "@/hooks/useNavigationHistory";
 import { SearchInput } from "@/components/ui/search-input";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
@@ -138,6 +139,9 @@ export default function PlantSwipe() {
   const { user, signIn, signUp, signOut, profile, refreshProfile } = useAuth()
   const currentLang = useLanguage()
   const { t } = useTranslation('common')
+  
+  // Track all navigation globally for back button functionality
+  useGlobalNavigationTracker()
   const routeLoadingFallback = (
     <div className="p-8 text-center text-sm opacity-60">{t('common.loading')}</div>
   )


### PR DESCRIPTION
Ensures "Back to previous page" button navigates correctly by implementing global history tracking.

The previous `useNavigationHistory` hook only tracked pages when it was active on a specific component (e.g., `/create/{id}`). This meant that pages visited *before* entering that component (like `/admin/plants`) were not recorded in the history. By introducing a `useGlobalNavigationTracker` in `PlantSwipe.tsx`, all page visits are now consistently recorded, allowing the back button to always find the correct previous page instead of falling back to `/search`.

---
<a href="https://cursor.com/background-agent?bcId=bc-3a72a72f-3d69-4dee-b5cd-db2168ce139a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3a72a72f-3d69-4dee-b5cd-db2168ce139a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

