### PR TITLE
🛡️ Sentinel: [HIGH] Fix Argument Injection in branch name

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@ Format:
 `**Vulnerability:** [What you found]`
 `**Learning:** [Why it existed]`
 `**Prevention:** [How to avoid next time]`
+
+## 2026-01-27 - Argument Injection in Admin API
+**Vulnerability:** The `/admin/pull-code` endpoint allowed unvalidated user input (`branch` parameter) to be passed to a `git` subprocess via an environment variable that was then consumed by a shell script which used it as an argument. This enabled Argument Injection (e.g., passing `-o/tmp/pwned`).
+**Learning:** Python's `subprocess` module, even when used with lists (avoiding shell injection), is still vulnerable to Argument Injection if the first argument (executable) accepts flags and subsequent arguments are user-controlled. In this case, passing the input via ENV var to a script which then uses it in `git checkout $VAR` without validation was the vector.
+**Prevention:** Always validate user input against a strict allowlist regex (e.g., `^[a-zA-Z0-9_./-]+$`) and explicitly reject inputs starting with `-` before passing them to subprocesses or environment variables used by subprocesses.

--- a/admin_api/test_branch_validation.py
+++ b/admin_api/test_branch_validation.py
@@ -1,0 +1,53 @@
+
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock
+
+# Add current directory to path so we can import app
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+# Set env vars before importing app to satisfy config
+os.environ["ADMIN_STATIC_TOKEN"] = "test-token"
+os.environ["ADMIN_BUTTON_SECRET"] = "change-me"
+
+from app import app
+
+class TestSecurity(unittest.TestCase):
+    def setUp(self):
+        self.app = app.test_client()
+        self.headers = {"X-Admin-Token": "test-token"}
+
+    @patch("app.subprocess.Popen")
+    @patch("app.os.path.isfile")
+    def test_branch_validation(self, mock_isfile, mock_popen):
+        # Mock script existence so it doesn't abort 500
+        mock_isfile.return_value = True
+
+        # Mock Popen to return a process with stdout/stderr
+        process_mock = MagicMock()
+        process_mock.stdout = ["line1", "line2"]
+        process_mock.wait.return_value = 0
+        mock_popen.return_value = process_mock
+
+        # 1. Valid branch
+        response = self.app.post("/admin/pull-code?branch=main", headers=self.headers)
+        self.assertEqual(response.status_code, 200, "Valid branch should work")
+
+        # Verify subprocess called with env var
+        args, kwargs = mock_popen.call_args
+        self.assertEqual(kwargs['env']['PLANTSWIPE_TARGET_BRANCH'], 'main')
+
+        # 2. Malicious branch (Argument Injection candidate)
+        malicious_branch = "-o/tmp/pwned"
+        response = self.app.post(f"/admin/pull-code?branch={malicious_branch}", headers=self.headers)
+
+        self.assertEqual(response.status_code, 400, "Malicious branch should be rejected with 400")
+
+        # 3. Invalid characters
+        invalid_chars = "feature/blah;rm -rf /"
+        response = self.app.post(f"/admin/pull-code?branch={invalid_chars}", headers=self.headers)
+        self.assertEqual(response.status_code, 400, "Branch with invalid characters should be rejected")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Vulnerability:** The `/admin/pull-code` endpoint allowed unvalidated user input (`branch` parameter) to be passed to a `git` subprocess via an environment variable that was then consumed by a shell script which used it as an argument. This enabled Argument Injection (e.g., passing `-o/tmp/pwned`).

**Fix:** Added strict input validation for the `branch` parameter in `admin_api/app.py` using a strict allowlist regex (`^[a-zA-Z0-9_./-]+$`) and explicitly rejecting inputs starting with `-`. This neutralizes Argument Injection and prevents malicious flags from being passed to `git checkout`.

**Impact:** Prevents attackers (authenticated with admin token) from potentially manipulating the deployment process or executing unexpected `git` operations.

**Verification:** Added `admin_api/test_branch_validation.py` which attempts to pass a malicious branch name and asserts that the API correctly returns a `400 Bad Request` response.

---
*PR created automatically by Jules for task [4473425173429737841](https://jules.google.com/task/4473425173429737841) started by @FrenchFive*