### PR TITLE
French setup page language

### DIFF
--- a/plant-swipe/src/components/i18n/Navigate.tsx
+++ b/plant-swipe/src/components/i18n/Navigate.tsx
@@ -1,12 +1,34 @@
 import { Navigate as RouterNavigate, type NavigateProps, useLocation } from 'react-router-dom'
-import { useLanguage, addLanguagePrefix, removeLanguagePrefix } from '@/lib/i18nRouting'
+import { useLanguage, addLanguagePrefix, removeLanguagePrefix, getLanguageFromPath } from '@/lib/i18nRouting'
+import i18n from '@/lib/i18n'
 
 /**
  * Language-aware Navigate component that preserves language when redirecting
+ * 
+ * Uses multiple sources to detect the current language to handle edge cases:
+ * 1. React Router location (primary source)
+ * 2. window.location.pathname (fallback for race conditions)
+ * 3. i18n.language (fallback for consistency)
+ * 
+ * Prefers non-default language (e.g., 'fr') if any source indicates it,
+ * to ensure French users aren't accidentally redirected to English pages.
  */
 export function Navigate({ to, ...props }: NavigateProps) {
-  const currentLang = useLanguage()
+  const routerLang = useLanguage()
   const location = useLocation()
+  
+  // Get language from multiple sources to handle edge cases where
+  // React Router's location state might be stale during redirects
+  const windowLang = typeof window !== 'undefined' 
+    ? getLanguageFromPath(window.location.pathname) 
+    : routerLang
+  const i18nLang = (i18n.language === 'fr' ? 'fr' : 'en') as 'en' | 'fr'
+  
+  // Prefer non-default language (French) if any source indicates it
+  // This ensures French users are always redirected to French pages
+  const currentLang = routerLang === 'fr' || windowLang === 'fr' || i18nLang === 'fr' 
+    ? 'fr' 
+    : 'en'
   
   // Convert 'to' to string if it's an object
   let toPath: string


### PR DESCRIPTION
Make the `Navigate` component's language detection more robust to prevent French users from being redirected to English setup pages.

The previous implementation could experience a race condition where React Router's location state wasn't fully synchronized during redirects, causing the `Navigate` component to incorrectly detect the user's language. This fix checks `window.location.pathname` and `i18n.language` as fallbacks to ensure the correct locale is always used for redirection.

---
<a href="https://cursor.com/background-agent?bcId=bc-04c19226-301b-418e-aa93-06fe4cb19324"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-04c19226-301b-418e-aa93-06fe4cb19324"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

