### PR TITLE
⚡ Bolt: Memoize SwipeCardSkeleton to prevent re-renders

### DIFF
--- a/plant-swipe/src/components/plant/SwipeCardSkeleton.tsx
+++ b/plant-swipe/src/components/plant/SwipeCardSkeleton.tsx
@@ -1,7 +1,8 @@
+import React from "react"
 import { Card } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
 
-export const SwipeCardSkeleton = () => {
+const SwipeCardSkeletonComponent = () => {
   const desktopCardHeight = "min(720px, calc(100vh - 12rem))"
 
   return (
@@ -67,3 +68,7 @@ export const SwipeCardSkeleton = () => {
     </>
   )
 }
+
+// ⚡ Bolt: Memoize SwipeCardSkeleton to prevent re-renders on every swipe.
+// The parent PlantSwipe re-renders frequently (index changes), but the skeleton UI is static.
+export const SwipeCardSkeleton = React.memo(SwipeCardSkeletonComponent)


### PR DESCRIPTION
💡 What: Refactored `SwipeCardSkeleton` to be wrapped in `React.memo()`.

🎯 Why: The component was re-rendering unnecessarily when its parent component `PlantSwipe` updated state during swipe interactions (e.g. tracking index, x, y coordinates). Because the skeleton UI is completely static and receives no props, it should only render once.

📊 Impact: Significantly reduces DOM reconstruction of a complex UI (multiple `Skeleton` components, badges, buttons, layout containers) when the user interacts during loading states or layout shifts.

🔬 Measurement: Verifiable by monitoring React component renders using React DevTools while simulating swipe interactions.

---
*PR created automatically by Jules for task [7740474931283791801](https://jules.google.com/task/7740474931283791801) started by @FrenchFive*