### PR TITLE
Media app redirection setup

### DIFF
--- a/domain.json.example
+++ b/domain.json.example
@@ -1,0 +1,7 @@
+{
+  "domains": [
+    "aphylia.app",
+    "www.aphylia.app",
+    "media.aphylia.app"
+  ]
+}

--- a/setup.sh
+++ b/setup.sh
@@ -1315,9 +1315,16 @@ PY
     # Ask for full domains (domain and subdomains included)
     echo ""
     echo "Enter the full domain(s) you want SSL certificates for."
+    echo ""
+    echo "IMPORTANT: Include 'media.aphylia.app' if you want images to work correctly!"
+    echo "The media subdomain is required for serving images from Supabase storage."
+    echo ""
     echo "Examples:"
     echo "  - Single domain: aphylia.app"
-    echo "  - Multiple domains: dev01.aphylia.app,dev02.aphylia.app,aphylia.app"
+    echo "  - With media: aphylia.app,media.aphylia.app"
+    echo "  - Full setup: aphylia.app,www.aphylia.app,media.aphylia.app"
+    echo ""
+    echo "See domain.json.example in the repository for a sample configuration."
     echo ""
     read -p "Enter domain(s) (comma-separated): " domains_input
     domains_input="${domains_input// /}"  # trim whitespace
@@ -2165,6 +2172,13 @@ Next steps:
      * staging: Set to true to use Let's Encrypt staging (for testing)
    - For wildcard certificates (*.domain), set dns_plugin and dns_credentials in cert-info.json
    - Certificates auto-renew via certbot.timer (enabled by default)
+   
+   IMPORTANT: Media Subdomain for Images
+   - Include 'media.aphylia.app' in domain.json for proper image serving!
+   - The media subdomain proxies requests to Supabase storage
+   - See domain.json.example for a sample configuration
+   - Without media.aphylia.app, images will not load correctly
+   
 3) Then run:
    sudo bash scripts/refresh-plant-swipe.sh
 


### PR DESCRIPTION
Create `domain.json.example` and update `setup.sh` to ensure `media.aphylia.app` is correctly configured for image serving.

The `setup.sh` script conditionally includes the `media.aphylia.app` server block only if it's present in `domain.json`. Without a `domain.json` or clear guidance, this critical subdomain for image display was often omitted, causing images to fail loading. This PR adds an example file and explicit instructions to prevent this issue.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-a10aca90-2ac7-477c-b9e7-37b25d596f68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a10aca90-2ac7-477c-b9e7-37b25d596f68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

