### PR TITLE
⚡ Bolt: Combine plant preparation loops

### DIFF
--- a/plant-swipe/src/PlantSwipe.tsx
+++ b/plant-swipe/src/PlantSwipe.tsx
@@ -436,21 +436,6 @@ export default function PlantSwipe() {
     return { primaryColors: primary, advancedColors: advanced }
   }, [colorOptions])
   
-  const typeOptions = useMemo(() => {
-    const labels = new Set<string>()
-    plants.forEach((plant) => {
-      const label = getPlantTypeLabel(plant.classification)
-      if (label) labels.add(label)
-    })
-    return Array.from(labels).sort((a, b) => a.localeCompare(b))
-  }, [plants])
-  const usageOptions = useMemo(() => {
-    const labels = new Set<string>()
-    plants.forEach((plant) => {
-      getPlantUsageLabels(plant).forEach((label) => labels.add(label))
-    })
-    return Array.from(labels).sort((a, b) => a.localeCompare(b))
-  }, [plants])
   const likedSet = React.useMemo(() => new Set(likedIds), [likedIds])
 
   // Hydrate liked ids from profile when available
@@ -817,10 +802,14 @@ export default function PlantSwipe() {
   // This avoids repeating expensive string operations on every filter change
   // All Set-based lookups enable O(1) membership tests instead of O(n) array scans
   // Enhanced: Now includes color translations for bi-directional language matching
-  const preparedPlants = useMemo(() => {
+  const { preparedPlants, typeOptions, usageOptions } = useMemo(() => {
     const { aliasMap } = colorLookups
     const now = new Date()
     
+    // Collections for filter options
+    const typeLabelsSet = new Set<string>()
+    const usageLabelsSet = new Set<string>()
+
     // ⚡ Bolt: Cache tokenization results for unique color strings
     // This avoids redundant regex splitting and alias lookups for common colors (e.g. "green")
     // repeated across thousands of plants.
@@ -863,7 +852,7 @@ export default function PlantSwipe() {
       return tokens
     }
 
-    return plants.map((p) => {
+    const prepared = plants.map((p) => {
       // ⚡ Bolt: Use lazy getters for expensive properties to optimize initial load time
       // This avoids computing regexes, Sets, and string manipulations for thousands of plants
       // unless they are actually needed by active filters.
@@ -872,7 +861,6 @@ export default function PlantSwipe() {
       let _cachedColors: string[] | undefined
       let _cachedNormalizedColors: string[] | undefined
       let _cachedColorTokens: Set<string> | undefined
-      let _cachedUsageLabels: string[] | undefined
       let _cachedUsageSet: Set<string> | undefined
       let _cachedHabitats: string[] | undefined
       let _cachedHabitatSet: Set<string> | undefined
@@ -880,7 +868,17 @@ export default function PlantSwipe() {
       let _cachedSearchString: string | undefined
 
       // Type
-      const typeLabel = getPlantTypeLabel(p.classification)?.toLowerCase() ?? null
+      // Eagerly compute type label for both prepared plant and options
+      const rawTypeLabel = getPlantTypeLabel(p.classification)
+      if (rawTypeLabel) typeLabelsSet.add(rawTypeLabel)
+      const typeLabel = rawTypeLabel?.toLowerCase() ?? null
+
+      // Usage
+      // Eagerly compute usage labels for both prepared plant and options
+      // This replaces lazy calculation since we need it for filter options anyway
+      const rawUsageLabels = getPlantUsageLabels(p)
+      rawUsageLabels.forEach(label => usageLabelsSet.add(label))
+      const usageLabelsLower = rawUsageLabels.map(l => l.toLowerCase())
 
       // Maintenance
       const maintenance = (p.identity?.maintenanceLevel || p.plantCare?.maintenanceLevel || p.care?.maintenanceLevel || '').toLowerCase()
@@ -928,12 +926,6 @@ export default function PlantSwipe() {
         return _cachedNormalizedColors
       }
 
-      const getUsageLabels = () => {
-        if (_cachedUsageLabels) return _cachedUsageLabels
-        _cachedUsageLabels = getPlantUsageLabels(p).map((label) => label.toLowerCase())
-        return _cachedUsageLabels
-      }
-
       const getHabitats = () => {
         if (_cachedHabitats) return _cachedHabitats
         _cachedHabitats = (p.plantCare?.habitat || p.care?.habitat || []).map((h) => h.toLowerCase())
@@ -973,12 +965,10 @@ export default function PlantSwipe() {
           return _cachedColorTokens
         },
         _typeLabel: typeLabel,
-        get _usageLabels() {
-           return getUsageLabels()
-        },
+        _usageLabels: usageLabelsLower, // Eager now
         get _usageSet() {
            if (_cachedUsageSet) return _cachedUsageSet
-           _cachedUsageSet = new Set(getUsageLabels())
+           _cachedUsageSet = new Set(usageLabelsLower)
            return _cachedUsageSet
         },
         get _habitats() {
@@ -1006,6 +996,12 @@ export default function PlantSwipe() {
         _isInProgress: isInProgress
       } as PreparedPlant
     })
+
+    return {
+      preparedPlants: prepared,
+      typeOptions: Array.from(typeLabelsSet).sort((a, b) => a.localeCompare(b)),
+      usageOptions: Array.from(usageLabelsSet).sort((a, b) => a.localeCompare(b))
+    }
   }, [plants, colorLookups])
 
   // Memoize color filter expansion separately to avoid recomputing on every filter change


### PR DESCRIPTION
This PR optimizes the `PlantSwipe` component by combining three separate iterations over the `plants` array into a single pass. Previously, `preparedPlants`, `typeOptions`, and `usageOptions` were calculated in separate `useMemo` hooks, leading to O(3N) complexity. The new implementation computes all three derived datasets in a single O(N) loop. 

This change improves initial render performance and reduces overhead when switching languages or updating the plant list. Type safety and linting checks have been verified.

---
*PR created automatically by Jules for task [9755724362406660944](https://jules.google.com/task/9755724362406660944) started by @FrenchFive*