### PR TITLE
🎨 Palette: Improved Garden List Empty State

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2025-05-26 - Search Keyboard Shortcut
 **Learning:** Adding a global search shortcut (⌘K/Ctrl+K) significantly improves navigation speed for power users. Visual hints in the search bar are essential for discoverability.
 **Action:** When implementing search, always include a keyboard shortcut and a visual badge (e.g., `<kbd>⌘K</kbd>`) when the input is empty.
+
+## 2025-05-27 - Garden List Empty State
+**Learning:** The "No gardens yet" empty state was previously just a text line, which failed to encourage new users to create their first garden.
+**Action:** Replaced the text-only empty state with a centered `Card` component featuring a `Sprout` icon and a prominent "Create Garden" button, aligning with the established empty state pattern used elsewhere in the app.

--- a/plant-swipe/src/pages/GardenListPage.tsx
+++ b/plant-swipe/src/pages/GardenListPage.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Sprout } from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -2282,9 +2283,18 @@ export const GardenListPage: React.FC = () => {
                   </div>
                 </Card>
               ) : (
-                <div className="opacity-60 text-sm">
-                  {t("garden.noGardens")}. {t("garden.createFirst")}
-                </div>
+                <Card className="rounded-[28px] border border-stone-200/80 dark:border-[#3e3e42]/80 bg-white/80 dark:bg-[#1f1f1f]/80 backdrop-blur p-8 max-w-md mx-auto shadow-[0_25px_70px_-40px_rgba(15,23,42,0.65)] flex flex-col items-center">
+                  <div className="w-16 h-16 rounded-full bg-emerald-100 dark:bg-emerald-900/30 flex items-center justify-center mb-4">
+                    <Sprout className="w-8 h-8 text-emerald-600 dark:text-emerald-400" />
+                  </div>
+                  <h3 className="text-lg font-semibold mb-2">{t("garden.noGardens")}</h3>
+                  <p className="text-sm opacity-60 mb-6 max-w-xs mx-auto">
+                    {t("garden.createFirst")}
+                  </p>
+                  <Button className="rounded-2xl w-full" onClick={() => setOpen(true)}>
+                    {t("garden.create")}
+                  </Button>
+                </Card>
               )}
             </div>
           )}


### PR DESCRIPTION
💡 What: Improved the empty state on the Garden List page for logged-in users who haven't created a garden yet.
🎯 Why: The previous empty state was a simple text message ("No gardens yet. Create your first garden to get started!"), which was easy to miss and didn't encourage action.
📸 Changes: Replaced the text with a centered `Card` component featuring a green `Sprout` icon, clear title/description, and a prominent "Create Garden" button.
♿ Accessibility: The new state uses semantic headings and a button with a clear call-to-action, improving navigation for all users.
👋 Patterns: Aligns with the established empty state pattern used in other parts of the application (e.g. GardenListSidebar).

---
*PR created automatically by Jules for task [13272487498226122997](https://jules.google.com/task/13272487498226122997) started by @FrenchFive*