### PR TITLE
⚡ Bolt: Optimize SwipePage rendering performance

### DIFF
--- a/plant-swipe/src/PlantSwipe.tsx
+++ b/plant-swipe/src/PlantSwipe.tsx
@@ -1343,7 +1343,7 @@ export default function PlantSwipe() {
     }
   }, [currentView, heroImageCandidate, index, current])
 
-  const handlePass = () => {
+  const handlePass = React.useCallback(() => {
     if (swipeList.length === 0) return
     setIndex((i) => {
       const next = i + 1
@@ -1353,20 +1353,20 @@ export default function PlantSwipe() {
       }
       return next
     })
-  }
+  }, [swipeList.length])
 
-  const handlePrevious = () => {
+  const handlePrevious = React.useCallback(() => {
     if (swipeList.length === 0) return
     setIndex((i) => {
       const prev = i - 1
       // Wrap around to the end if going back from the start
       return prev < 0 ? swipeList.length - 1 : prev
     })
-  }
+  }, [swipeList.length])
 
-  const handleInfo = () => {
+  const handleInfo = React.useCallback(() => {
     if (current) navigate(`/plants/${current.id}`)
-  }
+  }, [current, navigate])
 
   // Swipe logic
   const x = useMotionValue(0)
@@ -1382,7 +1382,7 @@ export default function PlantSwipe() {
     animate(y, 0, { duration: 0.1 })
   }, [index, x, y])
   
-  const onDragEnd = (_: unknown, info: { offset: { x: number; y: number }; velocity: { x: number; y: number } }) => {
+  const onDragEnd = React.useCallback((_: unknown, info: { offset: { x: number; y: number }; velocity: { x: number; y: number } }) => {
     const dx = info.offset.x
     const dy = info.offset.y
     
@@ -1430,19 +1430,19 @@ export default function PlantSwipe() {
       animate(x, 0, { duration: 0.2, type: "spring", stiffness: 300, damping: 30 })
       animate(y, 0, { duration: 0.2, type: "spring", stiffness: 300, damping: 30 })
     }
-  }
+  }, [handleInfo, handlePass, handlePrevious, x, y])
 
   // Favorites handling
-  const ensureLoggedIn = () => {
+  const ensureLoggedIn = React.useCallback(() => {
     if (!user) {
       setAuthMode('login')
       setAuthOpen(true)
       return false
     }
     return true
-  }
+  }, [user])
 
-  const toggleLiked = async (plantId: string) => {
+  const toggleLiked = React.useCallback(async (plantId: string) => {
     if (!ensureLoggedIn()) return
     setLikedIds((prev) => {
       const has = prev.includes(plantId)
@@ -1467,7 +1467,11 @@ export default function PlantSwipe() {
       })()
       return next
     })
-  }
+  }, [ensureLoggedIn, user, refreshProfile])
+
+  const handleToggleLike = React.useCallback(() => {
+    if (current) toggleLiked(current.id)
+  }, [current, toggleLiked])
 
   const openLogin = React.useCallback(() => { setAuthMode("login"); setAuthOpen(true) }, [])
   const openSignup = React.useCallback(() => { setAuthMode("signup"); setAuthOpen(true) }, [])
@@ -2510,9 +2514,7 @@ export default function PlantSwipe() {
                     handlePass={handlePass}
                     handlePrevious={handlePrevious}
                     liked={current ? likedIds.includes(current.id) : false}
-                    onToggleLike={() => {
-                      if (current) toggleLiked(current.id)
-                    }}
+                    onToggleLike={handleToggleLike}
                     boostImagePriority={boostImagePriority}
                   />
                 </Suspense>

--- a/plant-swipe/src/pages/SwipePage.tsx
+++ b/plant-swipe/src/pages/SwipePage.tsx
@@ -87,7 +87,7 @@ interface SwipePageProps {
   boostImagePriority?: boolean
 }
 
-export const SwipePage: React.FC<SwipePageProps> = ({
+export const SwipePage = React.memo<SwipePageProps>(({
   current,
   index: _index,
   setIndex,
@@ -680,7 +680,7 @@ export const SwipePage: React.FC<SwipePageProps> = ({
         </motion.section>
       </div>
     )
-}
+})
 
 const EmptyState = ({ onReset }: { onReset: () => void }) => {
   const { t } = useTranslation("common")


### PR DESCRIPTION
💡 What: Optimized `SwipePage` rendering by wrapping it in `React.memo` and memoizing all callback props (`handlePass`, `handlePrevious`, `handleInfo`, `onDragEnd`, `handleToggleLike`) passed from `PlantSwipe`.

🎯 Why: `SwipePage` was re-rendering on every state change in `PlantSwipe` (e.g. typing in search bar, opening filters) because its props (especially inline event handlers) were being recreated. This was inefficient for a heavy visual component.

📊 Impact: Significantly reduces re-renders of the Discovery view. `SwipePage` now only updates when the current plant changes or swipe interaction occurs.

🔬 Measurement: Verified by code review and logic analysis. Changes prevent prop churn for `SwipePage`.

---
*PR created automatically by Jules for task [16445848564239209821](https://jules.google.com/task/16445848564239209821) started by @FrenchFive*