### PR TITLE
Add automatic GitHub release creation on main branch push

### DIFF
--- a/.github/workflows/capacitor-mobile.yml
+++ b/.github/workflows/capacitor-mobile.yml
@@ -9,6 +9,19 @@ name: Capacitor mobile
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'plant-swipe/android/**'
+      - 'plant-swipe/ios/**'
+      - 'plant-swipe/capacitor.config.*'
+      - 'plant-swipe/package.json'
+      - 'plant-swipe/bun.lock'
+      - 'plant-swipe/scripts/sync-native-version.mjs'
+      - 'plant-swipe/scripts/cap-ci-sync.mjs'
+      - 'plant-swipe/scripts/assert-capacitor-store-bundle.mjs'
+      - '.github/workflows/capacitor-mobile.yml'
   pull_request:
     paths:
       - 'plant-swipe/android/**'
@@ -342,3 +355,65 @@ jobs:
           path: plant-swipe/ios-simulator-App.zip
           if-no-files-found: error
           retention-days: 14
+
+  create-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: [android-debug, android-release]
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get version from package.json
+        id: version
+        run: |
+          VERSION=$(node -p "require('./plant-swipe/package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Download debug APK
+        uses: actions/download-artifact@v4
+        with:
+          name: android-debug-apk
+          path: artifacts/debug
+
+      - name: Download release APK
+        uses: actions/download-artifact@v4
+        with:
+          name: android-release-apk
+          path: artifacts/release
+
+      - name: Rename APKs with version
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          for apk in artifacts/debug/*.apk; do
+            mv "$apk" "artifacts/PlantSwipe-v${VERSION}-debug.apk"
+          done
+          for apk in artifacts/release/*.apk; do
+            mv "$apk" "artifacts/PlantSwipe-v${VERSION}-release.apk"
+          done
+
+      - name: Create or update GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: PlantSwipe ${{ steps.version.outputs.tag }}
+          body: |
+            ## PlantSwipe ${{ steps.version.outputs.tag }}
+
+            **Automated release from CI build #${{ github.run_number }}**
+
+            ### Downloads
+            - **Release APK** — signed build for testing/distribution
+            - **Debug APK** — debug build with developer tools enabled
+
+            ### Commit
+            ${{ github.sha }}
+          draft: false
+          prerelease: false
+          generate_release_notes: true
+          files: |
+            artifacts/PlantSwipe-*.apk
+          make_latest: true


### PR DESCRIPTION
## Summary
This PR adds automated GitHub release creation to the Capacitor mobile CI/CD workflow. When changes are pushed to the main branch that affect mobile-related files, the workflow now automatically creates a GitHub release with versioned APK artifacts.

## Key Changes
- **Workflow trigger expansion**: Added `push` event trigger to the workflow that runs on changes to main branch affecting:
  - Android and iOS native directories
  - Capacitor configuration files
  - Package dependencies and version files
  - CI helper scripts
  - The workflow file itself

- **New `create-release` job**: Implements automated release creation with the following steps:
  - Extracts version from `package.json`
  - Downloads debug and release APK artifacts from previous build jobs
  - Renames APKs with semantic versioning (e.g., `PlantSwipe-v1.0.0-debug.apk`)
  - Creates a GitHub release with:
    - Version-based tag (e.g., `v1.0.0`)
    - Auto-generated release notes
    - Both debug and release APK artifacts
    - Build metadata (CI run number and commit SHA)
  - Marks release as latest

## Implementation Details
- The job depends on successful completion of both `android-debug` and `android-release` jobs
- Only runs on pushes to main branch (not on pull requests)
- Uses `softprops/action-gh-release@v2` for reliable release management
- Requires `contents: write` permission for creating releases
- APK artifacts are automatically attached to the release for easy distribution

https://claude.ai/code/session_01UQAK9mZ1GTtgmrPJ97YT49