### PR TITLE
⚡ Bolt: Optimize swipe list memoization

### DIFF
--- a/plant-swipe/src/PlantSwipe.tsx
+++ b/plant-swipe/src/PlantSwipe.tsx
@@ -1197,18 +1197,21 @@ export default function PlantSwipe() {
     }
   }, [swipeablePlants, shuffleEpoch])
   
+  // ⚡ Bolt: Memoize plant map to avoid O(N) reconstruction when only shuffle order changes
+  // This separates the data structure creation from the sorting logic
+  const plantMap = useMemo(() => {
+    return new Map(swipeablePlants.map(p => [p.id, p]))
+  }, [swipeablePlants])
+
   // Build the actual swipe list from the stable shuffled IDs
   const swipeList = useMemo(() => {
     if (shuffledPlantIds.length === 0) return []
-    
-    // Create a map for O(1) lookups
-    const plantMap = new Map(swipeablePlants.map(p => [p.id, p]))
     
     // Return plants in shuffled order, filtering out any that no longer exist
     return shuffledPlantIds
       .map(id => plantMap.get(id))
       .filter((p): p is PreparedPlant => p !== undefined)
-  }, [shuffledPlantIds, swipeablePlants])
+  }, [shuffledPlantIds, plantMap])
 
   const sortedSearchResults = useMemo(() => {
     // For default sort:


### PR DESCRIPTION
💡 **What**: Optimized the `swipeList` memoization in `PlantSwipe.tsx` by extracting the creation of the `plantMap` (used for O(1) lookups) into its own `useMemo` hook.

🎯 **Why**: Previously, `plantMap` was rebuilt every time `swipeList` was recalculated. Since `swipeList` depends on `shuffledPlantIds`, which changes when the deck is reshuffled (e.g., when the user swipes through all cards), this meant the `Map` (an O(N) operation) was being reconstructed unnecessarily even when the underlying plant data (`swipeablePlants`) hadn't changed.

📊 **Impact**: Reduces computational overhead during re-shuffles by skipping the `Map` construction step. For N plants, this saves O(N) insertions. The logic is now split:
1. `plantMap` depends only on `swipeablePlants` (data updates).
2. `swipeList` depends on `shuffledPlantIds` and `plantMap` (order updates).

🔬 **Measurement**: Verified that the component still renders correctly and functionality is preserved using a Playwright verification script. Type checking and linting passed.

---
*PR created automatically by Jules for task [17011638384749067793](https://jules.google.com/task/17011638384749067793) started by @FrenchFive*