### PR TITLE
Main page translation issue

### DIFF
--- a/plant-swipe/public/locales/en/Landing.json
+++ b/plant-swipe/public/locales/en/Landing.json
@@ -36,7 +36,13 @@
     },
     "careReminders": {
       "title": "Care Reminders",
-      "description": "Never forget to water, mist, or fertilize. Get personalized notifications based on each plant's unique needs."
+      "description": "Never forget to water, mist, or fertilize. Get personalized notifications based on each plant's unique needs.",
+      "notification1Title": "Water your Monstera",
+      "notification1Time": "Today at 9:00 AM",
+      "notification2Title": "Fertilize Snake Plant",
+      "notification2Time": "Tomorrow",
+      "notification3Title": "Mist your Fern",
+      "notification3Time": "In 2 days"
     },
     "collections": {
       "title": "Collections & Bookmarks",
@@ -235,7 +241,8 @@
     ],
     "supportTitle": "We're here to answer your questions",
     "supportSubtitle": "Let us know any question you have",
-    "supportButton": "Contact Support"
+    "supportButton": "Contact Support",
+    "emailUs": "Email Us"
   },
   "finalCta": {
     "title": "Ready to grow happier plants?",

--- a/plant-swipe/public/locales/fr/Landing.json
+++ b/plant-swipe/public/locales/fr/Landing.json
@@ -37,7 +37,13 @@
     },
     "careReminders": {
       "title": "Rappels d'entretien",
-      "description": "N'oubliez plus jamais d'arroser, brumiser ou fertiliser. Recevez des notifications personnalisées selon les besoins de chaque plante."
+      "description": "N'oubliez plus jamais d'arroser, brumiser ou fertiliser. Recevez des notifications personnalisées selon les besoins de chaque plante.",
+      "notification1Title": "Arroser votre Monstera",
+      "notification1Time": "Aujourd'hui à 9h00",
+      "notification2Title": "Fertiliser la Sansevière",
+      "notification2Time": "Demain",
+      "notification3Title": "Brumiser votre Fougère",
+      "notification3Time": "Dans 2 jours"
     },
     "collections": {
       "title": "Collections et favoris",
@@ -233,7 +239,8 @@
     ],
     "supportTitle": "Nous sommes là pour répondre à vos questions",
     "supportSubtitle": "Faites-nous part de toutes vos questions",
-    "supportButton": "Contacter le support"
+    "supportButton": "Contacter le support",
+    "emailUs": "Nous écrire"
   },
   "finalCta": {
     "badge": "Aucune expérience requise",

--- a/plant-swipe/src/pages/LandingPage.tsx
+++ b/plant-swipe/src/pages/LandingPage.tsx
@@ -1100,8 +1100,8 @@ const FeaturesSection: React.FC = () => {
                   <Droplets className="h-4 w-4 text-blue-500" />
                 </div>
                 <div className="flex-1 min-w-0">
-                  <p className="text-xs font-medium text-stone-700 dark:text-stone-200 truncate">Water your Monstera</p>
-                  <p className="text-[10px] text-stone-500">Today at 9:00 AM</p>
+                  <p className="text-xs font-medium text-stone-700 dark:text-stone-200 truncate">{t("features.careReminders.notification1Title")}</p>
+                  <p className="text-[10px] text-stone-500">{t("features.careReminders.notification1Time")}</p>
                 </div>
                 <div className="h-2 w-2 rounded-full bg-blue-500 animate-pulse" />
               </div>
@@ -1112,8 +1112,8 @@ const FeaturesSection: React.FC = () => {
                   <Sun className="h-4 w-4 text-amber-500" />
                 </div>
                 <div className="flex-1 min-w-0">
-                  <p className="text-xs font-medium text-stone-700 dark:text-stone-200 truncate">Fertilize Snake Plant</p>
-                  <p className="text-[10px] text-stone-500">Tomorrow</p>
+                  <p className="text-xs font-medium text-stone-700 dark:text-stone-200 truncate">{t("features.careReminders.notification2Title")}</p>
+                  <p className="text-[10px] text-stone-500">{t("features.careReminders.notification2Time")}</p>
                 </div>
               </div>
               
@@ -1123,8 +1123,8 @@ const FeaturesSection: React.FC = () => {
                   <Leaf className="h-4 w-4 text-emerald-500" />
                 </div>
                 <div className="flex-1 min-w-0">
-                  <p className="text-xs font-medium text-stone-700 dark:text-stone-200 truncate">Mist your Fern</p>
-                  <p className="text-[10px] text-stone-500">In 2 days</p>
+                  <p className="text-xs font-medium text-stone-700 dark:text-stone-200 truncate">{t("features.careReminders.notification3Title")}</p>
+                  <p className="text-[10px] text-stone-500">{t("features.careReminders.notification3Time")}</p>
                 </div>
               </div>
             </div>
@@ -2023,7 +2023,7 @@ const FAQSection: React.FC = () => {
                     <div className="relative h-10 w-10 rounded-xl bg-gradient-to-br from-amber-400 to-orange-600 flex items-center justify-center shadow-lg shadow-amber-500/30">
                       <Mail className="h-5 w-5 text-white" />
                     </div>
-                    <span className="relative">Email Us</span>
+                    <span className="relative">{t("faq.emailUs", { defaultValue: "Email Us" })}</span>
                   </a>
                 </div>
 


### PR DESCRIPTION
Translate hardcoded strings on the landing page to support i18n.

This PR replaces several hardcoded English strings in `LandingPage.tsx` with `t()` calls and adds the corresponding translation keys to `Landing.json` for both English and French, ensuring that the "Care Reminders" feature card and the "Email Us" link are properly translated when the page language is switched.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-35c6f2a7-c717-4abd-a489-440264f4ab3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-35c6f2a7-c717-4abd-a489-440264f4ab3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

