### PR TITLE
Cookie banner privacy link

### DIFF
--- a/plant-swipe/src/components/CookieConsent.tsx
+++ b/plant-swipe/src/components/CookieConsent.tsx
@@ -295,7 +295,7 @@ export function CookieConsent() {
             </button>
             <div className="flex gap-3">
               <Link
-                to="/terms"
+                to="/privacy"
                 className="underline hover:text-stone-700 dark:hover:text-stone-300 transition-colors"
               >
                 {t('cookieConsent.privacyPolicy', 'Privacy Policy')}


### PR DESCRIPTION
Fixes the Cookie banner Privacy Policy link to point to `/privacy` instead of `/terms`.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-6bbdbf5f-5efb-407a-a405-d6233f8f9f81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6bbdbf5f-5efb-407a-a405-d6233f8f9f81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

