### PR TITLE
Admin member category counts

### DIFF
--- a/plant-swipe/server.js
+++ b/plant-swipe/server.js
@@ -12343,12 +12343,15 @@ app.get('/api/admin/role-stats', async (req, res) => {
       const totalMembers = totalResult?.[0]?.count || 0
 
       // Count users by each role (users can have multiple roles)
+      // Use explicit CROSS JOIN LATERAL with proper column naming to ensure
+      // the column is correctly named 'role' in the result
       const roleCountsResult = await sql`
         select
-          role,
+          r as role,
           count(*)::int as count
-        from public.profiles, unnest(coalesce(roles, '{}')) as role
-        group by role
+        from public.profiles
+        cross join lateral unnest(coalesce(roles, '{}')) as r
+        group by r
         order by count desc
       `
 


### PR DESCRIPTION
Fixes incorrect category counts in the admin member list by correcting the SQL query for role statistics.

The original SQL query used `unnest(...) as role`, which created a table alias instead of a column alias, causing the `role` field to be missing from the result set and leading to 0 counts in the UI. The fix explicitly names the output column as `role` using `cross join lateral unnest(...) as r` and `select r as role`.

---
<a href="https://cursor.com/background-agent?bcId=bc-25e226fa-0148-4457-b9d9-caf47336a9c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-25e226fa-0148-4457-b9d9-caf47336a9c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

