### PR TITLE
🛡️ Sentinel: Remove hardcoded Sentry DSNs

### DIFF
--- a/EXTERNAL_APIS.md
+++ b/EXTERNAL_APIS.md
@@ -324,7 +324,7 @@ https://region1.google-analytics.com
 
 ### 9. Sentry
 
-**DSN:** `https://758053551e0396eab52314bdbcf57924@o4510783278350336.ingest.de.sentry.io/4510783285821520`
+**DSN:** `https://[REDACTED]@o4510783278350336.ingest.de.sentry.io/4510783285821520`
 
 **Region:** Germany (de.sentry.io)
 

--- a/admin_api/app.py
+++ b/admin_api/app.py
@@ -17,7 +17,7 @@ from urllib.parse import urlparse, urlunparse, parse_qsl, urlencode
 import sentry_sdk
 from sentry_sdk.integrations.flask import FlaskIntegration
 
-SENTRY_DSN = "https://758053551e0396eab52314bdbcf57924@o4510783278350336.ingest.de.sentry.io/4510783285821520"
+SENTRY_DSN = os.environ.get("SENTRY_DSN")
 
 # Server identification: Set PLANTSWIPE_SERVER_NAME to 'DEV' or 'MAIN' on each server
 SERVER_NAME = os.environ.get("PLANTSWIPE_SERVER_NAME") or os.environ.get("SERVER_NAME") or "unknown"
@@ -30,6 +30,10 @@ def _init_sentry() -> None:
     - Error scrubbing removes email patterns from error messages
     - Only operational metadata is captured, no personal data
     """
+    if not SENTRY_DSN:
+        print("[Sentry] SENTRY_DSN not configured. Error monitoring disabled.")
+        return
+
     try:
         sentry_sdk.init(
             dsn=SENTRY_DSN,

--- a/plant-swipe/scripts/generate-sitemap.js
+++ b/plant-swipe/scripts/generate-sitemap.js
@@ -7,8 +7,15 @@ import { fileURLToPath } from 'node:url'
 import dotenv from 'dotenv'
 import { createClient as createSupabaseClient } from '@supabase/supabase-js'
 
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const appRoot = path.resolve(__dirname, '..')
+
+// Load env files before accessing Sentry DSN
+loadEnvFiles(appRoot)
+
 // Sentry error monitoring for sitemap generation
-const SENTRY_DSN = 'https://758053551e0396eab52314bdbcf57924@o4510783278350336.ingest.de.sentry.io/4510783285821520'
+const SENTRY_DSN = process.env.SENTRY_DSN
 
 // Server identification: Set PLANTSWIPE_SERVER_NAME to 'DEV' or 'MAIN' on each server
 const SERVER_NAME = process.env.PLANTSWIPE_SERVER_NAME || process.env.SERVER_NAME || 'unknown'
@@ -17,7 +24,7 @@ let Sentry = null
 try {
   // Try to import Sentry (may not be available in all environments)
   const sentryModule = await import('@sentry/node').catch(() => null)
-  if (sentryModule) {
+  if (sentryModule && SENTRY_DSN) {
     Sentry = sentryModule
     Sentry.init({
       dsn: SENTRY_DSN,
@@ -47,13 +54,8 @@ try {
 
 const startedAt = Date.now()
 
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = path.dirname(__filename)
-const appRoot = path.resolve(__dirname, '..')
 const publicDir = path.join(appRoot, 'public')
 const sitemapPath = path.join(publicDir, 'sitemap.xml')
-
-loadEnvFiles(appRoot)
 
 const shouldSkip = parseBoolean(process.env.SKIP_SITEMAP_GENERATION)
 if (shouldSkip) {

--- a/plant-swipe/server.js
+++ b/plant-swipe/server.js
@@ -23,7 +23,7 @@ try {
 // @sentry/bun would only work when running with the Bun runtime
 import * as Sentry from '@sentry/node';
 
-const SENTRY_DSN = 'https://758053551e0396eab52314bdbcf57924@o4510783278350336.ingest.de.sentry.io/4510783285821520';
+const SENTRY_DSN = process.env.SENTRY_DSN || process.env.VITE_SENTRY_DSN;
 
 // Server identification: Set PLANTSWIPE_SERVER_NAME to 'DEV' or 'MAIN' on each server
 // Now this will correctly read from .env since dotenv was loaded above
@@ -156,10 +156,11 @@ function shouldSuppressMaintenanceError(event, hint) {
   return false;
 }
 
-Sentry.init({
-  dsn: SENTRY_DSN,
-  environment: process.env.NODE_ENV || 'production',
-  // Server identification
+if (SENTRY_DSN) {
+  Sentry.init({
+    dsn: SENTRY_DSN,
+    environment: process.env.NODE_ENV || 'production',
+    // Server identification
   serverName: SERVER_NAME,
   // Send structured logs to Sentry
   _experiments: {
@@ -263,8 +264,10 @@ Sentry.init({
     return event;
   },
 });
-
-console.log(`[Sentry] Initialized for server: ${SERVER_NAME} (GDPR-compliant)`);
+  console.log(`[Sentry] Initialized for server: ${SERVER_NAME} (GDPR-compliant)`);
+} else {
+  console.warn(`[Sentry] SENTRY_DSN not configured. Error monitoring disabled.`);
+}
 
 // Global error handlers for uncaught exceptions and unhandled rejections
 process.on('uncaughtException', (error) => {

--- a/plant-swipe/src/lib/sentry.ts
+++ b/plant-swipe/src/lib/sentry.ts
@@ -23,7 +23,7 @@
  */
 import * as Sentry from '@sentry/react'
 
-const SENTRY_DSN = 'https://758053551e0396eab52314bdbcf57924@o4510783278350336.ingest.de.sentry.io/4510783285821520'
+const SENTRY_DSN = import.meta.env.VITE_SENTRY_DSN
 
 // Server identification: Set VITE_SERVER_NAME to 'DEV' or 'MAIN' in your .env file
 const SERVER_NAME = (import.meta.env as Record<string, string>).VITE_SERVER_NAME || 
@@ -270,6 +270,11 @@ export function initSentry(): void {
 
   if (!isEnabled) {
     console.log('[Sentry] Skipping initialization in development mode')
+    return
+  }
+
+  if (!SENTRY_DSN) {
+    console.warn('[Sentry] Skipping initialization: VITE_SENTRY_DSN is missing')
     return
   }
 


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix hardcoded Sentry DSN secrets

🚨 Severity: CRITICAL
💡 Vulnerability: Hardcoded Sentry DSNs were found in multiple files (`server.js`, `app.py`, `sentry.ts`, `generate-sitemap.js`). While DSNs are sometimes considered public, best practice is to manage them via environment variables to allow rotation and environment-specific configuration.
🎯 Impact: Exposure of DSN allows anyone to send events to the Sentry project, potentially consuming quotas or spamming the error tracker.
🔧 Fix: Replaced all hardcoded instances with environment variable lookups (`SENTRY_DSN`, `VITE_SENTRY_DSN`). Added conditional logic to gracefully handle missing DSNs. Redacted the DSN from `EXTERNAL_APIS.md`.
✅ Verification:
- `bun run build` passed.
- `bun run lint` passed.
- Python tests `python3 -m unittest discover admin_api/tests` passed.
- `grep` confirms no hardcoded DSNs remain in source code.

---
*PR created automatically by Jules for task [3497574812246740648](https://jules.google.com/task/3497574812246740648) started by @FrenchFive*