### PR TITLE
Fix streaks and advice showing for gardens with no plants/tasks

### DIFF
--- a/plant-swipe/server.js
+++ b/plant-swipe/server.js
@@ -22881,11 +22881,10 @@ app.get('/api/garden/:id/advice', async (req, res) => {
     }
 
     // Garden must have at least one plant with tasks configured
-    const taskCountRows = await sql`
-      select count(*)::int as count from public.garden_plant_tasks where garden_id = ${gardenId}
+    const taskExistsRows = await sql`
+      select 1 from public.garden_plant_tasks where garden_id = ${gardenId} limit 1
     `
-    const taskCount = Number(taskCountRows[0]?.count || 0)
-    if (taskCount < 1) {
+    if (taskExistsRows.length < 1) {
       res.json({ ok: true, message: 'Add tasks to your plants to receive personalized advice.', advice: null })
       return
     }

--- a/plant-swipe/server.js
+++ b/plant-swipe/server.js
@@ -22880,6 +22880,16 @@ app.get('/api/garden/:id/advice', async (req, res) => {
       return
     }
 
+    // Garden must have at least one plant with tasks configured
+    const taskCountRows = await sql`
+      select count(*)::int as count from public.garden_plant_tasks where garden_id = ${gardenId}
+    `
+    const taskCount = Number(taskCountRows[0]?.count || 0)
+    if (taskCount < 1) {
+      res.json({ ok: true, message: 'Add tasks to your plants to receive personalized advice.', advice: null })
+      return
+    }
+
     // Calculate current week start (Monday)
     const now = new Date()
     const dayOfWeek = now.getUTCDay() // 0 = Sunday

--- a/plant-swipe/src/components/garden/GardenAnalyticsSection.tsx
+++ b/plant-swipe/src/components/garden/GardenAnalyticsSection.tsx
@@ -232,6 +232,8 @@ interface GardenAnalyticsSectionProps {
   onNavigateToSettings?: () => void;
   /** When true, hide all AI-powered features (gardener advice) */
   hideAiFeatures?: boolean;
+  /** Whether the garden has at least one plant with tasks configured */
+  gardenHasTasks?: boolean;
 }
 
 // Color palette for charts
@@ -270,18 +272,22 @@ export const GardenAnalyticsSection: React.FC<GardenAnalyticsSectionProps> = ({
   streak: streakProp,
   onNavigateToSettings,
   hideAiFeatures = false,
+  gardenHasTasks = false,
 }) => {
   // Default serverToday to current date if not provided
   const serverToday = serverTodayProp || new Date().toISOString().slice(0, 10);
   
-  // Compute streak from garden or default to 0
-  const baseStreak = streakProp ?? garden?.streak ?? 0;
+  // Compute streak from garden or default to 0.
+  // Gardens with no plants or no tasks configured should always show streak = 0.
+  const hasActiveTasks = plants.length > 0 && gardenHasTasks;
+  const baseStreak = hasActiveTasks ? (streakProp ?? garden?.streak ?? 0) : 0;
   const streak = React.useMemo(() => {
+    if (!hasActiveTasks) return 0;
     if (!serverToday || !dailyStats.length) return baseStreak;
     const today = dailyStats.find((d) => d.date === serverToday);
     if (today && today.success) return baseStreak + 1;
     return baseStreak;
-  }, [baseStreak, serverToday, dailyStats]);
+  }, [baseStreak, serverToday, dailyStats, hasActiveTasks]);
   const { t } = useTranslation("common");
   const currentLang = useLanguage();
   const { user: _user } = useAuth();
@@ -320,7 +326,7 @@ export const GardenAnalyticsSection: React.FC<GardenAnalyticsSectionProps> = ({
   const gardenAgeInDays = gardenCreatedAt
     ? Math.floor((Date.now() - gardenCreatedAt.getTime()) / (1000 * 60 * 60 * 24))
     : 0;
-  const isEligibleForAdvice = gardenAgeInDays >= 7 && plants.length >= 1;
+  const isEligibleForAdvice = gardenAgeInDays >= 7 && plants.length >= 1 && gardenHasTasks;
 
   // Compute analytics from dailyStats
   const computedAnalytics = React.useMemo(() => {
@@ -357,17 +363,21 @@ export const GardenAnalyticsSection: React.FC<GardenAnalyticsSectionProps> = ({
     if (trendValue > 5) trend = "up";
     else if (trendValue < -5) trend = "down";
 
-    // Calculate consecutive successful days for best streak
+    // Calculate consecutive successful days for best streak.
+    // Only count days that actually had tasks due — days with due=0 and
+    // success=true (from legacy empty-garden records) are skipped so they
+    // don't inflate the streak.
     let bestStreak = 0;
     let currentStreak = 0;
     const sortedStats = [...dailyStats].sort((a, b) => a.date.localeCompare(b.date));
     for (const stat of sortedStats) {
-      if (stat.success) {
+      if (stat.due > 0 && stat.success) {
         currentStreak++;
         bestStreak = Math.max(bestStreak, currentStreak);
-      } else {
+      } else if (stat.due > 0 && !stat.success) {
         currentStreak = 0;
       }
+      // days with due=0 are neutral — don't break or extend the streak
     }
 
     // Find last missed day
@@ -790,18 +800,19 @@ export const GardenAnalyticsSection: React.FC<GardenAnalyticsSectionProps> = ({
       Object.entries(dowCounts).sort((a, b) => b[1] - a[1])[0]?.[0] || "0",
     );
 
-    // Streak calculation
+    // Streak calculation — skip days with no tasks due (due=0)
     let bestStreak = 0;
     let runStreak = 0;
     const sorted = [...bestDailyStats].sort((a, b) => a.date.localeCompare(b.date));
     for (let i = 0; i < sorted.length; i++) {
       const stat = sorted[i];
-      if (stat.success) {
+      if ((stat.due || 0) > 0 && stat.success) {
         runStreak++;
         bestStreak = Math.max(bestStreak, runStreak);
-      } else {
+      } else if ((stat.due || 0) > 0 && !stat.success) {
         runStreak = 0;
       }
+      // days with due=0 are neutral
     }
 
     let lastMissed = null;
@@ -1268,12 +1279,16 @@ export const GardenAnalyticsSection: React.FC<GardenAnalyticsSectionProps> = ({
                     </div>
                     <p className="text-sm text-muted-foreground max-w-md mx-auto">
                       {gardenAgeInDays < 7
-                        ? t("gardenDashboard.analyticsSection.adviceRequiresAge", { 
+                        ? t("gardenDashboard.analyticsSection.adviceRequiresAge", {
                             defaultValue: "Your garden needs to be at least 1 week old to receive personalized advice. Come back in {{days}} days!",
                             days: 7 - gardenAgeInDays,
                           })
-                        : t("gardenDashboard.analyticsSection.adviceRequiresPlants", { 
+                        : plants.length < 1
+                        ? t("gardenDashboard.analyticsSection.adviceRequiresPlants", {
                             defaultValue: "Add at least 1 plant to your garden to receive personalized gardening advice.",
+                          })
+                        : t("gardenDashboard.analyticsSection.adviceRequiresTasks", {
+                            defaultValue: "Add tasks to your plants to receive personalized gardening advice.",
                           })
                       }
                     </p>

--- a/plant-swipe/src/pages/GardenDashboardPage.tsx
+++ b/plant-swipe/src/pages/GardenDashboardPage.tsx
@@ -3625,6 +3625,7 @@ export const GardenDashboardPage: React.FC = () => {
                       dailyStats={dailyStats}
                       onNavigateToSettings={() => navigate(`/garden/${id}/settings?section=location`)}
                       hideAiFeatures={garden?.hideAiChat ?? false}
+                      gardenHasTasks={Object.values(taskCountsByPlant).some(c => c > 0)}
                     />
                   ) : (
                     <Navigate to={`/garden/${id}/overview`} replace />
@@ -5068,14 +5069,17 @@ function OverviewSection({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }), [serverToday, dailyStats]);
 
+  const gardenHasTasks = Object.values(taskCountsByPlant).some(c => c > 0);
   const streak = React.useMemo(() => {
+    // Gardens with no plants or no tasks should not show a streak
+    if (plants.length === 0 || !gardenHasTasks) return 0;
     let s = baseStreak;
     if (serverToday) {
       const today = dailyStats.find((d) => d.date === serverToday);
       if (today && today.success) s = baseStreak + 1;
     }
     return s;
-  }, [baseStreak, serverToday, dailyStats]);
+  }, [baseStreak, serverToday, dailyStats, plants.length, gardenHasTasks]);
 
   // Calculate task counts per plant - use server data or compute from todayTaskOccurrences
   const taskCountsPerPlant = React.useMemo(() => {

--- a/plant-swipe/supabase/sync_parts/07_ownership_and_rpcs.sql
+++ b/plant-swipe/supabase/sync_parts/07_ownership_and_rpcs.sql
@@ -901,7 +901,10 @@ declare
 begin
   select array_agg(t.id) into task_ids from public.garden_plant_tasks t where t.garden_id = _garden_id;
   if task_ids is null or array_length(task_ids,1) is null then
-    perform public.touch_garden_task(_garden_id, _day, null, true);
+    -- No tasks exist for this garden (no plants or no tasks configured).
+    -- Remove any existing garden_tasks record so empty gardens don't inflate streaks.
+    delete from public.garden_tasks
+      where garden_id = _garden_id and day = _day and task_type = 'watering';
     return;
   end if;
   select coalesce(sum(gpto.required_count), 0) into due_count
@@ -924,13 +927,15 @@ language sql
 security definer
 set search_path = public
 as $$
+  -- Only create garden_tasks records for gardens that actually have tasks configured.
+  -- Gardens with no plants or no tasks should not get records (prevents false streaks).
   insert into public.garden_tasks (garden_id, day, task_type, garden_plant_ids, success)
   select g.id, _day, 'watering', '{}'::uuid[], true
   from public.gardens g
+  where exists (
+    select 1 from public.garden_plant_tasks t where t.garden_id = g.id
+  )
   on conflict (garden_id, day, task_type) do nothing;
-  update public.garden_tasks
-    set success = true
-  where day = _day and task_type = 'watering' and coalesce(array_length(garden_plant_ids, 1), 0) = 0;
 $$;
 
 create or replace function public.get_user_id_by_email(_email text)


### PR DESCRIPTION
Gardens with no plants or no tasks configured were accumulating false
streaks because compute_garden_task_for_day marked empty gardens as
success=true. Similarly, Gardener's Advice was available for gardens
with plants but no tasks.

DB: compute_garden_task_for_day now deletes garden_tasks records for
taskless gardens instead of creating success=true entries.
DB: ensure_daily_tasks_for_gardens now only creates records for gardens
with at least one garden_plant_task.
Frontend: streak display and bestStreak calculation now require plants
and tasks; days with due=0 are treated as neutral for streak counting.
Backend: advice endpoint now checks for garden_plant_tasks existence.

https://claude.ai/code/session_01FG7sTFDesmgAG8tFAiEui4