### PR TITLE
Broadcast message persistence

### DIFF
--- a/plant-swipe/server.js
+++ b/plant-swipe/server.js
@@ -15700,9 +15700,12 @@ app.get('/api/broadcast/active', async (_req, res) => {
       res.setHeader('Pragma', 'no-cache')
     } catch { }
     const row = await getActiveBroadcastRow()
+    const serverTime = new Date().toISOString()
     if (row) {
       res.json({
-        ok: true, broadcast: {
+        ok: true,
+        serverTime,
+        broadcast: {
           id: String(row.id || ''),
           message: String(row.message || ''),
           severity: String(row.severity || 'info'),
@@ -15713,7 +15716,7 @@ app.get('/api/broadcast/active', async (_req, res) => {
         }
       })
     } else {
-      res.json({ ok: true, broadcast: null })
+      res.json({ ok: true, serverTime, broadcast: null })
     }
   } catch (e) {
     res.status(500).json({ ok: false, error: e?.message || 'Failed to load broadcast' })
@@ -20505,7 +20508,7 @@ app.post('/api/admin/broadcast', async (req, res) => {
     }
     const rows = await sql`
       insert into public.broadcast_messages (message, severity, created_by, expires_at)
-      values (${messageRaw}, ${severity}, ${typeof adminId === 'string' ? adminId : null}, ${expiresAt ? expiresAt : null})
+      values (${messageRaw}, ${severity}, ${toAdminUuid(adminId)}, ${expiresAt ? expiresAt : null})
       returning id::text as id, message, severity, created_at, expires_at, created_by::text as created_by
     `
     const row = Array.isArray(rows) && rows[0] ? rows[0] : null


### PR DESCRIPTION
Fix broadcast creation by correctly handling UUID insertion and add server time to active broadcast endpoint.

The `created_by` column, a UUID type, was receiving string values like 'static-admin', causing an "invalid input syntax for type uuid" error. This PR uses `toAdminUuid()` to ensure correct UUID or `null` insertion. `serverTime` was added to the active broadcast endpoint for accurate client-side expiration handling.

---
<a href="https://cursor.com/background-agent?bcId=bc-0fac2166-3a72-46e6-8266-bc7d28da5e90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0fac2166-3a72-46e6-8266-bc7d28da5e90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

