### PR TITLE
🎨 Palette: Improved empty state for garden tasks sidebar

### DIFF
--- a/plant-swipe/src/components/garden/GardenListSidebar.tsx
+++ b/plant-swipe/src/components/garden/GardenListSidebar.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Loader2, RefreshCw, Sprout, Check, X } from "lucide-react";
+import { Loader2, RefreshCw, Sprout, Check, X, Coffee } from "lucide-react";
 import type { GardenInvite } from "@/types/notification";
 import type { TFunction } from "i18next";
 import type { User } from "@supabase/supabase-js";
@@ -201,16 +201,26 @@ const GardenListSidebarComponent: React.FC<GardenListSidebarProps> = ({
         {!loadingTasks &&
           gardensWithTasks.length === 0 &&
           todayTaskOccurrences.length === 0 && (
-            <Card className="rounded-[28px] border border-stone-200/70 dark:border-[#3e3e42]/70 bg-white/80 dark:bg-[#1f1f1f]/80 backdrop-blur p-5 shadow-sm">
-              <div className="text-sm opacity-70 mb-2">
-                {t("garden.noTasksToday")}
+            <Card className="rounded-[28px] border border-stone-200/70 dark:border-[#3e3e42]/70 bg-white/80 dark:bg-[#1f1f1f]/80 backdrop-blur p-8 shadow-sm text-center">
+              <div className="flex flex-col items-center justify-center gap-3">
+                <div className="h-12 w-12 rounded-full bg-emerald-100 dark:bg-emerald-900/30 flex items-center justify-center">
+                  <Coffee className="h-6 w-6 text-emerald-600 dark:text-emerald-400" />
+                </div>
+                <div>
+                  <div className="font-semibold text-lg text-stone-800 dark:text-stone-200">
+                    {t("garden.allCaughtUp", "All caught up!")}
+                  </div>
+                  <div className="text-sm text-stone-500 dark:text-stone-400 mt-1 max-w-[200px] mx-auto">
+                    {t("garden.noTasksToday", "No tasks due today. Enjoy your time off!")}
+                  </div>
+                </div>
               </div>
               {/* Show reload button if progress indicates tasks exist */}
               {Object.values(progressByGarden).some(
                 (prog) => (prog.due || 0) > 0,
               ) && (
                 <Button
-                  className="rounded-xl w-full mt-2"
+                  className="rounded-xl w-full mt-4"
                   variant="outline"
                   onClick={onReloadTasks}
                 >


### PR DESCRIPTION
💡 **What**: Improved the empty state in the Garden List sidebar when there are no tasks due today.
🎯 **Why**: The previous empty state was a plain text message "No tasks today". The new design celebrates the user's completion of tasks ("All caught up!") and provides a friendlier, more engaging visual feedback.
📸 **Visual**: Replaced text-only card with a centered layout containing a Coffee icon, bold "All caught up!" heading, and descriptive subtext.
♿ **Accessibility**: Uses semantic markup and consistent text contrast.

---
*PR created automatically by Jules for task [8090091432661536892](https://jules.google.com/task/8090091432661536892) started by @FrenchFive*