### PR TITLE
🛡️ Sentinel: Harden Admin API inputs and configuration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@ Format:
 `**Vulnerability:** [What you found]`
 `**Learning:** [Why it existed]`
 `**Prevention:** [How to avoid next time]`
+
+## 2026-02-06 - Admin API Input Validation & Configuration
+**Vulnerability:** The `/admin/pull-code` endpoint accepted raw branch names and passed them to a shell script (`scripts/refresh-plant-swipe.sh`). While the script quoted the variable, it lacked strict validation against argument injection (e.g. branch names starting with `-`) or shell metacharacters. Additionally, the `APP_SECRET` fail-secure policy (terminating in production if default) was missing in code despite being documented.
+**Learning:** Admin endpoints, even if internal, are high-value targets. Trusting shell scripts to handle inputs safely is insufficient; input validation must occur at the API boundary (defense in depth). Documentation of security controls (like fail-secure defaults) can drift from implementation.
+**Prevention:** Enforce strict allow-lists (regex) for all inputs passed to shell commands. Implement explicit checks for default secrets at application startup and fail hard in production environments.


### PR DESCRIPTION
🛡️ Sentinel: Harden Admin API inputs and configuration

**Vulnerability:** The `/admin/pull-code` endpoint accepted raw branch names and passed them to a shell script. This allowed potential argument injection (e.g. branch names starting with `-`) or command injection via shell metacharacters. Additionally, the `APP_SECRET` fail-secure policy was missing in code.

**Fix:**
- Added `_validate_branch_name` function to enforce strict regex whitelist and reject hyphens at start.
- Added explicit check for `APP_SECRET` default value in production to fail fast.
- Updated `admin_refresh` and `admin_refresh_stream` to use validation.

**Verification:**
- Verified syntax with `python3 -m py_compile`.
- Verified regex logic with test script.


---
*PR created automatically by Jules for task [7722701591135709508](https://jules.google.com/task/7722701591135709508) started by @FrenchFive*