### PR TITLE
Email verification template consolidation

### DIFF
--- a/plant-swipe/server.js
+++ b/plant-swipe/server.js
@@ -9171,11 +9171,6 @@ const DEFAULT_EMAIL_TRIGGERS = [
   },
   // Security Emails - Email Change
   {
-    triggerType: 'EMAIL_CHANGE_VERIFICATION',
-    displayName: 'Email Change Verification',
-    description: 'Sent to the NEW email address with a verification link when user requests to change their email. Variables: {{url}}, {{new_email}}, {{old_email}}',
-  },
-  {
     triggerType: 'EMAIL_CHANGE_NOTIFICATION',
     displayName: 'Email Changed Notification',
     description: 'Sent to the OLD email address to inform that the email has been changed. Variables: {{new_email}}, {{old_email}}, {{time}}',
@@ -9538,7 +9533,7 @@ app.post('/api/send-automatic-email', async (req, res) => {
  * - Supports extra context variables for security info
  * - Can send to any email address (important for email change notifications)
  * 
- * @param triggerType - The trigger type (e.g., 'PASSWORD_RESET_REQUEST', 'EMAIL_CHANGE_VERIFICATION')
+ * @param triggerType - The trigger type (e.g., 'PASSWORD_RESET_REQUEST', 'EMAIL_VERIFICATION')
  * @param options.recipientEmail - Email address to send to (may differ from user's current email)
  * @param options.userId - User ID for logging
  * @param options.userDisplayName - User's display name for {{user}} variable
@@ -9708,7 +9703,6 @@ app.post('/api/send-security-email', async (req, res) => {
 
   // Validate trigger type is a security-related trigger
   const securityTriggers = [
-    'EMAIL_CHANGE_VERIFICATION',
     'EMAIL_CHANGE_NOTIFICATION', 
     'PASSWORD_RESET_REQUEST',
     'PASSWORD_CHANGE_CONFIRMATION',

--- a/plant-swipe/src/components/admin/AdminEmailsPanel.tsx
+++ b/plant-swipe/src/components/admin/AdminEmailsPanel.tsx
@@ -59,15 +59,6 @@ const TRIGGER_VARIABLES: Record<string, {
     ]
   },
   // Security triggers - Email Change
-  EMAIL_CHANGE_VERIFICATION: {
-    category: 'security',
-    variables: [
-      { token: '{{user}}', description: "User's display name", required: true },
-      { token: '{{url}}', description: 'Secure link to verify new email (verification URL)', required: true },
-      { token: '{{new_email}}', description: 'The new email address being verified' },
-      { token: '{{old_email}}', description: 'The previous email address' },
-    ]
-  },
   EMAIL_CHANGE_NOTIFICATION: {
     category: 'security',
     variables: [


### PR DESCRIPTION
Remove unused `EMAIL_CHANGE_VERIFICATION` template to consolidate email verification.

The `EMAIL_CHANGE_VERIFICATION` template was an old URL-based verification method that was defined but never actually called in the codebase. The system exclusively uses the OTP-based `EMAIL_VERIFICATION` template for all email verification purposes.

---
<a href="https://cursor.com/background-agent?bcId=bc-083b4c18-0f07-41d7-9f4e-c49ebd25fbe5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-083b4c18-0f07-41d7-9f4e-c49ebd25fbe5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

