### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix default secret vulnerability in Admin API

### DIFF
--- a/admin_api/app.py
+++ b/admin_api/app.py
@@ -337,6 +337,11 @@ def _log_admin_action(action: str, target: str = "", detail: dict | None = None)
 
 
 def _verify_request() -> None:
+    # FAIL SECURE: Reject requests if secret is default
+    if APP_SECRET == "change-me":
+        print("[Security] Rejecting request: APP_SECRET is default 'change-me'. Please configure ADMIN_BUTTON_SECRET.")
+        abort(500, description="Server configuration error: Default secret in use.")
+
     # Option A: HMAC on raw body via X-Button-Token
     provided_sig = request.headers.get(HMAC_HEADER, "")
     if provided_sig:


### PR DESCRIPTION
**Vulnerability:** The Admin API used a default secret "change-me" for HMAC authentication if `ADMIN_BUTTON_SECRET` was not configured. This allowed attackers to forge request signatures and execute admin commands (e.g., restart server, run setup).

**Fix:** Added a check in `_verify_request` to explicitly reject requests (500 Internal Server Error) if `APP_SECRET` is "change-me".

**Impact:** Prevents unauthorized access to sensitive admin endpoints in default or misconfigured deployments.

**Verification:**
1.  Attempted to call `/admin/restart-app` with a signature generated using "change-me".
2.  Before fix: 200 OK (Vulnerable).
3.  After fix: 500 Internal Server Error (Secure).


---
*PR created automatically by Jules for task [4841933841835192589](https://jules.google.com/task/4841933841835192589) started by @FrenchFive*