### PR TITLE
🎨 Palette: Enhance NotificationBell accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -39,3 +39,7 @@
 **Action:** Always make validation suggestions actionable by implementing a click handler that applies the suggestion to the input field.
 **Learning:** Buttons that appear only on hover (e.g., "Remove Tag" x) are invisible to keyboard users when focused, causing confusion as the focus ring appears around "nothing".
 **Action:** Always add `focus:opacity-100` (or equivalent) to `group-hover:opacity-100` elements to ensure they become visible when tabbing.
+
+## 2026-05-29 - Prop Spreading for Accessibility
+**Learning:** Custom atomic components like `Switch` that don't spread `...props` to their underlying interactive element effectively swallow accessibility attributes like `aria-label` passed by consumers, making them inaccessible in specific contexts.
+**Action:** Always spread `...props` to the root interactive element of reusable UI components to enable consumers to augment them with necessary ARIA attributes.

--- a/plant-swipe/src/components/layout/NotificationPanel.tsx
+++ b/plant-swipe/src/components/layout/NotificationPanel.tsx
@@ -586,6 +586,7 @@ export function NotificationBell({
   onRefresh,
   className
 }: NotificationBellProps) {
+  const { t } = useTranslation('common')
   const [isOpen, setIsOpen] = React.useState(false)
   const buttonRef = React.useRef<HTMLButtonElement>(null)
 
@@ -601,7 +602,11 @@ export function NotificationBell({
             e.stopPropagation()
             setIsOpen(!isOpen)
           }}
-          aria-label="Notifications"
+          aria-label={totalCount > 0
+            ? `${t('notifications.title', { defaultValue: 'Notifications' })}, ${totalCount} ${t('notifications.pending', { defaultValue: 'pending' })}`
+            : t('notifications.title', { defaultValue: 'Notifications' })}
+          aria-expanded={isOpen}
+          aria-haspopup="dialog"
         >
           <Bell className="h-4 w-4" />
         </Button>

--- a/plant-swipe/src/components/ui/switch.tsx
+++ b/plant-swipe/src/components/ui/switch.tsx
@@ -1,32 +1,32 @@
 import * as React from "react"
 import { cn } from "@/lib/utils"
 
-export interface SwitchProps {
+export interface SwitchProps extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "onChange"> {
   checked?: boolean
   onCheckedChange?: (checked: boolean) => void
-  disabled?: boolean
-  className?: string
-  id?: string
-  name?: string
 }
 
 const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(
-  ({ checked = false, onCheckedChange, disabled = false, className, id, name }, ref) => {
+  ({ checked = false, onCheckedChange, disabled = false, className, id, name, ...props }, ref) => {
     return (
       <button
-        ref={ref}
         type="button"
         role="switch"
         aria-checked={checked}
+        data-state={checked ? "checked" : "unchecked"}
         disabled={disabled}
         id={id}
-        data-state={checked ? "checked" : "unchecked"}
+        {...props}
         className={cn(
           "peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50",
           checked ? "bg-emerald-500" : "bg-stone-200 dark:bg-stone-700",
           className
         )}
-        onClick={() => onCheckedChange?.(!checked)}
+        onClick={(e) => {
+          onCheckedChange?.(!checked)
+          props.onClick?.(e)
+        }}
+        ref={ref}
       >
         <span
           className={cn(


### PR DESCRIPTION
💡 What: Enhanced accessibility for the NotificationBell and Switch components.
🎯 Why: Screen reader users were unable to determine the state of the notification panel (expanded/collapsed) or if there were pending notifications without opening it. Additionally, the `Switch` component swallowed custom ARIA attributes, limiting its accessible usage.
📸 Before/After: 
- `NotificationBell`: Now announces "Notifications, 3 pending" and "expanded" state.
- `Switch`: Now accepts `aria-label` and other HTML attributes.
♿ Accessibility: Added `aria-expanded`, dynamic `aria-label` for notification count, and prop spreading for custom attributes.

---
*PR created automatically by Jules for task [3204091250945453766](https://jules.google.com/task/3204091250945453766) started by @FrenchFive*