### PR TITLE
🎨 Palette: Add missing ARIA labels to Admin Panel icon buttons

### DIFF
--- a/plant-swipe/src/components/admin/AdminBugsPanel.tsx
+++ b/plant-swipe/src/components/admin/AdminBugsPanel.tsx
@@ -836,6 +836,7 @@ export const AdminBugsPanel: React.FC = () => {
                           className="rounded-lg h-8 w-8"
                           onClick={() => handleViewResponses(action)}
                           title="View Responses"
+                          aria-label="View Responses"
                         >
                           <Eye className="h-4 w-4" />
                         </Button>
@@ -845,6 +846,7 @@ export const AdminBugsPanel: React.FC = () => {
                           className="rounded-lg h-8 w-8"
                           onClick={() => handleEditAction(action)}
                           title="Edit"
+                          aria-label="Edit"
                         >
                           <Edit2 className="h-4 w-4" />
                         </Button>
@@ -855,6 +857,7 @@ export const AdminBugsPanel: React.FC = () => {
                             className="rounded-lg h-8 w-8 text-emerald-600"
                             onClick={() => handleChangeActionStatus(action.id, 'active')}
                             title="Activate"
+                            aria-label="Activate"
                           >
                             <Play className="h-4 w-4" />
                           </Button>
@@ -866,6 +869,7 @@ export const AdminBugsPanel: React.FC = () => {
                             className="rounded-lg h-8 w-8 text-orange-600"
                             onClick={() => handleChangeActionStatus(action.id, 'closed')}
                             title="Close"
+                            aria-label="Close"
                           >
                             <Archive className="h-4 w-4" />
                           </Button>
@@ -876,6 +880,7 @@ export const AdminBugsPanel: React.FC = () => {
                           className="rounded-lg h-8 w-8 text-red-600"
                           onClick={() => handleDeleteAction(action.id)}
                           title="Delete"
+                          aria-label="Delete"
                         >
                           <Trash2 className="h-4 w-4" />
                         </Button>

--- a/plant-swipe/src/components/admin/AdminLandingPanel.tsx
+++ b/plant-swipe/src/components/admin/AdminLandingPanel.tsx
@@ -1870,6 +1870,7 @@ const HeroCardsTab: React.FC<{
                         variant="ghost"
                         size="icon"
                         onClick={() => updateLocalCard(card.id, { is_active: !card.is_active })}
+                        aria-label="Toggle active status"
                         className={cn(
                           "rounded-xl",
                           card.is_active ? "text-emerald-600 bg-emerald-50 dark:bg-emerald-900/20" : "text-stone-400"
@@ -1881,6 +1882,7 @@ const HeroCardsTab: React.FC<{
                         variant="ghost"
                         size="icon"
                         onClick={() => deleteCard(card.id)}
+                        aria-label="Delete card"
                         className="rounded-xl text-red-500 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20"
                       >
                         <Trash2 className="h-4 w-4" />
@@ -2560,6 +2562,7 @@ const TestimonialsTab: React.FC<{
                       variant="ghost"
                       size="icon"
                       onClick={() => updateLocalTestimonial(testimonial.id, { is_active: !testimonial.is_active })}
+                      aria-label="Toggle active status"
                       className={cn(
                         "rounded-xl h-8 w-8",
                         testimonial.is_active ? "text-emerald-600 bg-emerald-50" : "text-stone-400"
@@ -2571,6 +2574,7 @@ const TestimonialsTab: React.FC<{
                       variant="ghost"
                       size="icon"
                       onClick={() => deleteTestimonial(testimonial.id)}
+                      aria-label="Delete testimonial"
                       className="rounded-xl h-8 w-8 text-red-500 hover:bg-red-50"
                     >
                       <Trash2 className="h-3.5 w-3.5" />

--- a/plant-swipe/src/components/admin/AdminReportsPanel.tsx
+++ b/plant-swipe/src/components/admin/AdminReportsPanel.tsx
@@ -384,6 +384,7 @@ export function AdminReportsPanel() {
                       size="icon"
                       className="rounded-lg"
                       onClick={() => setSelectedReport(null)}
+                      aria-label="Close"
                     >
                       <X className="h-4 w-4" />
                     </Button>


### PR DESCRIPTION
💡 What: Added missing `aria-label` tags to icon-only buttons in multiple admin panel components.
🎯 Why: Admin views are essential, but screen reader and keyboard users were missing actionable context regarding what various icon buttons achieved.
♿ Accessibility: Ensures that status toggles, edit buttons, action buttons, and modal dismissal components are correctly parsed by screen readers.

---
*PR created automatically by Jules for task [7561767335927807581](https://jules.google.com/task/7561767335927807581) started by @FrenchFive*