### PR TITLE
Plant scan malfunction

### DIFF
--- a/plant-swipe/supabase/DATABASE_SCHEMA.md
+++ b/plant-swipe/supabase/DATABASE_SCHEMA.md
@@ -347,6 +347,36 @@ used_at     TIMESTAMPTZ
 UNIQUE(user_id, code)
 ```
 
+### `plant_scans`
+
+```sql
+id                          UUID PRIMARY KEY
+user_id                     UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE
+image_url                   TEXT NOT NULL
+image_path                  TEXT             -- Storage path if stored in Supabase
+image_bucket                TEXT DEFAULT 'PHOTOS'
+api_access_token            TEXT             -- Kindwise API access token for the request
+api_model_version           TEXT             -- e.g., 'plant_id:3.1.0'
+api_status                  TEXT DEFAULT 'pending'  -- pending, processing, completed, failed
+api_response                JSONB            -- Full API response stored for reference
+is_plant                    BOOLEAN
+is_plant_probability        NUMERIC(5,4)     -- 0.0000 to 1.0000
+top_match_name              TEXT
+top_match_scientific_name   TEXT
+top_match_probability       NUMERIC(5,4)
+top_match_entity_id         TEXT
+suggestions                 JSONB DEFAULT '[]'  -- All identification suggestions
+similar_images              JSONB DEFAULT '[]'  -- Similar images from API
+latitude                    NUMERIC(9,6)
+longitude                   NUMERIC(9,6)
+classification_level        TEXT DEFAULT 'species'  -- 'species', 'all', or 'genus'
+matched_plant_id            TEXT REFERENCES plants(id) ON DELETE SET NULL
+user_notes                  TEXT
+created_at                  TIMESTAMPTZ DEFAULT NOW()
+updated_at                  TIMESTAMPTZ DEFAULT NOW()
+deleted_at                  TIMESTAMPTZ      -- Soft delete
+```
+
 ---
 
 ## Row Level Security (RLS)

--- a/plant-swipe/supabase/sync_parts/14_scanning_and_bugs.sql
+++ b/plant-swipe/supabase/sync_parts/14_scanning_and_bugs.sql
@@ -39,6 +39,9 @@ CREATE TABLE IF NOT EXISTS public.plant_scans (
   latitude NUMERIC(9,6),
   longitude NUMERIC(9,6),
   
+  -- Classification level used for the identification request
+  classification_level TEXT DEFAULT 'species',  -- 'species', 'all', or 'genus'
+  
   -- Link to our database plant (if matched)
   matched_plant_id TEXT REFERENCES public.plants(id) ON DELETE SET NULL,
   
@@ -68,6 +71,7 @@ ALTER TABLE public.plant_scans ADD COLUMN IF NOT EXISTS suggestions JSONB DEFAUL
 ALTER TABLE public.plant_scans ADD COLUMN IF NOT EXISTS similar_images JSONB DEFAULT '[]'::jsonb;
 ALTER TABLE public.plant_scans ADD COLUMN IF NOT EXISTS latitude NUMERIC(9,6);
 ALTER TABLE public.plant_scans ADD COLUMN IF NOT EXISTS longitude NUMERIC(9,6);
+ALTER TABLE public.plant_scans ADD COLUMN IF NOT EXISTS classification_level TEXT DEFAULT 'species';
 ALTER TABLE public.plant_scans ADD COLUMN IF NOT EXISTS matched_plant_id TEXT;
 ALTER TABLE public.plant_scans ADD COLUMN IF NOT EXISTS user_notes TEXT;
 ALTER TABLE public.plant_scans ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ DEFAULT NOW();


### PR DESCRIPTION
Add `classification_level` column to `plant_scans` table and update schema documentation.

The Plant Scan feature was broken because the application code (`plantScan.ts`) expected the `classification_level` column to exist in the `plant_scans` table, but it was never added to the database schema (`14_scanning_and_bugs.sql`). This PR adds the missing column and updates the `DATABASE_SCHEMA.md` for clarity.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-f73d3500-e4e4-48f9-9a11-7936a160d844"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f73d3500-e4e4-48f9-9a11-7936a160d844"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

