### PR TITLE
Obsolete email triggers cleanup

### DIFF
--- a/plant-swipe/server.js
+++ b/plant-swipe/server.js
@@ -11074,6 +11074,16 @@ async function ensureDefaultEmailTriggers() {
             description = EXCLUDED.description,
             updated_at = now()
     `)
+
+    const validTypes = DEFAULT_EMAIL_TRIGGERS.map(t => `'${t.triggerType}'`).join(', ')
+    const deleted = await sql.unsafe(`
+      DELETE FROM public.admin_email_triggers
+      WHERE trigger_type NOT IN (${validTypes})
+      RETURNING trigger_type
+    `)
+    if (deleted.length > 0) {
+      console.log(`[email-triggers] Removed obsolete triggers: ${deleted.map(r => r.trigger_type).join(', ')}`)
+    }
     
     defaultTriggersEnsured = true
     console.log('[email-triggers] Default triggers ensured')


### PR DESCRIPTION
Add logic to remove obsolete email triggers from the database to prevent them from persisting after being removed from `DEFAULT_EMAIL_TRIGGERS`.

Previously, the `ensureDefaultEmailTriggers` function only upserted triggers, but did not remove any that were no longer defined in `DEFAULT_EMAIL_TRIGGERS`. This caused old, undefined triggers to remain in the `admin_email_triggers` table and appear in the admin panel.

---
<p><a href="https://cursor.com/agents?id=bc-0e181ce4-6dc1-4953-86f3-5c6115e5ef66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e181ce4-6dc1-4953-86f3-5c6115e5ef66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

