### PR TITLE
Garden context always included

### DIFF
--- a/plant-swipe/src/components/aphylia/AphyliaChat.tsx
+++ b/plant-swipe/src/components/aphylia/AphyliaChat.tsx
@@ -8,19 +8,17 @@
  * Context is passed directly to the hook via refs, not state, to avoid re-render loops.
  */
 
-import React, { useMemo } from 'react'
+import React from 'react'
 import { useAphyliaChat } from '@/hooks/useAphyliaChat'
 import { AphyliaChatBubble } from './AphyliaChatBubble'
 import { AphyliaChatPanel } from './AphyliaChatPanel'
-import type { GardenContext, PlantContext, ContextChip } from '@/types/aphyliaChat'
+import type { GardenContext, PlantContext } from '@/types/aphyliaChat'
 
 interface AphyliaChatProps {
   /** Current garden context (pass when user is viewing a garden) */
   gardenContext?: GardenContext | null
   /** Current plant context (pass when user is viewing a specific plant) */
   plantContext?: PlantContext | null
-  /** Additional context chips available for the user to select */
-  availableChips?: ContextChip[]
   /** Whether to show the chat bubble (can be hidden on certain pages) */
   showBubble?: boolean
   /** Class name for positioning overrides */
@@ -30,11 +28,11 @@ interface AphyliaChatProps {
 export const AphyliaChat: React.FC<AphyliaChatProps> = ({
   gardenContext,
   plantContext,
-  availableChips = [],
   showBubble = true,
   className
 }) => {
   // Pass context directly to hook - it uses refs internally to avoid re-render issues
+  // Garden context is ALWAYS included automatically (no user toggle needed)
   const {
     state,
     closeChat,
@@ -45,8 +43,6 @@ export const AphyliaChat: React.FC<AphyliaChatProps> = ({
     executeQuickAction,
     uploadImage,
     removePendingAttachment,
-    addContextChip,
-    removeContextChip,
     clearMessages,
     abortStream,
     isStreaming
@@ -54,34 +50,6 @@ export const AphyliaChat: React.FC<AphyliaChatProps> = ({
     gardenContext,
     plantContext
   })
-  
-  // Build available chips from context - memoized to avoid unnecessary re-renders
-  // We intentionally use specific properties instead of full objects to prevent
-  // re-renders caused by object reference changes from parent components
-  const computedAvailableChips = useMemo(() => {
-    const chips: ContextChip[] = [...availableChips]
-    
-    if (gardenContext) {
-      chips.unshift({
-        type: 'garden',
-        id: gardenContext.gardenId,
-        label: gardenContext.gardenName,
-        data: { ...gardenContext }
-      })
-    }
-    
-    if (plantContext) {
-      chips.unshift({
-        type: 'plant',
-        id: plantContext.gardenPlantId,
-        label: plantContext.nickname || plantContext.plantName,
-        data: { ...plantContext }
-      })
-    }
-    
-    return chips
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [gardenContext?.gardenId, gardenContext?.gardenName, plantContext?.gardenPlantId, plantContext?.nickname, plantContext?.plantName, availableChips])
   
   // Handle image upload
   const handleUploadImage = async (file: File) => {
@@ -103,7 +71,7 @@ export const AphyliaChat: React.FC<AphyliaChatProps> = ({
         />
       )}
       
-      {/* Chat panel */}
+      {/* Chat panel - garden context is always included automatically */}
       <AphyliaChatPanel
         isOpen={state.isOpen}
         isMinimized={state.isMinimized}
@@ -111,7 +79,6 @@ export const AphyliaChat: React.FC<AphyliaChatProps> = ({
         input={state.input}
         pendingAttachments={state.pendingAttachments}
         selectedChips={state.selectedChips}
-        availableChips={computedAvailableChips}
         isSending={state.isSending}
         isStreaming={isStreaming}
         onClose={closeChat}
@@ -120,8 +87,6 @@ export const AphyliaChat: React.FC<AphyliaChatProps> = ({
         onSendMessage={sendMessage}
         onUploadImage={handleUploadImage}
         onRemoveAttachment={removePendingAttachment}
-        onAddChip={addContextChip}
-        onRemoveChip={removeContextChip}
         onClearMessages={clearMessages}
         onQuickAction={executeQuickAction}
         onAbortStream={abortStream}

--- a/plant-swipe/src/components/aphylia/AphyliaChatPanel.tsx
+++ b/plant-swipe/src/components/aphylia/AphyliaChatPanel.tsx
@@ -44,7 +44,6 @@ interface AphyliaChatPanelProps {
   input: string
   pendingAttachments: ChatAttachment[]
   selectedChips: ContextChip[]
-  availableChips: ContextChip[]
   isSending: boolean
   isStreaming: boolean
   onClose: () => void
@@ -53,8 +52,6 @@ interface AphyliaChatPanelProps {
   onSendMessage: (content?: string) => void
   onUploadImage: (file: File) => Promise<void>
   onRemoveAttachment: (id: string) => void
-  onAddChip: (chip: ContextChip) => void
-  onRemoveChip: (id: string) => void
   onClearMessages: () => void
   onQuickAction: (actionId: QuickActionId) => void
   onAbortStream: () => void
@@ -261,7 +258,6 @@ export const AphyliaChatPanel: React.FC<AphyliaChatPanelProps> = ({
   input,
   pendingAttachments,
   selectedChips,
-  availableChips,
   isSending,
   isStreaming,
   onClose,
@@ -270,8 +266,6 @@ export const AphyliaChatPanel: React.FC<AphyliaChatPanelProps> = ({
   onSendMessage,
   onUploadImage,
   onRemoveAttachment,
-  onAddChip,
-  onRemoveChip,
   onClearMessages,
   onQuickAction,
   onAbortStream,
@@ -513,19 +507,17 @@ export const AphyliaChatPanel: React.FC<AphyliaChatPanelProps> = ({
                       </div>
                     </div>
                     
-                    {/* Context chips */}
-                    {availableChips.length > 0 && (
+                    {/* Active context indicator - garden context is always included */}
+                    {selectedChips.length > 0 && (
                       <div className="space-y-2">
                         <p className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide px-1">
-                          {t('aphylia.context.title', 'Add Context')}
+                          {t('aphylia.context.activeTitle', 'Context')}
                         </p>
                         <div className="flex flex-wrap gap-2">
-                          {availableChips.map(chip => (
+                          {selectedChips.map(chip => (
                             <ContextChipBadge
                               key={`${chip.type}-${chip.id}`}
                               chip={chip}
-                              selectable
-                              onSelect={() => onAddChip(chip)}
                             />
                           ))}
                         </div>
@@ -547,15 +539,14 @@ export const AphyliaChatPanel: React.FC<AphyliaChatPanelProps> = ({
                 )}
               </div>
               
-              {/* Selected context chips */}
-              {selectedChips.length > 0 && (
+              {/* Active context chips (always included, non-removable) */}
+              {selectedChips.length > 0 && messages.length > 0 && (
                 <div className="flex-shrink-0 px-3 py-2 border-t border-gray-100 dark:border-gray-800">
                   <div className="flex flex-wrap gap-1.5">
                     {selectedChips.map(chip => (
                       <ContextChipBadge
                         key={`selected-${chip.type}-${chip.id}`}
                         chip={chip}
-                        onRemove={() => onRemoveChip(chip.id)}
                       />
                     ))}
                   </div>


### PR DESCRIPTION
Removes the 'Add Context' UI from the AI chat to ensure garden context is always included and non-removable.

The previous UI allowed users to manually add/remove context chips, even though the garden context was already being sent to the API. This change aligns the UI with the intended behavior, making the garden context a permanent, non-configurable part of the chat.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-1d9e47ac-60ec-4b0d-9838-25f37db21d1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1d9e47ac-60ec-4b0d-9838-25f37db21d1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

