### PR TITLE
Refactor emptyPlant to function for proper UUID generation

### DIFF
--- a/plant-swipe/src/pages/CreatePlantPage.tsx
+++ b/plant-swipe/src/pages/CreatePlantPage.tsx
@@ -306,23 +306,25 @@ async function generateUniquePlantName(baseName: string): Promise<string> {
   return result
 }
 
-const emptyPlant: Plant = {
-  id: generateUUIDv4(),
-  name: "",
-  utility: [],
-  comestiblePart: [],
-  fruitType: [],
-  images: [],
-  identity: { givenNames: [], colors: [], multicolor: false, bicolor: false },
-  plantCare: { watering: { schedules: [] } },
-  growth: {},
-  usage: {},
-  ecology: {},
-  danger: {},
-  miscellaneous: { sources: [] },
-  meta: { contributors: [] },
-  seasons: [],
-  colors: [],
+function createEmptyPlant(): Plant {
+  return {
+    id: generateUUIDv4(),
+    name: "",
+    utility: [],
+    comestiblePart: [],
+    fruitType: [],
+    images: [],
+    identity: { givenNames: [], colors: [], multicolor: false, bicolor: false },
+    plantCare: { watering: { schedules: [] } },
+    growth: {},
+    usage: {},
+    ecology: {},
+    danger: {},
+    miscellaneous: { sources: [] },
+    meta: { contributors: [] },
+    seasons: [],
+    colors: [],
+  }
 }
 
 const normalizeSeasonSlug = (value?: string | null): string | null => {
@@ -1150,7 +1152,10 @@ export const CreatePlantPage: React.FC<{ onCancel: () => void; onSaved?: (id: st
   const urlLanguage = useLanguage()
   const [language, setLanguage] = React.useState<SupportedLanguage>(urlLanguage)
   const languageRef = React.useRef<SupportedLanguage>(urlLanguage)
-  const [plant, setPlant] = React.useState<Plant>(() => ({ ...emptyPlant, name: effectiveInitialName, id: id || emptyPlant.id }))
+  const [plant, setPlant] = React.useState<Plant>(() => {
+    const empty = createEmptyPlant()
+    return { ...empty, name: effectiveInitialName, id: id || empty.id }
+  })
   // Cache of plant data per language to preserve edits when switching languages
   const [plantByLanguage, setPlantByLanguage] = React.useState<Partial<Record<SupportedLanguage, Plant>>>({})
   // Track which languages have been loaded from DB


### PR DESCRIPTION
## Summary
Converted the `emptyPlant` constant to a `createEmptyPlant()` function to ensure each plant instance receives a unique UUID, preventing ID collisions when creating multiple plants.

## Key Changes
- Changed `emptyPlant` from a module-level constant to a `createEmptyPlant()` factory function
- Updated the plant state initialization in `CreatePlantPage` to call `createEmptyPlant()` instead of spreading the constant
- This ensures `generateUUIDv4()` is called fresh for each new plant, rather than reusing a single UUID across instances

## Implementation Details
The previous implementation had a potential bug where all new plants would share the same UUID since `generateUUIDv4()` was only called once when the module loaded. By converting to a factory function, each call to `createEmptyPlant()` generates a new unique ID, which is the correct behavior for creating distinct plant records.

https://claude.ai/code/session_01SJ2jerwwQJHvn9U3ZQ3BLE