### PR TITLE
Mobile friend request bug

### DIFF
--- a/plant-swipe/src/components/layout/MobileNavBar.tsx
+++ b/plant-swipe/src/components/layout/MobileNavBar.tsx
@@ -53,6 +53,17 @@ const MobileNavBarComponent: React.FC<MobileNavBarProps> = ({ canCreate, onProfi
   const [notificationSheetOpen, setNotificationSheetOpen] = React.useState(false)
   const navRef = React.useRef<HTMLElement | null>(null)
 
+  // Helper to open notification sheet from profile menu.
+  // Delays the notification sheet opening so the profile menu Sheet
+  // fully closes first — avoids overlapping Radix Dialog transitions
+  // which can break pointer-event handling on mobile.
+  const openNotificationsFromMenu = React.useCallback(() => {
+    setProfileMenuOpen(false)
+    // Wait for the Sheet close animation (150ms) to finish before opening
+    // the notification sheet so Radix Dialog can clean up properly.
+    setTimeout(() => setNotificationSheetOpen(true), 180)
+  }, [])
+
   React.useEffect(() => {
     if (typeof document === "undefined") return undefined
     document.body.classList.add("mobile-nav-mounted")
@@ -201,10 +212,7 @@ const MobileNavBarComponent: React.FC<MobileNavBarProps> = ({ canCreate, onProfi
                   variant="secondary"
                   size="icon"
                   className="rounded-2xl h-9 w-9"
-                  onClick={() => {
-                    setProfileMenuOpen(false)
-                    setNotificationSheetOpen(true)
-                  }}
+                  onClick={openNotificationsFromMenu}
                   aria-label="Notifications"
                 >
                   <Bell className="h-4 w-4" />
@@ -226,10 +234,7 @@ const MobileNavBarComponent: React.FC<MobileNavBarProps> = ({ canCreate, onProfi
             {combinedNotificationCount > 0 && (
               <div className="px-4 py-3">
                 <button
-                  onClick={() => {
-                    setProfileMenuOpen(false)
-                    setNotificationSheetOpen(true)
-                  }}
+                  onClick={openNotificationsFromMenu}
                   className="w-full p-4 rounded-2xl bg-amber-50 dark:bg-amber-900/20 border border-amber-200/50 dark:border-amber-800/30 flex items-center gap-4 active:scale-[0.98] transition-transform"
                 >
                   <div className="h-10 w-10 rounded-full bg-amber-100 dark:bg-amber-900/40 flex items-center justify-center">

--- a/plant-swipe/src/components/layout/NotificationPanel.tsx
+++ b/plant-swipe/src/components/layout/NotificationPanel.tsx
@@ -157,7 +157,8 @@ export function NotificationPanel({
   const handleAcceptFriendRequest = async (requestId: string) => {
     setProcessingId(requestId)
     try {
-      await supabase.rpc('accept_friend_request', { _request_id: requestId })
+      const { error } = await supabase.rpc('accept_friend_request', { _request_id: requestId })
+      if (error) throw error
       await onRefresh(true) // Force refresh to bypass throttle
       refreshBadge()
     } catch (e: any) {
@@ -170,10 +171,11 @@ export function NotificationPanel({
   const handleRejectFriendRequest = async (requestId: string) => {
     setProcessingId(requestId)
     try {
-      await supabase
+      const { error } = await supabase
         .from('friend_requests')
         .update({ status: 'rejected' })
         .eq('id', requestId)
+      if (error) throw error
       await onRefresh(true) // Force refresh to bypass throttle
       refreshBadge()
     } catch (e: any) {

--- a/plant-swipe/src/pages/FriendsPage.tsx
+++ b/plant-swipe/src/pages/FriendsPage.tsx
@@ -422,7 +422,8 @@ export const FriendsPage: React.FC = () => {
           // If there's a pending request FROM the other user TO us, we should accept it instead
           if (existingRequest.requester_id === recipientId) {
             // Accept their request instead of sending a new one
-            await supabase.rpc("accept_friend_request", { _request_id: existingRequest.id });
+            const { error: acceptErr } = await supabase.rpc("accept_friend_request", { _request_id: existingRequest.id });
+            if (acceptErr) throw acceptErr;
             handleDialogSearch();
             await Promise.all([loadFriends(), loadPendingRequests(), loadSentPendingRequests()]);
             setError(null);
@@ -469,7 +470,8 @@ export const FriendsPage: React.FC = () => {
   const acceptRequest = React.useCallback(async (requestId: string) => {
     setProcessingId(requestId);
     try {
-      await supabase.rpc("accept_friend_request", { _request_id: requestId });
+      const { error } = await supabase.rpc("accept_friend_request", { _request_id: requestId });
+      if (error) throw error;
       await Promise.all([loadFriends(), loadPendingRequests(), loadSentPendingRequests()]);
       setError(null);
       // Refresh app badge after accepting request
@@ -487,7 +489,8 @@ export const FriendsPage: React.FC = () => {
   const rejectRequest = React.useCallback(async (requestId: string) => {
     setProcessingId(requestId);
     try {
-      await supabase.from("friend_requests").update({ status: "rejected" }).eq("id", requestId);
+      const { error } = await supabase.from("friend_requests").update({ status: "rejected" }).eq("id", requestId);
+      if (error) throw error;
       await Promise.all([loadPendingRequests(), loadSentPendingRequests()]);
       setError(null);
       // Refresh app badge after rejecting request


### PR DESCRIPTION
Fixes friend request acceptance from mobile notifications by handling Supabase RPC errors and preventing overlapping UI transitions.

The bug stemmed from two issues: Supabase `.rpc()` and `.update()` calls silently swallowing errors, causing failed actions to appear unresponsive, and simultaneous Radix Dialog transitions for the profile menu and notification sheet interfering with mobile pointer events.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-7808d113-1962-4e48-885d-c4499d06a2bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7808d113-1962-4e48-885d-c4499d06a2bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

