### PR TITLE
Box layout stability

### DIFF
--- a/plant-swipe/src/pages/PlantInfoPage.tsx
+++ b/plant-swipe/src/pages/PlantInfoPage.tsx
@@ -1898,32 +1898,29 @@ const GanttTimeline: React.FC<GanttTimelineProps> = ({ timelineData, monthLabels
   }
 
   return (
-    <div className="space-y-2">
+    <div
+      className="grid items-center gap-x-1 sm:gap-x-1.5 gap-y-2"
+      style={{ gridTemplateColumns: 'auto repeat(12, minmax(0, 1fr))' }}
+    >
       {/* Month labels row */}
-      <div className="grid gap-1 sm:gap-1.5" style={{ gridTemplateColumns: 'minmax(90px, auto) repeat(12, minmax(0, 1fr))' }}>
-        <div />
-        {monthLabels.map((label, idx) => (
-          <div key={idx} className="flex items-center justify-center">
-            <span className="text-[8px] sm:text-[9px] font-medium uppercase tracking-wide text-stone-400 dark:text-stone-500">
-              {label.slice(0, 3)}
-            </span>
-          </div>
-        ))}
-      </div>
+      <div />
+      {monthLabels.map((label, idx) => (
+        <div key={idx} className="flex items-center justify-center">
+          <span className="text-[8px] sm:text-[9px] font-medium uppercase tracking-wide text-stone-400 dark:text-stone-500">
+            {label.slice(0, 3)}
+          </span>
+        </div>
+      ))}
 
       {/* Activity rows */}
       {activeRows.map((row) => {
         const segments = buildSegments(row.key)
         return (
-          <div
-            key={row.key}
-            className="grid gap-1 sm:gap-1.5 items-center"
-            style={{ gridTemplateColumns: 'minmax(90px, auto) repeat(12, minmax(0, 1fr))' }}
-          >
+          <React.Fragment key={row.key}>
             {/* Row label */}
-            <div className="flex items-center gap-1.5 sm:gap-2 pr-2">
+            <div className="flex items-center gap-1.5 sm:gap-2 pr-2 min-w-0">
               {row.icon}
-              <span className="text-[10px] sm:text-xs font-semibold text-stone-600 dark:text-stone-300 truncate">
+              <span className="text-[10px] sm:text-xs font-semibold text-stone-600 dark:text-stone-300 whitespace-nowrap">
                 {row.label}
               </span>
             </div>
@@ -1939,7 +1936,6 @@ const GanttTimeline: React.FC<GanttTimelineProps> = ({ timelineData, monthLabels
               {/* Colored bar segments overlaid */}
               {segments.map((seg, sIdx) => {
                 const span = seg.end - seg.start + 1
-                // Calculate position with gap offsets
                 return (
                   <div
                     key={sIdx}
@@ -1957,7 +1953,7 @@ const GanttTimeline: React.FC<GanttTimelineProps> = ({ timelineData, monthLabels
                 )
               })}
             </div>
-          </div>
+          </React.Fragment>
         )
       })}
     </div>


### PR DESCRIPTION
Refactor GanttTimeline to use a single shared CSS grid, preventing month box misalignment caused by varying label column widths.

The previous implementation used separate CSS grids for each row, where the label column width was independently determined by the content of each row's label. This caused longer labels like "Fructification" to push and misalign the month boxes in their row relative to other rows. The change introduces a single grid container for all rows, ensuring the label column width is uniformly determined by the widest label, thus aligning all month boxes.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-04792e73-73c1-4542-a5b7-a1470aebd6f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-04792e73-73c1-4542-a5b7-a1470aebd6f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

