### PR TITLE
Contact form CORS issue

### DIFF
--- a/plant-swipe/supabase/functions/contact-support/index.ts
+++ b/plant-swipe/supabase/functions/contact-support/index.ts
@@ -62,7 +62,7 @@ const contactSchema = z.object({
 
 const corsHeaders: Record<string, string> = {
   "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, apikey, content-type, x-client-info, prefer",
+  "Access-Control-Allow-Headers": "authorization, apikey, content-type, x-client-info, prefer, x-supabase-client-platform, x-supabase-client, x-supabase-version",
   "Access-Control-Allow-Methods": "POST, OPTIONS",
   "Access-Control-Max-Age": "86400",
   "Vary": "Origin",

--- a/plant-swipe/supabase/functions/email-campaign-runner/index.ts
+++ b/plant-swipe/supabase/functions/email-campaign-runner/index.ts
@@ -123,7 +123,7 @@ const payloadSchema = z
 
 const corsHeaders: Record<string, string> = {
   "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, apikey, content-type, x-client-info, prefer",
+  "Access-Control-Allow-Headers": "authorization, apikey, content-type, x-client-info, prefer, x-supabase-client-platform, x-supabase-client, x-supabase-version",
   "Access-Control-Allow-Methods": "POST, OPTIONS",
   "Access-Control-Max-Age": "86400",
   "Vary": "Origin",


### PR DESCRIPTION
Add Supabase client headers to CORS configuration in Edge Functions to resolve CORS errors for contact form and email campaign runner.

The Supabase client automatically sends headers like `x-supabase-client-platform`, which were not explicitly allowed in the `Access-Control-Allow-Headers` list of the Edge Functions, causing preflight requests to fail due to CORS policy.

---
<a href="https://cursor.com/background-agent?bcId=bc-ee62054d-36b4-4ae2-9aa5-b9122757e2b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ee62054d-36b4-4ae2-9aa5-b9122757e2b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

