### PR TITLE
Admin bulk plant requests

### DIFF
--- a/plant-swipe/src/pages/AdminPage.tsx
+++ b/plant-swipe/src/pages/AdminPage.tsx
@@ -8440,7 +8440,7 @@ export const AdminPage: React.FC = () => {
                               Sorted by request count and most recent updates.
                             </div>
                           </div>
-                          <div className="flex flex-wrap items-center gap-2">
+                          <div className="flex flex-wrap items-center justify-end gap-2">
                             <Button
                               variant="outline"
                               className="rounded-xl"


### PR DESCRIPTION
Add a bulk plant request feature for admins in Admin / Plants / Requests.

This allows admins to paste a list of plant names, which are then parsed, deduplicated, checked against existing requests, and added one by one to avoid request limits, with progress and a summary provided.

---
<a href="https://cursor.com/background-agent?bcId=bc-aec3ccda-6ca6-4924-82ed-1a0e1a6b6e65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-aec3ccda-6ca6-4924-82ed-1a0e1a6b6e65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

