### PR TITLE
Plant request notification sync

### DIFF
--- a/plant-swipe/server.js
+++ b/plant-swipe/server.js
@@ -8386,9 +8386,7 @@ app.get('/api/admin/notification-automations', async (req, res) => {
               join public.garden_members gm on gm.user_id = p.id
               join public.garden_plant_tasks t on t.garden_id = gm.garden_id
               join public.garden_plant_task_occurrences occ on occ.task_id = t.id
-              where (p.notify_push is null or p.notify_push = true)
-                and (p.push_task_reminders is null or p.push_task_reminders = true)
-                and (occ.due_at at time zone coalesce(p.timezone, ${DEFAULT_USER_TIMEZONE}))::date = (now() at time zone coalesce(p.timezone, ${DEFAULT_USER_TIMEZONE}))::date
+              where (occ.due_at at time zone coalesce(p.timezone, ${DEFAULT_USER_TIMEZONE}))::date = (now() at time zone coalesce(p.timezone, ${DEFAULT_USER_TIMEZONE}))::date
                 and coalesce(occ.completed_count, 0) < coalesce(occ.required_count, 1)
                 and not exists (
                   select 1 from public.user_notifications un
@@ -8750,9 +8748,7 @@ async function runAutomation(automation) {
       join public.garden_members gm on gm.user_id = p.id
       join public.garden_plant_tasks t on t.garden_id = gm.garden_id
       join public.garden_plant_task_occurrences occ on occ.task_id = t.id
-      where (p.notify_push is null or p.notify_push = true)
-        and (p.push_task_reminders is null or p.push_task_reminders = true)
-        and (occ.due_at at time zone coalesce(p.timezone, ${DEFAULT_USER_TIMEZONE}))::date = (now() at time zone coalesce(p.timezone, ${DEFAULT_USER_TIMEZONE}))::date
+      where (occ.due_at at time zone coalesce(p.timezone, ${DEFAULT_USER_TIMEZONE}))::date = (now() at time zone coalesce(p.timezone, ${DEFAULT_USER_TIMEZONE}))::date
         and coalesce(occ.completed_count, 0) < coalesce(occ.required_count, 1)
       limit 5000
     `
@@ -26393,9 +26389,7 @@ async function processDueAutomations() {
             join public.garden_members gm on gm.user_id = p.id
             join public.garden_plant_tasks t on t.garden_id = gm.garden_id
             join public.garden_plant_task_occurrences occ on occ.task_id = t.id
-            where (p.notify_push is null or p.notify_push = true)
-              and (p.push_task_reminders is null or p.push_task_reminders = true)
-              and (occ.due_at at time zone coalesce(p.timezone, ${DEFAULT_USER_TIMEZONE}))::date = (now() at time zone coalesce(p.timezone, ${DEFAULT_USER_TIMEZONE}))::date
+            where (occ.due_at at time zone coalesce(p.timezone, ${DEFAULT_USER_TIMEZONE}))::date = (now() at time zone coalesce(p.timezone, ${DEFAULT_USER_TIMEZONE}))::date
               and coalesce(occ.completed_count, 0) < coalesce(occ.required_count, 1)
               and extract(hour from now() at time zone coalesce(p.timezone, ${DEFAULT_USER_TIMEZONE}))
                 between coalesce(nullif(regexp_replace(p.notification_time, '[^0-9]', '', 'g'), '')::int, ${DEFAULT_NOTIFICATION_HOUR})
@@ -26459,9 +26453,7 @@ async function processDueAutomations() {
                   join public.garden_members gm on gm.user_id = p.id
                   join public.garden_plant_tasks t on t.garden_id = gm.garden_id
                   join public.garden_plant_task_occurrences occ on occ.task_id = t.id
-                  where (p.notify_push is null or p.notify_push = true)
-                    and (p.push_task_reminders is null or p.push_task_reminders = true)
-                    and (occ.due_at at time zone coalesce(p.timezone, ${DEFAULT_USER_TIMEZONE}))::date = (now() at time zone coalesce(p.timezone, ${DEFAULT_USER_TIMEZONE}))::date
+                  where (occ.due_at at time zone coalesce(p.timezone, ${DEFAULT_USER_TIMEZONE}))::date = (now() at time zone coalesce(p.timezone, ${DEFAULT_USER_TIMEZONE}))::date
                     and coalesce(occ.completed_count, 0) < coalesce(occ.required_count, 1)
                 `
                 const totalWithTasks = Number(debugCount?.[0]?.total_with_tasks || 0)


### PR DESCRIPTION
Remove app-level preference filters for daily task reminders to ensure consistent delivery with other notification types.

The previous implementation for daily task reminders (including watering and plant tasks) explicitly checked `profiles.notify_push` and `profiles.push_task_reminders`. This change removes these checks, allowing task reminders to be queued and sent as long as the user has granted browser notification permission and has an active push subscription, aligning their behavior with friend requests and garden invites.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-2055c7d5-773a-4a5a-9d15-50f4b63ca05d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2055c7d5-773a-4a5a-9d15-50f4b63ca05d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

