### PR TITLE
Task creation prevention

### DIFF
--- a/plant-swipe/src/components/plant/TaskCreateDialog.tsx
+++ b/plant-swipe/src/components/plant/TaskCreateDialog.tsx
@@ -65,6 +65,7 @@ export function TaskCreateDialog({
       setWeeklyDays([])
       setMonthlyNthWeekdays([])
       setYearlyDays([])
+      setSaving(false)
       setError(null)
     }
   }, [open])
@@ -116,6 +117,7 @@ export function TaskCreateDialog({
         monthlyNthWeekdays: period === 'month' ? [...monthlyNthWeekdays].sort() : null,
       })
 
+      setSaving(false)
       onOpenChange(false)
 
       const taskTypeLabel = type === 'custom' ? (customName || t('garden.taskTypes.custom')) : t(`garden.taskTypes.${type}`)


### PR DESCRIPTION
Fixes a bug preventing users from creating new tasks after the first successful creation.

The `saving` state was not reset to `false` after a successful task creation, causing the "Create" button to remain permanently disabled on subsequent dialog openings. This PR adds `setSaving(false)` on the success path and to the dialog's reset effect.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-0f620882-1743-49a0-8ba0-0083efe799e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0f620882-1743-49a0-8ba0-0083efe799e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

