### PR TITLE
User task frequency

### DIFF
--- a/plant-swipe/src/components/plant/SchedulePickerDialog.tsx
+++ b/plant-swipe/src/components/plant/SchedulePickerDialog.tsx
@@ -2,6 +2,7 @@
 import React from 'react'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
+import { Minus, Plus } from 'lucide-react'
 
 type Period = 'week' | 'month' | 'year'
 
@@ -260,15 +261,25 @@ export function SchedulePickerDialog(props: {
                 })}
               </div>
             </div>
-            <input
-              type="number"
-              className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring md:text-sm"
-              min={1}
-              max={maxForPeriod(lockToYear ? 'year' : period)}
-              value={String(amount)}
-              onChange={(e) => handleAmountChange(Number(e.target.value || '1'))}
-              disabled={!!lockToYear}
-            />
+            <div className="flex items-center gap-0 rounded-md border border-input bg-transparent overflow-hidden h-9">
+              <button
+                type="button"
+                onClick={() => handleAmountChange(amount - 1)}
+                disabled={amount <= 1 || !!lockToYear}
+                className="h-full w-9 flex items-center justify-center text-stone-500 hover:bg-stone-100 dark:hover:bg-stone-700 disabled:opacity-30 transition-colors"
+              >
+                <Minus className="w-4 h-4" />
+              </button>
+              <span className="flex-1 text-center font-bold text-base tabular-nums select-none">{amount}</span>
+              <button
+                type="button"
+                onClick={() => handleAmountChange(amount + 1)}
+                disabled={amount >= maxForPeriod(lockToYear ? 'year' : period) || !!lockToYear}
+                className="h-full w-9 flex items-center justify-center text-stone-500 hover:bg-stone-100 dark:hover:bg-stone-700 disabled:opacity-30 transition-colors"
+              >
+                <Plus className="w-4 h-4" />
+              </button>
+            </div>
           </div>
             <div className="text-xs opacity-60">
               {(!lockToYear && period === 'week') && 'Max 7 per week.'}


### PR DESCRIPTION
Replaced the frequency number input with a stepper control in `SchedulePickerDialog` to fix mobile input issues.

On mobile, the previous `<input type="number">` would append digits (e.g., '1' + '7' became '17') instead of replacing the value, leading to incorrect clamping and preventing users from setting the desired frequency for tasks. This change aligns the editing experience with the task creation dialog.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-c406d72f-81ca-4249-ad43-93ac5fb80b0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c406d72f-81ca-4249-ad43-93ac5fb80b0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

