### PR TITLE
⚡ Bolt: Memoize SwipePage and stabilize handlers

### DIFF
--- a/plant-swipe/src/pages/SwipePage.tsx
+++ b/plant-swipe/src/pages/SwipePage.tsx
@@ -87,7 +87,7 @@ interface SwipePageProps {
   boostImagePriority?: boolean
 }
 
-export const SwipePage: React.FC<SwipePageProps> = ({
+const SwipePageComponent: React.FC<SwipePageProps> = ({
   current,
   index: _index,
   setIndex,
@@ -681,6 +681,10 @@ export const SwipePage: React.FC<SwipePageProps> = ({
       </div>
     )
 }
+
+// ⚡ Bolt: Memoize SwipePage to prevent re-renders on every parent state change (e.g. auth dialog toggles)
+// The handlers (handlePass, onDragEnd, etc.) are stable in PlantSwipe thanks to currentRef optimization.
+export const SwipePage = React.memo(SwipePageComponent)
 
 const EmptyState = ({ onReset }: { onReset: () => void }) => {
   const { t } = useTranslation("common")


### PR DESCRIPTION
This PR optimizes the `PlantSwipe` component by memoizing the `SwipePage` child component and stabilizing the event handlers passed to it.

Previously, `SwipePage` would re-render whenever `PlantSwipe` re-rendered (e.g., when auth dialog state changed, or notification toast state changed), even if the plant card itself didn't need to update. This was because the event handlers (`handlePass`, `handleInfo`, etc.) were recreated on every render.

By using a `useRef` to track the `current` plant and wrapping handlers in `useCallback`, we ensure that the props passed to `SwipePage` remain referentially stable unless the `index` changes (which triggers a necessary re-render). This reduces unnecessary re-renders of the heavy `SwipePage` component.

---
*PR created automatically by Jules for task [16011401930168120441](https://jules.google.com/task/16011401930168120441) started by @FrenchFive*