### PR TITLE
🎨 Palette: Add focus styles to custom interactive elements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-05-26 - Search Keyboard Shortcut
 **Learning:** Adding a global search shortcut (⌘K/Ctrl+K) significantly improves navigation speed for power users. Visual hints in the search bar are essential for discoverability.
 **Action:** When implementing search, always include a keyboard shortcut and a visual badge (e.g., `<kbd>⌘K</kbd>`) when the input is empty.
+
+## 2025-05-27 - Focus Styles on Custom Interactive Elements
+**Learning:** Custom interactive elements (like icon-only buttons or mobile navigation items) using raw HTML tags often miss focus styles, making them inaccessible to keyboard users.
+**Action:** Always verify `focus-visible` styles when using raw `button` or `a` tags, especially in custom UI components like search inputs or navigation bars.

--- a/plant-swipe/src/components/layout/MobileNavBar.tsx
+++ b/plant-swipe/src/components/layout/MobileNavBar.tsx
@@ -410,6 +410,7 @@ function NavItem({
       className={`
         flex flex-col items-center justify-center gap-0.5 px-2 py-2 min-w-[56px] rounded-xl no-underline
         transition-colors duration-150 active:scale-95
+        focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500
         ${isActive 
           ? 'text-emerald-600 dark:text-emerald-400' 
           : 'text-stone-500 dark:text-stone-400 hover:text-stone-700 dark:hover:text-stone-200'
@@ -464,6 +465,7 @@ function NavItemButton({
       className={`
         flex flex-col items-center justify-center gap-0.5 px-2 py-2 min-w-[56px] rounded-xl
         transition-colors duration-150 active:scale-95
+        focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500
         ${highlight
           ? 'text-emerald-600 dark:text-emerald-400'
           : isActive 
@@ -508,7 +510,7 @@ function QuickActionButton({
     <button
       type="button"
       onClick={onClick}
-      className={`flex flex-col items-center gap-2 p-3 rounded-2xl active:scale-95 transition-all ${
+      className={`flex flex-col items-center gap-2 p-3 rounded-2xl active:scale-95 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 ${
         highlight 
           ? 'bg-emerald-50 dark:bg-emerald-900/20 hover:bg-emerald-100 dark:hover:bg-emerald-900/30' 
           : 'bg-stone-50 dark:bg-[#2a2a2d] hover:bg-stone-100 dark:hover:bg-[#333336]'
@@ -553,6 +555,7 @@ function MenuButton({
       className={`
         w-full flex items-center gap-3 px-4 py-3 rounded-xl
         transition-all duration-150 active:scale-[0.98]
+        focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500
         ${destructive 
           ? 'text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20' 
           : bugCatcher

--- a/plant-swipe/src/components/ui/search-input.tsx
+++ b/plant-swipe/src/components/ui/search-input.tsx
@@ -114,7 +114,7 @@ const SearchInput = React.forwardRef<HTMLInputElement, SearchInputProps>(
             type="button"
             onClick={onClear}
             className={cn(
-              "absolute top-1/2 -translate-y-1/2 text-stone-400 hover:text-stone-600 dark:text-stone-500 dark:hover:text-stone-300 transition-colors rounded-full hover:bg-stone-100 dark:hover:bg-stone-800 p-0.5",
+              "absolute top-1/2 -translate-y-1/2 text-stone-400 hover:text-stone-600 dark:text-stone-500 dark:hover:text-stone-300 transition-colors rounded-full hover:bg-stone-100 dark:hover:bg-stone-800 p-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500",
               isLarge ? "right-4" : isSmall ? "right-2.5" : "right-3"
             )}
             aria-label="Clear search"


### PR DESCRIPTION
Improved keyboard accessibility by adding visible focus indicators to the search input clear button and mobile navigation items. Verified with Playwright screenshots.

---
*PR created automatically by Jules for task [305724094130976972](https://jules.google.com/task/305724094130976972) started by @FrenchFive*