### PR TITLE
Radix dialog title

### DIFF
--- a/plant-swipe/src/pages/BlogPostPage.tsx
+++ b/plant-swipe/src/pages/BlogPostPage.tsx
@@ -5,7 +5,7 @@ import { ArrowLeft, CalendarClock, CalendarDays, Clock, UserRound, X, ZoomIn } f
 import { useTranslation } from 'react-i18next'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
-import { Dialog, DialogContent } from '@/components/ui/dialog'
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
 import { Link } from '@/components/i18n/Link'
 import { usePageMetadata } from '@/hooks/usePageMetadata'
 import type { BlogPost } from '@/types/blog'
@@ -268,6 +268,9 @@ export default function BlogPostPage() {
       {/* Fullscreen Image Viewer */}
       <Dialog open={!!fullscreenImage} onOpenChange={(open) => !open && setFullscreenImage(null)}>
         <DialogContent className="max-w-[95vw] max-h-[95vh] p-0 bg-black/95 border-none rounded-2xl overflow-hidden">
+          <DialogTitle className="sr-only">
+            {t('blogPage.detail.fullscreenImageTitle', { defaultValue: 'Fullscreen image view' })}
+          </DialogTitle>
           <button
             onClick={() => setFullscreenImage(null)}
             className="absolute top-4 right-4 z-10 p-2 rounded-full bg-black/50 text-white hover:bg-black/70 transition-colors"

--- a/plant-swipe/src/pages/ScanPage.tsx
+++ b/plant-swipe/src/pages/ScanPage.tsx
@@ -922,6 +922,9 @@ export const ScanPage: React.FC = () => {
       {/* Fullscreen Image Viewer */}
       <Dialog open={!!fullscreenImage} onOpenChange={(open) => !open && setFullscreenImage(null)}>
         <DialogContent className="max-w-[95vw] max-h-[95vh] p-0 bg-black/95 border-none rounded-2xl overflow-hidden">
+          <DialogTitle className="sr-only">
+            {t('scan.fullscreenImageTitle', { defaultValue: 'Fullscreen image view' })}
+          </DialogTitle>
           <button
             onClick={() => setFullscreenImage(null)}
             className="absolute top-4 right-4 z-10 p-2 rounded-full bg-black/50 text-white hover:bg-black/70 transition-colors"


### PR DESCRIPTION
Add visually hidden `DialogTitle` to Radix UI Dialogs to resolve screen reader accessibility errors.

The `DialogTitle` was missing from fullscreen image viewer dialogs on the blog and scan pages. The `sr-only` Tailwind CSS class ensures the title is accessible to screen readers while remaining visually hidden, following Radix UI recommendations.

---
<a href="https://cursor.com/background-agent?bcId=bc-194b32d8-f065-4aae-bdb2-c9d1a801447f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-194b32d8-f065-4aae-bdb2-c9d1a801447f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

