### PR TITLE
⚡ Bolt: Optimize SearchPage re-renders

### DIFF
--- a/plant-swipe/src/PlantSwipe.tsx
+++ b/plant-swipe/src/PlantSwipe.tsx
@@ -1412,6 +1412,10 @@ export default function PlantSwipe() {
     if (current) navigate(`/plants/${current.id}`)
   }, [current, navigate])
 
+  const handleOpenInfo = React.useCallback((p: Plant) => {
+    navigate(`/plants/${p.id}`)
+  }, [navigate])
+
   // Swipe logic
   const x = useMotionValue(0)
   const y = useMotionValue(0)
@@ -2265,7 +2269,7 @@ export default function PlantSwipe() {
                 <Suspense fallback={routeLoadingFallback}>
                   <SearchPageLazy
                     plants={sortedSearchResults}
-                    openInfo={(p) => navigate(`/plants/${p.id}`)}
+                    openInfo={handleOpenInfo}
                     likedIds={likedIds}
                   />
                 </Suspense>

--- a/plant-swipe/src/lib/i18nRouting.ts
+++ b/plant-swipe/src/lib/i18nRouting.ts
@@ -1,3 +1,4 @@
+import { useCallback } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { SUPPORTED_LANGUAGES, DEFAULT_LANGUAGE, type SupportedLanguage } from './i18n'
 import i18n from './i18n'
@@ -109,7 +110,7 @@ export function useLanguageNavigate() {
   const location = useLocation()
   const currentLang = useLanguage()
   
-  return (to: string | number, options?: { replace?: boolean; state?: any }) => {
+  return useCallback((to: string | number, options?: { replace?: boolean; state?: any }) => {
     // Handle browser history navigation (numbers)
     if (typeof to === 'number') {
       navigate(to as any, options)
@@ -145,7 +146,7 @@ export function useLanguageNavigate() {
     }
     
     navigate(pathWithLang, options)
-  }
+  }, [navigate, location, currentLang])
 }
 
 /**

--- a/plant-swipe/src/pages/SearchPage.tsx
+++ b/plant-swipe/src/pages/SearchPage.tsx
@@ -15,7 +15,9 @@ interface SearchPageProps {
   likedIds?: string[];
 }
 
-export const SearchPage: React.FC<SearchPageProps> = ({
+// ⚡ Bolt: Memoize SearchPage to prevent unnecessary re-renders when parent re-renders (e.g. typing, scrolling)
+// but props (plants) are stable.
+export const SearchPage: React.FC<SearchPageProps> = React.memo(({
   plants,
   openInfo,
   likedIds = [],
@@ -297,4 +299,4 @@ export const SearchPage: React.FC<SearchPageProps> = ({
       </Button>
     </div>
   );
-};
+});


### PR DESCRIPTION
💡 What: 
- Memoized `SearchPage` component using `React.memo`.
- Memoized `useLanguageNavigate` hook using `useCallback` to ensure the returned navigation function is stable (when dependencies like `location` are stable).
- Memoized `handleOpenInfo` callback in `PlantSwipe.tsx` using `useCallback`.

🎯 Why: 
- `PlantSwipe` re-renders on scroll (due to `searchBarVisible` logic on mobile/responsive layouts).
- This caused `SearchPage` (a heavy component rendering a list of cards) to re-render because:
    1. `SearchPage` was not memoized.
    2. Even if memoized, the `openInfo` prop was unstable because `useLanguageNavigate` returned a new function on every render, causing `handleOpenInfo` to be recreated.
- This led to unnecessary re-renders of the entire plant grid while scrolling or typing, impacting performance especially on mobile devices.

📊 Impact: 
- Reduces `SearchPage` re-renders to 0 during scrolling (when search bar toggles) and typing (before debounce).
- Verified with Playwright script: originally showed re-renders on every scroll action; after optimization, no re-renders occurred.

🔬 Measurement:
- Verified using a custom Playwright script that injected console logs to track render counts during scroll events.
- Before: `SearchPage render` logs appeared on every scroll direction change.
- After: No `SearchPage render` logs appeared during scroll.

---
*PR created automatically by Jules for task [12831262047493730716](https://jules.google.com/task/12831262047493730716) started by @FrenchFive*