### PR TITLE
Apple App Store rejection risks doc + iOS privacy manifest and plist fixes

### DIFF
--- a/plant-swipe/docs/APPLE_APP_STORE_REJECTION_RISKS.md
+++ b/plant-swipe/docs/APPLE_APP_STORE_REJECTION_RISKS.md
@@ -1,0 +1,135 @@
+# Apple App Store — common rejection themes and how we mitigate them
+
+This is an internal engineering checklist. It is **not legal advice**. App Store Review Guidelines change; always read [Apple’s current guidelines](https://developer.apple.com/app-store/review/guidelines/) and align App Privacy labels and review notes with your counsel.
+
+---
+
+## 1. Safety, scams, and illegal content (4.x)
+
+| Risk | What reviewers look for | Mitigation in this repo |
+|------|-------------------------|-------------------------|
+| User-generated content without moderation | Abuse, harassment, illegal goods | Keep moderation tooling and reporting aligned with your policy; document in review notes if UGC is central. |
+| Deceptive behavior | Fake functionality, hidden purchases | No fake “pay to unlock” in consumer paths; pricing must match IAP if you add subscriptions. |
+
+---
+
+## 2. Performance, completeness, and “minimum functionality” (2.1, 4.2)
+
+| Risk | What reviewers look for | Mitigation |
+|------|-------------------------|------------|
+| Crashes, blank screens, broken core flows | App must work on current iOS | Test **release** builds on **physical devices**; cold start, login, main tabs, offline errors (no infinite spinners). |
+| Thin website wrapper | Desktop UI in a WebView, poor touch targets | Mobile-first layout, safe areas, native chrome (`StatusBar`, `contentInset`); see `docs/APP_STORE_READINESS.md`. |
+| Placeholder or “coming soon” as main feature | Broken or empty primary navigation | Remove or hide unfinished consumer features from production routes. |
+| **Remote code / changing app behavior** (2.5.2) | Loading executable logic that alters features post-review | **No `server.url` in production**; bundled `webDir` only. See `docs/LIVE_UPDATES_STORE_POLICY.md`. |
+
+---
+
+## 3. Business, payments, and subscriptions (3.1.x)
+
+| Risk | Mitigation |
+|------|------------|
+| Digital goods without IAP | If you sell digital subscriptions in the app, use Apple IAP (or qualify for a narrow exception — verify with counsel). |
+| External purchase links where not allowed | Follow current “reader app” and StoreKit External Purchase rules if applicable. |
+
+*(Aphylia’s store monetization model must be verified before submission.)*
+
+---
+
+## 4. Design, spam, and copycats (4.0, 4.3)
+
+| Risk | Mitigation |
+|------|------------|
+| App looks like a template or duplicate | Distinct branding, screenshots, and copy; avoid generic placeholder art in the binary. |
+| Misleading metadata | Screenshots and description must match the **submitted build**. |
+
+---
+
+## 5. Privacy, tracking, and data collection (5.1.x)
+
+| Risk | Mitigation |
+|------|------------|
+| Missing or inaccurate **App Privacy** answers | Declare data collected by the app and SDKs (Supabase, Sentry, analytics if enabled, reCAPTCHA, push). |
+| **App Tracking Transparency (ATT)** | If you use IDFA or certain cross-app tracking, implement ATT + `NSUserTrackingUsageDescription`. Gate analytics to match web consent where applicable. |
+| **Privacy manifest** (required reason APIs) | `ios/App/App/PrivacyInfo.xcprivacy` declares **UserDefaults** (`CA92.1`) for typical Capacitor/plugin use. **Expand** this file if Xcode or App Store Connect reports additional required APIs (e.g. disk space, boot time). |
+| Secret tracking / fingerprinting | Do not collect more than disclosed; document server-side retention. |
+
+---
+
+## 6. Permissions and Info.plist strings (5.1.1)
+
+| Capability | Key | Status in repo |
+|------------|-----|----------------|
+| Camera / photos (picker) | `NSCameraUsageDescription`, `NSPhotoLibraryUsageDescription` | Present in `Info.plist`. |
+| Location (GPS city picker in web app) | `NSLocationWhenInUseUsageDescription` | **Added** — required before iOS shows the location prompt. |
+| Microphone | `NSMicrophoneUsageDescription` | **Not** in plist — camera path uses **video-only** `getUserMedia` (`audio: false`). Add this key only if you enable microphone. |
+| Photo library **write** | `NSPhotoLibraryAddUsageDescription` | Add only if you save images to the library. |
+| Push | Background mode `remote-notification` + user-facing notification permission | Configured; ensure copy matches real use (messages, reminders). |
+
+---
+
+## 7. Encryption export compliance
+
+| Risk | Mitigation |
+|------|------------|
+| Unclear export compliance in App Store Connect | `ITSAppUsesNonExemptEncryption` set to **`false`** in `Info.plist` for standard HTTPS/TLS only. **Change to `true` and complete export paperwork** if you ship custom or non-exempt crypto. |
+
+---
+
+## 8. Sign in with Apple (4.8)
+
+| Risk | Mitigation |
+|------|------------|
+| Third-party social login without Apple | Current primary auth is **email/password** via Supabase. **If you add** Google/Facebook/etc. as sign-in, evaluate **Sign in with Apple** requirement and implement alongside. |
+
+---
+
+## 9. Account deletion (5.1.1(v))
+
+| Risk | Mitigation |
+|------|------------|
+| No way to delete account | In-app GDPR / account deletion must work; note URL in App Store Connect if required. See `docs/APP_STORE_READINESS.md`. |
+
+---
+
+## 10. Legal, intellectual property, and metadata (5.2, metadata)
+
+| Risk | Mitigation |
+|------|------------|
+| Missing terms / privacy links | Ensure live URLs in App Store Connect match the app. |
+| Third-party content rights | Plant images, user uploads — ensure licensing and DMCA/process as needed. |
+
+---
+
+## 11. Universal Links, auth, and WebView navigation
+
+| Risk | Mitigation |
+|------|------------|
+| Magic links / OAuth break in app | `allowNavigation` for Supabase and app domain via env at `cap sync`; auth URL handling in `supabaseClient.ts`. See `docs/UNIVERSAL_LINKS_AND_AUTH.md`. |
+| Associated domains misconfigured | Host `apple-app-site-association` on HTTPS; match Team ID + bundle ID. |
+
+---
+
+## 12. Device requirements
+
+| Item | Change |
+|------|--------|
+| `UIRequiredDeviceCapabilities` | **Updated** from `armv7` to **`arm64`** (64-bit only; aligns with modern App Store expectations). |
+
+---
+
+## Pre-upload sanity (engineering)
+
+```bash
+cd plant-swipe
+bun run build:cap
+# Xcode: Archive → Validate; fix any Privacy Manifest or signing warnings
+```
+
+---
+
+## Related docs
+
+- `docs/APP_STORE_REVIEW_CHECKLIST.md` — short pre-flight list  
+- `docs/APP_STORE_READINESS.md` — UX, SDKs, permissions detail  
+- `docs/MOBILE_ARCHITECTURE.md` — bundled assets, no production `server.url`  
+- `docs/LIVE_UPDATES_STORE_POLICY.md` — guideline 2.5.2 stance  

--- a/plant-swipe/docs/APP_STORE_READINESS.md
+++ b/plant-swipe/docs/APP_STORE_READINESS.md
@@ -25,9 +25,13 @@ After `npx cap add ios`, edit **`ios/App/App/Info.plist`** (or target build sett
 | `NSPhotoLibraryAddUsageDescription` | Saving images to library |
 | `NSMicrophoneUsageDescription` | Only if you enable microphone (e.g. video) |
 | `NSUserTrackingUsageDescription` | Only if you use App Tracking Transparency (IDFA) |
-| `NSLocationWhenInUseUsageDescription` | If you use geolocation (e.g. city picker) |
+| `NSLocationWhenInUseUsageDescription` | GPS city detection in setup (see `city-country-selector.tsx`) — **present in `Info.plist`** |
 
 **Push:** system permission prompt uses text you configure for notifications; ensure copy matches actual use (task reminders, messages, etc.).
+
+**Privacy manifest:** `ios/App/App/PrivacyInfo.xcprivacy` declares **UserDefaults** (required-reason API) for typical Capacitor usage. Re-validate in Xcode after dependency upgrades; add entries if Apple flags additional API categories.
+
+**Export compliance:** `ITSAppUsesNonExemptEncryption` is set to `false` for standard TLS/HTTPS. Update if you ship custom cryptography.
 
 **Tracking:** If you use **Google Analytics** or other cross-app tracking on iOS 14+, follow ATT rules and App Privacy disclosures. The web app gates GA behind cookie consent; mirror that behavior in the native shell and disclose collected data types in App Store Connect.
 

--- a/plant-swipe/docs/APP_STORE_REVIEW_CHECKLIST.md
+++ b/plant-swipe/docs/APP_STORE_REVIEW_CHECKLIST.md
@@ -20,6 +20,8 @@ Internal pre-submission list for **Aphylia** (Capacitor + shared web app). Not l
 ## Permissions & plist / manifest
 
 - [ ] **iOS `Info.plist`:** every runtime permission has a clear **usage description** (camera, photos, location, mic, tracking, etc.—only keys you actually use).
+- [ ] **`PrivacyInfo.xcprivacy`** bundled in the app target; **required-reason APIs** declared (expand if App Store Connect reports missing types).
+- [ ] **`ITSAppUsesNonExemptEncryption`:** set correctly for your crypto story (HTTPS-only → `false` unless counsel says otherwise).
 - [ ] **Android:** dangerous permissions declared only if used; **runtime** requests match copy shown to users.
 - [ ] **Push:** if implemented, notification copy matches actual behavior; native push may require FCM/APNs beyond web push.
 
@@ -63,6 +65,7 @@ bun run build:cap          # native bundle + sync
 
 ## Related docs
 
+- `docs/APPLE_APP_STORE_REJECTION_RISKS.md` — themed list of common rejection reasons + repo mitigations
 - `docs/APP_STORE_READINESS.md` — deeper UX/SDK notes (update plugin names there if they drift)
 - `docs/LIVE_UPDATES_STORE_POLICY.md`
 - `docs/MOBILE_ARCHITECTURE.md`

--- a/plant-swipe/ios/App/App.xcodeproj/project.pbxproj
+++ b/plant-swipe/ios/App/App.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		504EC30F1FED79650016851F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 504EC30E1FED79650016851F /* Assets.xcassets */; };
 		504EC3121FED79650016851F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 504EC3101FED79650016851F /* LaunchScreen.storyboard */; };
 		50B271D11FEDC1A000F3C39B /* public in Resources */ = {isa = PBXBuildFile; fileRef = 50B271D01FEDC1A000F3C39B /* public */; };
+		504EC31A1FED79650016851F /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 504EC3191FED79650016851F /* PrivacyInfo.xcprivacy */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -26,6 +27,7 @@
 		504EC30E1FED79650016851F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		504EC3111FED79650016851F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		504EC3131FED79650016851F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		504EC3191FED79650016851F /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		50B271D01FEDC1A000F3C39B /* public */ = {isa = PBXFileReference; lastKnownFileType = folder; path = public; sourceTree = "<group>"; };
 		958DCC722DB07C7200EA8C5F /* debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = debug.xcconfig; path = ../debug.xcconfig; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
@@ -68,6 +70,7 @@
 				504EC30E1FED79650016851F /* Assets.xcassets */,
 				504EC3101FED79650016851F /* LaunchScreen.storyboard */,
 				504EC3131FED79650016851F /* Info.plist */,
+				504EC3191FED79650016851F /* PrivacyInfo.xcprivacy */,
 				2FAD9762203C412B000D30F8 /* config.xml */,
 				50B271D01FEDC1A000F3C39B /* public */,
 			);
@@ -144,6 +147,7 @@
 				504EC30F1FED79650016851F /* Assets.xcassets in Resources */,
 				50379B232058CBB4000EE86E /* capacitor.config.json in Resources */,
 				504EC30D1FED79650016851F /* Main.storyboard in Resources */,
+				504EC31A1FED79650016851F /* PrivacyInfo.xcprivacy in Resources */,
 				2FAD9763203C412B000D30F8 /* config.xml in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/plant-swipe/ios/App/App/Info.plist
+++ b/plant-swipe/ios/App/App/Info.plist
@@ -30,7 +30,7 @@
 	<string>Main</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
-		<string>armv7</string>
+		<string>arm64</string>
 	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
@@ -49,6 +49,10 @@
 	<string>Aphylia uses the camera to capture plant photos and messages.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Aphylia may access your photo library when you choose an existing image.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Aphylia uses your location only when you choose to detect your city with GPS for weather and garden recommendations.</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>remote-notification</string>

--- a/plant-swipe/ios/App/App/PrivacyInfo.xcprivacy
+++ b/plant-swipe/ios/App/App/PrivacyInfo.xcprivacy
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a structured **Apple rejection risk** document and fixes several **iOS submission gaps** that often cause App Store Connect back-and-forth.

## Changes

- **New** `docs/APPLE_APP_STORE_REJECTION_RISKS.md` — themed list (safety, minimum functionality, 2.5.2, privacy manifest, permissions, 4.8, account deletion, etc.) with how the repo mitigates each.
- **`PrivacyInfo.xcprivacy`** — declares **UserDefaults** required-reason API (`CA92.1`); wired into the Xcode target Resources.
- **`Info.plist`**
  - `NSLocationWhenInUseUsageDescription` — required because the web app uses `navigator.geolocation` for the city picker.
  - `ITSAppUsesNonExemptEncryption` = `false` — standard HTTPS/TLS only; **change if** you ship non-exempt crypto.
  - `UIRequiredDeviceCapabilities`: `armv7` → **`arm64`** (modern 64-bit expectation).
- **Docs**: checklist + readiness cross-links.

## Reviewer note

After **Archive → Validate** in Xcode, if Apple flags **additional** required-reason APIs, extend `PrivacyInfo.xcprivacy` (do not assume UserDefaults is the only one forever).

## Related

Complements existing `docs/APP_STORE_REVIEW_CHECKLIST.md`, `docs/APP_STORE_READINESS.md`, `docs/LIVE_UPDATES_STORE_POLICY.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1db1b648-f909-427f-bbaf-93304dcc7e76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1db1b648-f909-427f-bbaf-93304dcc7e76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

