### PR TITLE
🎨 Palette: Fix accessible labels in Garden Create dialog

### DIFF
--- a/plant-swipe/src/pages/GardenListPage.tsx
+++ b/plant-swipe/src/pages/GardenListPage.tsx
@@ -5,6 +5,7 @@ import React from "react";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import {
   Dialog,
   DialogContent,
@@ -2302,10 +2303,11 @@ export const GardenListPage: React.FC = () => {
               </DialogHeader>
               <div className="space-y-3">
                 <div className="grid gap-2">
-                  <label className="text-sm font-medium">
+                  <Label htmlFor="garden-name">
                     {t("garden.name")}
-                  </label>
+                  </Label>
                   <Input
+                    id="garden-name"
                     value={name}
                     onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                       setName(e.target.value)
@@ -2314,10 +2316,11 @@ export const GardenListPage: React.FC = () => {
                   />
                 </div>
                 <div className="grid gap-2">
-                  <label className="text-sm font-medium">
+                  <Label htmlFor="garden-image">
                     {t("garden.coverImageUrl")}
-                  </label>
+                  </Label>
                   <Input
+                    id="garden-image"
                     value={imageUrl}
                     onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                       setImageUrl(e.target.value)


### PR DESCRIPTION
💡 What: Replaced raw HTML `<label>` tags with the `Label` UI component in the "Create Garden" dialog.
🎯 Why: To ensure proper accessibility by correctly associating labels with inputs using `htmlFor` and `id`. This fixes an issue where inputs were not programmaticlly labelled.
📸 Before/After: No visual changes, but the accessibility tree now correctly links the "Name" and "Cover Image URL" labels to their inputs.
♿ Accessibility: Ensures inputs have accessible names for screen readers and clicking the label focuses the input.

---
*PR created automatically by Jules for task [8480384251537599185](https://jules.google.com/task/8480384251537599185) started by @FrenchFive*