### PR TITLE
Friend request acceptance bug

### DIFF
--- a/plant-swipe/supabase/sync_parts/14_scanning_and_bugs.sql
+++ b/plant-swipe/supabase/sync_parts/14_scanning_and_bugs.sql
@@ -910,8 +910,8 @@ BEGIN
   IF NEW.status = 'pending' THEN
     -- Count pending friend requests sent by this user in the last hour
     SELECT COUNT(*)::INTEGER INTO v_request_count
-    FROM public.friends
-    WHERE user_id = NEW.user_id
+    FROM public.friend_requests
+    WHERE requester_id = NEW.requester_id
       AND status = 'pending'
       AND created_at > NOW() - v_window_interval;
     
@@ -924,9 +924,12 @@ BEGIN
 END;
 $$;
 
+-- Remove the old incorrect trigger from the friends table
 DROP TRIGGER IF EXISTS friend_request_rate_limit_trigger ON public.friends;
+-- Create the trigger on the correct table: friend_requests
+DROP TRIGGER IF EXISTS friend_request_rate_limit_trigger ON public.friend_requests;
 CREATE TRIGGER friend_request_rate_limit_trigger
-  BEFORE INSERT ON public.friends
+  BEFORE INSERT ON public.friend_requests
   FOR EACH ROW
   EXECUTE FUNCTION public.check_friend_request_rate_limit();
 


### PR DESCRIPTION
Move `friend_request_rate_limit_trigger` to the `friend_requests` table and correct column references to fix friend request acceptance.

The trigger was incorrectly attached to the `friends` table, which caused an error (`record "new" has no field "status"`) when accepting friend requests because the `friends` table does not have a `status` column. This fix ensures the trigger correctly applies to `friend_requests` and references the appropriate columns.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-bc477cad-9dd6-4059-afb8-910d4c605647"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bc477cad-9dd6-4059-afb8-910d4c605647"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

