### PR TITLE
Admin page chart warning

### DIFF
--- a/plant-swipe/src/components/admin/LazyChart.tsx
+++ b/plant-swipe/src/components/admin/LazyChart.tsx
@@ -107,28 +107,32 @@ const useSafeContainerDimensions = (minWidth = 1, minHeight = 1) => {
 
 // Chart components that use the shared context
 // SafeResponsiveContainer waits for valid dimensions before rendering
-const ResponsiveContainerImpl: React.FC<ResponsiveContainerProps> = (props) => {
+const ResponsiveContainerImpl: React.FC<ResponsiveContainerProps> = ({ minWidth, minHeight, ...restProps }) => {
   const charts = useCharts()
   const { containerRef, isReady } = useSafeContainerDimensions(1, 1)
+  
+  // Enforce a floor of 1 so recharts never sees 0 or negative dimensions
+  const safeMinWidth = Math.max(Number(minWidth) || 1, 1)
+  const safeMinHeight = Math.max(Number(minHeight) || 1, 1)
   
   return (
     <div 
       ref={containerRef} 
       style={{ 
-        width: props.width ?? '100%', 
-        height: props.height ?? '100%',
-        minWidth: props.minWidth ?? 1,
-        minHeight: props.minHeight ?? 1,
+        width: restProps.width ?? '100%', 
+        height: restProps.height ?? '100%',
+        minWidth: safeMinWidth,
+        minHeight: safeMinHeight,
       }}
     >
       {isReady ? (
         <charts.ResponsiveContainer 
           debounce={50}
-          minWidth={1}
-          minHeight={1}
-          {...props}
+          {...restProps}
           width="100%"
           height="100%"
+          minWidth={safeMinWidth}
+          minHeight={safeMinHeight}
         />
       ) : (
         <div className="w-full h-full flex items-center justify-center">
@@ -280,12 +284,16 @@ export const SafeResponsiveContainer: React.FC<
   ResponsiveContainerProps & { 
     loadingFallback?: React.ReactNode 
   }
-> = ({ loadingFallback, children, ...props }) => {
+> = ({ loadingFallback, children, minWidth, minHeight, ...restProps }) => {
   const { containerRef, isReady } = useSafeContainerDimensions(1, 1)
   // Dynamically import ResponsiveContainer from recharts
   const [RechartResponsiveContainer, setRechartResponsiveContainer] = useState<
     typeof import('recharts').ResponsiveContainer | null
   >(null)
+  
+  // Enforce a floor of 1 so recharts never sees 0 or negative dimensions
+  const safeMinWidth = Math.max(Number(minWidth) || 1, 1)
+  const safeMinHeight = Math.max(Number(minHeight) || 1, 1)
   
   useEffect(() => {
     import('recharts').then((mod) => {
@@ -297,20 +305,20 @@ export const SafeResponsiveContainer: React.FC<
     <div 
       ref={containerRef} 
       style={{ 
-        width: props.width ?? '100%', 
-        height: props.height ?? '100%',
-        minWidth: props.minWidth ?? 1,
-        minHeight: props.minHeight ?? 1,
+        width: restProps.width ?? '100%', 
+        height: restProps.height ?? '100%',
+        minWidth: safeMinWidth,
+        minHeight: safeMinHeight,
       }}
     >
       {isReady && RechartResponsiveContainer ? (
         <RechartResponsiveContainer 
           debounce={50}
-          minWidth={1}
-          minHeight={1}
-          {...props}
+          {...restProps}
           width="100%"
           height="100%"
+          minWidth={safeMinWidth}
+          minHeight={safeMinHeight}
         >
           {children}
         </RechartResponsiveContainer>

--- a/plant-swipe/src/components/garden/GardenAnalyticsSection.tsx
+++ b/plant-swipe/src/components/garden/GardenAnalyticsSection.tsx
@@ -44,7 +44,7 @@ const ChartContainer: React.FC<
     return <div style={{ width: typeof w === "number" ? w : "100%", height: typeof h === "number" ? h : 0 }} />;
   }
   return (
-    <ResponsiveContainer width={w} height={h} minWidth={0} minHeight={0} {...rest}>
+    <ResponsiveContainer width={w} height={h} minWidth={1} minHeight={1} {...rest}>
       {children}
     </ResponsiveContainer>
   );

--- a/plant-swipe/src/pages/AdminPage.tsx
+++ b/plant-swipe/src/pages/AdminPage.tsx
@@ -7181,8 +7181,6 @@ export const AdminPage: React.FC = () => {
                                       <ResponsiveContainer
                                         width="100%"
                                         height="100%"
-                                        minWidth={0}
-                                        minHeight={0}
                                       >
                                         <ComposedChart
                                           data={visitorsSeries}
@@ -7355,8 +7353,6 @@ export const AdminPage: React.FC = () => {
                                               <ResponsiveContainer
                                                 width="100%"
                                                 height={150}
-                                                minWidth={0}
-                                                minHeight={0}
                                               >
                                                 <PieChart
                                                   margin={{
@@ -8035,7 +8031,7 @@ export const AdminPage: React.FC = () => {
                                               </div>
                                             }
                                           >
-                                            <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={0}>
+                                            <ResponsiveContainer width="100%" height="100%">
                                               <PieChart>
                                                 <Pie
                                                   data={plantStatusDonutData}
@@ -8118,7 +8114,7 @@ export const AdminPage: React.FC = () => {
                                                 </div>
                                               }
                                             >
-                                              <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={0}>
+                                              <ResponsiveContainer width="100%" height="100%">
                                                 <RadialBarChart
                                                   data={[{ name: "ratio", value: requestsVsApproved.gaugeValue }]}
                                                   startAngle={180}
@@ -8195,7 +8191,7 @@ export const AdminPage: React.FC = () => {
                                             </div>
                                           }
                                         >
-                                          <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={0}>
+                                          <ResponsiveContainer width="100%" height="100%">
                                             <BarChart data={promotionMonthData} barCategoryGap="10%" margin={{ left: 16, right: 16, top: 16, bottom: 12 }}>
                                               <CartesianGrid
                                                 strokeDasharray="3 3"
@@ -10882,8 +10878,6 @@ export const AdminPage: React.FC = () => {
                                           <ResponsiveContainer
                                             width="100%"
                                             height="100%"
-                                            minWidth={0}
-                                            minHeight={0}
                                           >
                                             <ComposedChart
                                               data={memberVisitsSeries}


### PR DESCRIPTION
Fixes recharts `ResponsiveContainer` warnings by ensuring charts always have positive minimum dimensions.

The `ResponsiveContainer` was logging warnings because `minWidth={0}` and `minHeight={0}` props, passed by callers, overrode the safe `minWidth={1}` and `minHeight={1}` defaults in `LazyChart.tsx` due to prop spreading order. This allowed recharts to calculate negative dimensions before layout completion. The fix ensures a minimum dimension of 1 is always enforced.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-fe10a533-85b2-4512-aa2c-16f91cf6593a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fe10a533-85b2-4512-aa2c-16f91cf6593a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

