### PR TITLE
Add pruning season support and improve toxicity level handling

### DIFF
--- a/plant-swipe/public/locales/en/plantInfo.json
+++ b/plant-swipe/public/locales/en/plantInfo.json
@@ -32,7 +32,8 @@
     "legend": {
       "flowering": "Flowering",
       "fruiting": "Fruiting",
-      "sowing": "Sowing"
+      "sowing": "Sowing",
+      "pruning": "Pruning"
     }
   },
   "habitatMap": {

--- a/plant-swipe/public/locales/fr/plantInfo.json
+++ b/plant-swipe/public/locales/fr/plantInfo.json
@@ -32,7 +32,8 @@
     "legend": {
       "flowering": "Floraison",
       "fruiting": "Fructification",
-      "sowing": "Semis"
+      "sowing": "Semis",
+      "pruning": "Taille"
     }
   },
   "habitatMap": {


### PR DESCRIPTION
## Summary
This PR adds support for displaying pruning seasons in the plant timeline and improves the toxicity level classification system to handle more input variations.

## Key Changes

### Pruning Season Timeline Support
- Added `Scissors` icon import from lucide-react
- Added `pruning` color (`#ec4899` - pink) to the timeline color palette
- Extended `buildTimelineData()` to extract and process `pruningMonth` data from plants
- Updated `GanttTimeline` component to display pruning as a fourth activity row alongside flowering, fruiting, and sowing
- Added pruning translations in English ("Pruning") and French ("Taille") locale files

### Toxicity Level Normalization
- Enhanced `getToxicityConfig()` function to recognize additional toxicity level variations:
  - **Safe**: Added "safe" as alias for "nontoxic"
  - **Mild**: Added "slightlytoxic", "mildlyirritating", and "mild" as aliases
  - **High**: Added "verytoxic" and "toxic" as aliases
  - **Lethal**: Added "deadly", "lethal", and "fatal" as aliases
  - **Unknown**: Added handling for "undetermined", "unknown", and "notdetermined" (returns null)
- Standardized key names in config objects for consistency (e.g., "slightlytoxic", "verytoxic", "deadly")

## Implementation Details
- The pruning timeline row only displays if the plant has pruning months defined, maintaining clean UI
- Toxicity level matching is case-insensitive and strips whitespace/hyphens for robust matching
- All new strings are properly internationalized with locale file entries

https://claude.ai/code/session_01Lcb3VEiP2mdzk3saCh6Tj4