### PR TITLE
🛡️ Sentinel: [CRITICAL] Enforce strong ADMIN_BUTTON_SECRET in production

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@ Format:
 `**Vulnerability:** [What you found]`
 `**Learning:** [Why it existed]`
 `**Prevention:** [How to avoid next time]`
+
+## 2025-02-18 - Weak Default Secret Configuration
+**Vulnerability:** The Admin API's `APP_SECRET` defaulted to "change-me" in code, allowing potential authentication bypass if the environment variable `ADMIN_BUTTON_SECRET` was not set.
+**Learning:** Hardcoded default secrets in code ("secure by default" violation) are dangerous because they fail open if configuration is missing. Relying on documentation or "hope" that users change defaults is insufficient.
+**Prevention:** Enforce "Fail Secure". If critical secrets are missing or set to known defaults in production environments, the application should refuse to start. Added a check to `admin_api/app.py` to exit with a critical error if the secret is "change-me" in production.

--- a/admin_api/app.py
+++ b/admin_api/app.py
@@ -2,6 +2,7 @@ import hmac
 import hashlib
 import os
 import subprocess
+import sys
 from typing import Set, Optional
 
 from flask import Flask, request, abort, jsonify, Response
@@ -260,6 +261,19 @@ _load_repo_env()
 # Now read config variables AFTER env files are loaded
 APP_SECRET = _get_env_var("ADMIN_BUTTON_SECRET", "change-me")
 ADMIN_STATIC_TOKEN = _get_env_var("ADMIN_STATIC_TOKEN", "")
+
+# 🛡️ Sentinel Security Check
+if APP_SECRET == "change-me":
+    is_prod = os.environ.get("FLASK_ENV", "production") == "production"
+    msg = "[SECURITY] CRITICAL: ADMIN_BUTTON_SECRET is set to default 'change-me'. This allows unauthorized access."
+    if is_prod:
+        # Fail secure in production
+        print(f"{msg} Exiting.", file=sys.stderr)
+        sys.exit(1)
+    else:
+        # Warn in dev
+        print(f"{msg} Please set a strong secret in .env.", file=sys.stderr)
+
 # Allow nginx, node app, and admin api by default; can be overridden via env
 ALLOWED_SERVICES_RAW = _get_env_var("ADMIN_ALLOWED_SERVICES", "nginx,plant-swipe-node,admin-api")
 DEFAULT_SERVICE = _get_env_var("ADMIN_DEFAULT_SERVICE", "plant-swipe-node")


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The Admin API defaulted to a known weak secret ("change-me") if `ADMIN_BUTTON_SECRET` was not set, allowing authentication bypass.
🎯 Impact: Attackers could bypass admin authentication and forge requests.
🔧 Fix: Added a startup check in `admin_api/app.py`. If `APP_SECRET` is "change-me" and the environment is production, the app exits immediately. In dev, it warns.
✅ Verification: Created and ran `admin_api/test_security.py` to verify that production builds exit with status 1 and development builds warn but proceed.

---
*PR created automatically by Jules for task [15621940255036722322](https://jules.google.com/task/15621940255036722322) started by @FrenchFive*