### PR TITLE
⚡ Bolt: Combine multiple status count aggregations into a single loop

### DIFF
--- a/plant-swipe/src/components/admin/AdminBugsPanel.tsx
+++ b/plant-swipe/src/components/admin/AdminBugsPanel.tsx
@@ -447,12 +447,26 @@ export const AdminBugsPanel: React.FC = () => {
 
   // Computed: action counts by status
   const actionStatusCounts = React.useMemo(() => {
+    // ⚡ Bolt: Calculate multiple status counts using a single-pass loop instead of chained .filter().length calls
+    let draft = 0;
+    let planned = 0;
+    let active = 0;
+    let closed = 0;
+
+    for (let i = 0; i < actions.length; i++) {
+      const status = actions[i].status;
+      if (status === 'draft') draft++;
+      else if (status === 'planned') planned++;
+      else if (status === 'active') active++;
+      else if (status === 'closed') closed++;
+    }
+
     return {
       all: actions.length,
-      draft: actions.filter(a => a.status === 'draft').length,
-      planned: actions.filter(a => a.status === 'planned').length,
-      active: actions.filter(a => a.status === 'active').length,
-      closed: actions.filter(a => a.status === 'closed').length,
+      draft,
+      planned,
+      active,
+      closed,
     }
   }, [actions])
 


### PR DESCRIPTION
💡 What: Replaced four separate `.filter(a => a.status === '...').length` calls in the `actionStatusCounts` memo block with a single-pass `for` loop that aggregates all status counts simultaneously.

🎯 Why: Each `.filter().length` chain iterates over the entire `actions` array and allocates a new intermediate array just to calculate the length and discard it. Performing this four times results in O(4N) complexity and unnecessary garbage collection overhead on every render that triggers this memo block.

📊 Impact: Reduces time complexity from O(4N) to O(N) and completely eliminates the allocation of four intermediate arrays, improving memory efficiency and reducing GC pauses.

🔬 Measurement: Verify by running `bun run build:low-mem` to ensure the build succeeds and `bun run lint` to confirm no new linting errors were introduced. The `actionStatusCounts` logic is well-isolated inside its `useMemo` block.

---
*PR created automatically by Jules for task [7144871816271120634](https://jules.google.com/task/7144871816271120634) started by @FrenchFive*