### PR TITLE
Email template save redirect

### DIFF
--- a/plant-swipe/src/pages/AdminEmailTemplatePage.tsx
+++ b/plant-swipe/src/pages/AdminEmailTemplatePage.tsx
@@ -703,7 +703,30 @@ export const AdminEmailTemplatePage: React.FC = () => {
         }
       }
 
-      navigate("/admin/emails/templates")
+      if (isNew) {
+        // For new templates, navigate to the edit page of the newly created template
+        if (templateId) {
+          navigate(`/admin/emails/templates/${templateId}`)
+        } else {
+          navigate("/admin/emails/templates")
+        }
+      } else {
+        // For existing templates, stay on the page and update local state
+        const savedTemplate = data.template
+        if (savedTemplate) {
+          setExistingTemplate(prev => prev ? {
+            ...prev,
+            title: savedTemplate.title ?? templateForm.title,
+            subject: savedTemplate.subject ?? defaultContent.subject,
+            description: savedTemplate.description ?? templateForm.description,
+            bodyHtml: savedTemplate.bodyHtml ?? defaultContent.bodyHtml,
+            bodyJson: savedTemplate.bodyJson ?? defaultContent.bodyDoc,
+            updatedAt: savedTemplate.updatedAt ?? new Date().toISOString(),
+            version: savedTemplate.version ?? prev.version,
+          } : prev)
+        }
+        setTranslationsCache(updatedCache)
+      }
     } catch (err) {
       alert((err as Error).message)
     } finally {


### PR DESCRIPTION
Change email template save behavior to prevent unwanted redirects and improve user flow.

The previous implementation always navigated back to the template list (`/admin/emails/templates`) after saving, regardless of whether the user was creating a new template or editing an existing one. This PR modifies the `handleSave` function so that existing templates keep the user on the current edit page, and new templates navigate to the newly created template's edit page.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-71cf8ca3-4c46-48fb-92bc-f7b117b9d19b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-71cf8ca3-4c46-48fb-92bc-f7b117b9d19b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

