### PR TITLE
🎨 Palette: Improve AdminUserMessagesDialog accessibility

### DIFF
--- a/plant-swipe/src/components/admin/AdminUserMessagesDialog.tsx
+++ b/plant-swipe/src/components/admin/AdminUserMessagesDialog.tsx
@@ -658,6 +658,7 @@ export const AdminUserMessagesDialog: React.FC<AdminUserMessagesDialogProps> = (
                   <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-stone-400" />
                   <input
                     type="text"
+                    aria-label="Filter conversations"
                     placeholder="Filter conversations..."
                     value={searchQuery}
                     onChange={(e) => setSearchQuery(e.target.value)}
@@ -743,6 +744,7 @@ export const AdminUserMessagesDialog: React.FC<AdminUserMessagesDialogProps> = (
                   <input
                     ref={searchInputRef}
                     type="text"
+                    aria-label="Search in message content"
                     placeholder="Search in message content..."
                     value={messageSearchQuery}
                     onChange={(e) => setMessageSearchQuery(e.target.value)}
@@ -956,8 +958,8 @@ export const AdminUserMessagesDialog: React.FC<AdminUserMessagesDialogProps> = (
                             }}
                             className={cn(
                               "absolute bottom-1 right-1 p-1.5 rounded-full transition-all",
-                              "bg-black/60 text-white",
-                              "opacity-0 group-hover:opacity-100",
+                              "bg-black/60 text-white focus-visible:outline-none",
+                              "opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-white",
                               "active:scale-95",
                               downloadSuccess === img.id && "bg-green-500"
                             )}


### PR DESCRIPTION
💡 What: The UX enhancement added
Added proper `aria-label` attributes to two text inputs (Filter and Search) in the `AdminUserMessagesDialog` component, and fixed a keyboard accessibility issue where the quick download image button was only visible on hover, completely hiding it from keyboard navigation.

🎯 Why: The user problem it solves
Screen reader users would hear an unlabeled text input when tabbing to the search fields, making it unclear what they were searching. Keyboard-only users could tab to the quick download button but couldn't see it because it remained `opacity-0` without hover.

📸 Before/After:
Before: `opacity-0 group-hover:opacity-100` on the download button. Unlabeled inputs.
After: `opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-white focus-visible:outline-none` on the download button. Inputs have explicit `aria-label`s.

♿ Accessibility:
Improved screen reader context for text inputs and fixed a major keyboard navigation visibility trap.

---
*PR created automatically by Jules for task [12486849691011141170](https://jules.google.com/task/12486849691011141170) started by @FrenchFive*