### PR TITLE
⚡ Bolt: Memoize SwipePage and stabilize handlers

### DIFF
--- a/plant-swipe/src/pages/SwipePage.tsx
+++ b/plant-swipe/src/pages/SwipePage.tsx
@@ -87,7 +87,8 @@ interface SwipePageProps {
   boostImagePriority?: boolean
 }
 
-export const SwipePage: React.FC<SwipePageProps> = ({
+// ⚡ Bolt: Memoized to prevent re-renders when parent state changes (e.g. auth, search) but props are stable
+export const SwipePage: React.FC<SwipePageProps> = React.memo(({
   current,
   index: _index,
   setIndex,
@@ -680,7 +681,7 @@ export const SwipePage: React.FC<SwipePageProps> = ({
         </motion.section>
       </div>
     )
-}
+})
 
 const EmptyState = ({ onReset }: { onReset: () => void }) => {
   const { t } = useTranslation("common")


### PR DESCRIPTION
💡 What: Wrapped `SwipePage` in `React.memo` and stabilized all event handler props (`handlePass`, `handlePrevious`, `handleInfo`, `onDragEnd`, `onToggleLike`) passed to it from `PlantSwipe`. Introduced `currentRef` in `PlantSwipe` to access the current plant in handlers without recreating them on every index change.
🎯 Why: `SwipePage` is a heavy component (images, badges, animations). It was re-rendering whenever `PlantSwipe` re-rendered (e.g., due to background auth checks, search query changes, or other state updates), even if the displayed plant hadn't changed.
📊 Impact: Eliminates unnecessary re-renders of the main swipe card view when parent state changes but the active plant remains the same.
🔬 Measurement: Verified build passes and app loads correctly. Visual verification confirmed no regression in rendering.

---
*PR created automatically by Jules for task [9335195924858725327](https://jules.google.com/task/9335195924858725327) started by @FrenchFive*