### PR TITLE
Template picker variable cleanup

### DIFF
--- a/plant-swipe/src/components/admin/AdminEmailsPanel.tsx
+++ b/plant-swipe/src/components/admin/AdminEmailsPanel.tsx
@@ -322,8 +322,6 @@ export const AdminEmailsPanel: React.FC = () => {
   const [dialogOpen, setDialogOpen] = React.useState(false)
   const [scheduledForError, setScheduledForError] = React.useState<string | null>(null)
   const [minScheduleDateTime, setMinScheduleDateTime] = React.useState(getMinDateTimeLocal)
-  const [templatePickerOpen, setTemplatePickerOpen] = React.useState(false)
-  const [templatePickerSearch, setTemplatePickerSearch] = React.useState("")
   const [rolesExpanded, setRolesExpanded] = React.useState(false)
 
   const location = useLocation()


### PR DESCRIPTION
Remove unused state declarations to fix TypeScript `TS6133` errors.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-23d345c1-d90a-423f-b9ea-561cb0a92bc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-23d345c1-d90a-423f-b9ea-561cb0a92bc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

