### PR TITLE
⚡ Bolt: Lazy load search strings for improved initial load performance

### DIFF
--- a/plant-swipe/src/PlantSwipe.tsx
+++ b/plant-swipe/src/PlantSwipe.tsx
@@ -884,13 +884,6 @@ export default function PlantSwipe() {
         }
       })
 
-      // Search string - includes name, scientific name, meaning, colors, common names and synonyms
-      // This allows users to search by any name they might know the plant by
-      const commonNames = (p.identity?.commonNames || []).join(' ')
-      const synonyms = (p.identity?.synonyms || []).join(' ')
-      const givenNames = (p.identity?.givenNames || []).join(' ')
-      const searchString = `${p.name} ${p.scientificName || ''} ${p.meaning || ''} ${colors.join(" ")} ${commonNames} ${synonyms} ${givenNames}`.toLowerCase()
-
       // Type
       const typeLabel = getPlantTypeLabel(p.classification)?.toLowerCase() ?? null
 
@@ -936,9 +929,24 @@ export default function PlantSwipe() {
       const status = p.meta?.status?.toLowerCase()
       const isInProgress = status === 'in progres' || status === 'in progress'
 
+      // ⚡ Bolt: Lazy search string generation to save memory and CPU on initial load
+      // Search string is only computed when user actually types a query
+      let _cachedSearchString: string | undefined
+
       return {
         ...p,
-        _searchString: searchString,
+        get _searchString() {
+          if (_cachedSearchString !== undefined) return _cachedSearchString
+
+          // Search string - includes name, scientific name, meaning, colors, common names and synonyms
+          // This allows users to search by any name they might know the plant by
+          const commonNames = (p.identity?.commonNames || []).join(' ')
+          const synonyms = (p.identity?.synonyms || []).join(' ')
+          const givenNames = (p.identity?.givenNames || []).join(' ')
+
+          _cachedSearchString = `${p.name} ${p.scientificName || ''} ${p.meaning || ''} ${colors.join(" ")} ${commonNames} ${synonyms} ${givenNames}`.toLowerCase()
+          return _cachedSearchString
+        },
         _normalizedColors: normalizedColors,
         _colorTokens: colorTokens,
         _typeLabel: typeLabel,


### PR DESCRIPTION
⚡ Bolt: Implement lazy evaluation for search strings

💡 What:
Converted the `_searchString` property in the `preparedPlants` mapping from an eagerly computed string to a lazy getter with caching.

🎯 Why:
The `_searchString` combines multiple fields (name, scientific name, meaning, colors, common names, synonyms) and normalizes them (toLowerCase) for *every* plant on every render/language change. However, this string is only used when the user actively searches. By making it lazy, we avoid this expensive string manipulation for the default "Swipe" mode, saving CPU and memory on initial load.

📊 Impact:
- Reduces initial computation time for `preparedPlants` by deferring string operations.
- Reduces memory pressure by not allocating large search strings for all plants immediately.
- Zero impact on functionality: search works exactly as before, just computed on-demand.

🔬 Measurement:
Verified with a Playwright script that navigates to `/discovery` and confirms the plant renders correctly. The app builds and runs without errors. Code review confirmed the logic is sound and safe.

---
*PR created automatically by Jules for task [6942312947921795532](https://jules.google.com/task/6942312947921795532) started by @FrenchFive*