### PR TITLE
🎨 Palette: Add focus rings to mobile navigation

### DIFF
--- a/plant-swipe/src/components/layout/MobileNavBar.tsx
+++ b/plant-swipe/src/components/layout/MobileNavBar.tsx
@@ -235,7 +235,7 @@ const MobileNavBarComponent: React.FC<MobileNavBarProps> = ({ canCreate, onProfi
               <div className="px-4 py-3">
                 <button
                   onClick={openNotificationsFromMenu}
-                  className="w-full p-4 rounded-2xl bg-amber-50 dark:bg-amber-900/20 border border-amber-200/50 dark:border-amber-800/30 flex items-center gap-4 active:scale-[0.98] transition-transform"
+                  className="w-full p-4 rounded-2xl bg-amber-50 dark:bg-amber-900/20 border border-amber-200/50 dark:border-amber-800/30 flex items-center gap-4 active:scale-[0.98] transition-transform focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500"
                 >
                   <div className="h-10 w-10 rounded-full bg-amber-100 dark:bg-amber-900/40 flex items-center justify-center">
                     <Bell className="h-5 w-5 text-amber-600 dark:text-amber-400" />
@@ -359,7 +359,7 @@ const MobileNavBarComponent: React.FC<MobileNavBarProps> = ({ canCreate, onProfi
                 setGuestMenuOpen(false)
                 if (onLogin) onLogin()
               }}
-              className="w-full text-left px-4 py-3 rounded-2xl hover:bg-stone-100 dark:hover:bg-[#2d2d30] flex items-center gap-3 active:scale-[0.98] transition-transform"
+              className="w-full text-left px-4 py-3 rounded-2xl hover:bg-stone-100 dark:hover:bg-[#2d2d30] flex items-center gap-3 active:scale-[0.98] transition-transform focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500"
             >
               <LogIn className="h-5 w-5" />
               <span>{t("common.login")}</span>
@@ -369,7 +369,7 @@ const MobileNavBarComponent: React.FC<MobileNavBarProps> = ({ canCreate, onProfi
                 setGuestMenuOpen(false)
                 if (onSignup) onSignup()
               }}
-              className="w-full text-left px-4 py-3 rounded-2xl hover:bg-stone-100 dark:hover:bg-[#2d2d30] flex items-center gap-3 text-emerald-600 dark:text-emerald-400 active:scale-[0.98] transition-transform"
+              className="w-full text-left px-4 py-3 rounded-2xl hover:bg-stone-100 dark:hover:bg-[#2d2d30] flex items-center gap-3 text-emerald-600 dark:text-emerald-400 active:scale-[0.98] transition-transform focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500"
             >
               <UserPlus className="h-5 w-5" />
               <span>{t("common.signup")}</span>
@@ -414,7 +414,7 @@ function NavItem({
       to={to}
       className={`
         flex flex-col items-center justify-center gap-0.5 px-2 py-2 min-w-[56px] rounded-xl no-underline
-        transition-colors duration-150 active:scale-95
+        transition-colors duration-150 active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500
         ${isActive 
           ? 'text-emerald-600 dark:text-emerald-400' 
           : 'text-stone-500 dark:text-stone-400 hover:text-stone-700 dark:hover:text-stone-200'
@@ -468,7 +468,7 @@ function NavItemButton({
       onClick={onClick}
       className={`
         flex flex-col items-center justify-center gap-0.5 px-2 py-2 min-w-[56px] rounded-xl
-        transition-colors duration-150 active:scale-95
+        transition-colors duration-150 active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500
         ${highlight
           ? 'text-emerald-600 dark:text-emerald-400'
           : isActive 
@@ -513,7 +513,7 @@ function QuickActionButton({
     <button
       type="button"
       onClick={onClick}
-      className={`flex flex-col items-center gap-2 p-3 rounded-2xl active:scale-95 transition-all ${
+      className={`flex flex-col items-center gap-2 p-3 rounded-2xl active:scale-95 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 ${
         highlight 
           ? 'bg-emerald-50 dark:bg-emerald-900/20 hover:bg-emerald-100 dark:hover:bg-emerald-900/30' 
           : 'bg-stone-50 dark:bg-[#2a2a2d] hover:bg-stone-100 dark:hover:bg-[#333336]'
@@ -557,7 +557,7 @@ function MenuButton({
       onClick={onClick}
       className={`
         w-full flex items-center gap-3 px-4 py-3 rounded-xl
-        transition-all duration-150 active:scale-[0.98]
+        transition-all duration-150 active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500
         ${destructive 
           ? 'text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20' 
           : bugCatcher


### PR DESCRIPTION
*   💡 **What:** Added `focus-visible:ring-2` and `focus-visible:ring-emerald-500` styles to `NavItem` and `NavItemButton` components in `MobileNavBar.tsx`.
*   🎯 **Why:** To improve accessibility for keyboard and screen reader users by providing clear visual indicators when navigating the mobile menu.
*   📸 **Before/After:** (Verified locally with Playwright screenshots)
*   ♿ **Accessibility:** Ensures interactive elements in the mobile navbar meet WCAG focus visible requirements.

---
*PR created automatically by Jules for task [9781531765829080565](https://jules.google.com/task/9781531765829080565) started by @FrenchFive*