### PR TITLE
Add garden switcher dropdown for multi-garden navigation

### DIFF
--- a/plant-swipe/src/components/garden/GardenSwitcherDropdown.tsx
+++ b/plant-swipe/src/components/garden/GardenSwitcherDropdown.tsx
@@ -13,12 +13,15 @@ interface GardenSwitcherDropdownProps {
   currentGarden: Garden;
   userId: string;
   onSwitch: (gardenId: string) => void;
+  /** Custom trigger element. Receives the garden and renders as DropdownMenuTrigger child. */
+  children?: React.ReactNode;
 }
 
 export const GardenSwitcherDropdown: React.FC<GardenSwitcherDropdownProps> = ({
   currentGarden,
   userId,
   onSwitch,
+  children,
 }) => {
   const [gardens, setGardens] = React.useState<Garden[]>([]);
   const [loaded, setLoaded] = React.useState(false);
@@ -37,16 +40,20 @@ export const GardenSwitcherDropdown: React.FC<GardenSwitcherDropdownProps> = ({
 
   const otherGardens = gardens.filter((g) => g.id !== currentGarden.id);
 
+  const defaultTrigger = (
+    <button
+      className="hidden md:flex items-center gap-1.5 text-xl font-semibold text-left hover:opacity-80 transition-opacity cursor-pointer bg-transparent border-none outline-none p-0"
+      aria-label="Switch garden"
+    >
+      <span className="truncate max-w-[160px]">{currentGarden.name}</span>
+      <ChevronDown className="w-4 h-4 flex-shrink-0 opacity-60" />
+    </button>
+  );
+
   return (
     <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild>
-        <button
-          className="hidden md:flex items-center gap-1.5 text-xl font-semibold text-left hover:opacity-80 transition-opacity cursor-pointer bg-transparent border-none outline-none p-0"
-          aria-label="Switch garden"
-        >
-          <span className="truncate max-w-[160px]">{currentGarden.name}</span>
-          <ChevronDown className="w-4 h-4 flex-shrink-0 opacity-60" />
-        </button>
+        {children || defaultTrigger}
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className="w-56 rounded-xl">
         {/* Current garden - shown as active */}

--- a/plant-swipe/src/pages/GardenDashboardPage.tsx
+++ b/plant-swipe/src/pages/GardenDashboardPage.tsx
@@ -4221,6 +4221,7 @@ function OverviewSection({
 }) {
   const { t } = useTranslation("common");
   const navigate = useLanguageNavigate();
+  const { user: authUser } = useAuth();
   const [activity, setActivity] = React.useState<
     Array<{
       id: string;
@@ -4466,9 +4467,26 @@ function OverviewSection({
             <div className="relative z-10 p-8 md:p-10 min-h-[280px] flex flex-col justify-end">
               <div className="flex flex-col md:flex-row md:items-end md:justify-between gap-6">
                 <div className="space-y-3">
-                  <h1 className="text-3xl md:text-4xl font-bold text-white drop-shadow-lg">
-                    {garden.name}
-                  </h1>
+                  {authUser && garden ? (
+                    <GardenSwitcherDropdown
+                      currentGarden={garden}
+                      userId={authUser.id}
+                      onSwitch={(gid) => navigate(`/garden/${gid}/overview`)}
+                    >
+                      <h1
+                        className="text-3xl md:text-4xl font-bold text-white drop-shadow-lg flex items-center gap-2 cursor-pointer hover:opacity-90 transition-opacity"
+                        role="button"
+                        tabIndex={0}
+                      >
+                        {garden.name}
+                        <ChevronDown className="w-5 h-5 opacity-70" />
+                      </h1>
+                    </GardenSwitcherDropdown>
+                  ) : (
+                    <h1 className="text-3xl md:text-4xl font-bold text-white drop-shadow-lg">
+                      {garden?.name}
+                    </h1>
+                  )}
                   <div className="flex flex-wrap items-center gap-4 text-white/90">
                     <div className="flex items-center gap-2 bg-black/30 backdrop-blur-sm rounded-full px-3 py-1.5">
                       <span className="text-lg">🌱</span>
@@ -4541,9 +4559,26 @@ function OverviewSection({
 
             <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-6 relative">
               <div className="space-y-3">
-                <h1 className="text-3xl md:text-4xl font-bold bg-gradient-to-r from-emerald-600 to-teal-600 dark:from-emerald-400 dark:to-teal-400 bg-clip-text text-transparent">
-                  {garden?.name || t("gardenDashboard.overview")}
-                </h1>
+                {authUser && garden ? (
+                  <GardenSwitcherDropdown
+                    currentGarden={garden}
+                    userId={authUser.id}
+                    onSwitch={(gid) => navigate(`/garden/${gid}/overview`)}
+                  >
+                    <h1
+                      className="text-3xl md:text-4xl font-bold bg-gradient-to-r from-emerald-600 to-teal-600 dark:from-emerald-400 dark:to-teal-400 bg-clip-text text-transparent flex items-center gap-2 cursor-pointer hover:opacity-90 transition-opacity"
+                      role="button"
+                      tabIndex={0}
+                    >
+                      {garden.name}
+                      <ChevronDown className="w-5 h-5 text-emerald-600 dark:text-emerald-400" />
+                    </h1>
+                  </GardenSwitcherDropdown>
+                ) : (
+                  <h1 className="text-3xl md:text-4xl font-bold bg-gradient-to-r from-emerald-600 to-teal-600 dark:from-emerald-400 dark:to-teal-400 bg-clip-text text-transparent">
+                    {garden?.name || t("gardenDashboard.overview")}
+                  </h1>
+                )}
                 <div className="flex flex-wrap items-center gap-3">
                   <div className="flex items-center gap-2 bg-white/60 dark:bg-white/10 backdrop-blur-sm rounded-full px-3 py-1.5 border border-emerald-200/50 dark:border-emerald-500/20">
                     <span className="text-lg">🌱</span>


### PR DESCRIPTION
## Summary
This PR introduces a new `GardenSwitcherDropdown` component that allows users to quickly switch between their gardens from the dashboard. The dropdown is integrated into both the sidebar and the main overview section header.

## Key Changes
- **New Component**: Created `GardenSwitcherDropdown.tsx` that provides:
  - A dropdown menu showing the current garden (highlighted) and other available gardens
  - Pre-fetching of user's gardens on mount for instant access
  - Support for custom trigger elements via children prop
  - Default trigger button with chevron icon for desktop view
  - Loading and empty states

- **GardenDashboardPage Integration**:
  - Replaced static garden name in sidebar with `GardenSwitcherDropdown`
  - Added garden switcher to both light and dark theme overview headers
  - Integrated with navigation to switch between gardens while preserving current tab
  - Conditional rendering based on user authentication status

## Implementation Details
- The dropdown pre-fetches gardens on component mount using a cancellation flag to prevent state updates on unmounted components
- Supports customizable trigger elements while providing a sensible default (text + chevron icon)
- Current garden is displayed as a disabled, highlighted menu item
- Other gardens are clickable and trigger navigation via the `onSwitch` callback
- Responsive design with hidden trigger on mobile (sidebar version only)
- Includes proper accessibility attributes (aria-label, role, tabIndex)

https://claude.ai/code/session_01K7JBTACqqASw2uE6gGq9Qr