### PR TITLE
Fix native app API origin routing

### DIFF
--- a/plant-swipe/README.md
+++ b/plant-swipe/README.md
@@ -267,6 +267,7 @@ VITE_SUPABASE_ANON_KEY=your-anon-key
 # App Configuration (optional)
 VITE_APP_BASE_PATH=/               # Base path for sub-path deployments
 VITE_SITE_URL=https://aphylia.app  # Canonical site URL
+VITE_API_ORIGIN=https://aphylia.app # Absolute HTTPS API origin for bundled native builds
 
 # PWA Configuration (optional)
 VITE_ENABLE_PWA=false              # Enable PWA in development

--- a/plant-swipe/docs/MOBILE_ARCHITECTURE.md
+++ b/plant-swipe/docs/MOBILE_ARCHITECTURE.md
@@ -66,7 +66,7 @@ Environment variables commonly used:
 
 - **`VITE_APP_NATIVE_BUILD=1`** — set by `build:web:native` / Capacitor pipeline; disables vite-plugin-pwa for the native bundle.
 - **`NATIVE_BUILD_NUMBER`** — integer passed to `sync-native-version.mjs` for Android `versionCode` / iOS `CFBundleVersion` (e.g. CI run number).
-- **`VITE_SUPABASE_URL`**, **`VITE_APP_UNIVERSAL_LINK_ORIGIN`**, **`CAP_ALLOW_NAVIGATION_HOSTS`** — supply at **`cap sync`** time so `sync-native-version.mjs` can set `server.allowNavigation` (not read from `.env` in that script).
+- **`VITE_API_ORIGIN`**, **`VITE_SUPABASE_URL`**, **`VITE_APP_UNIVERSAL_LINK_ORIGIN`**, **`CAP_ALLOW_NAVIGATION_HOSTS`** — supply at **native build / `cap sync`** time. `VITE_API_ORIGIN` tells the bundled WebView where `/api/*` should resolve in store builds; `sync-native-version.mjs` uses the host-based vars to set `server.allowNavigation`.
 
 ## Related docs
 

--- a/plant-swipe/index.html
+++ b/plant-swipe/index.html
@@ -118,6 +118,13 @@
         });
       </script>
       <script>
+        window.__APHYLIA_HTML_ENV__ = {
+          nativeBuild: "%VITE_APP_NATIVE_BUILD%",
+          apiOrigin: "%VITE_API_ORIGIN%",
+          siteUrl: "%VITE_SITE_URL%"
+        };
+      </script>
+      <script>
         (function() {
           try {
             var savedTheme = localStorage.getItem('plantswipe.theme') || 'system';

--- a/plant-swipe/public/env-loader.js
+++ b/plant-swipe/public/env-loader.js
@@ -10,6 +10,25 @@
     if (typeof window !== 'object') return
     if (window.__ENV__ && typeof window.__ENV__ === 'object') return
 
+    function normalizeOrigin(raw) {
+      if (typeof raw !== 'string') return null
+      var trimmed = raw.trim()
+      if (!trimmed || /^%[A-Z0-9_]+%$/i.test(trimmed)) return null
+      try {
+        return new URL(trimmed).origin
+      } catch (_) {
+        return null
+      }
+    }
+
+    function isNativeStoreBuild() {
+      var htmlEnv = window.__APHYLIA_HTML_ENV__ || {}
+      var raw = htmlEnv.nativeBuild
+      if (typeof raw !== 'string') return false
+      var normalized = raw.trim().toLowerCase()
+      return normalized === '1' || normalized === 'true' || normalized === 'yes'
+    }
+
     function normalizeBase(path) {
       if (typeof path !== 'string' || !path.length) return '/'
       if (!path.startsWith('/')) path = '/' + path
@@ -42,6 +61,15 @@
     }
 
     var candidates = []
+    var nativeApiOrigin = isNativeStoreBuild()
+      ? normalizeOrigin(
+          (window.__ENV__ && window.__ENV__.VITE_API_ORIGIN) ||
+          (window.__APHYLIA_HTML_ENV__ && window.__APHYLIA_HTML_ENV__.apiOrigin) ||
+          (window.__ENV__ && window.__ENV__.VITE_SITE_URL) ||
+          (window.__APHYLIA_HTML_ENV__ && window.__APHYLIA_HTML_ENV__.siteUrl) ||
+          'https://aphylia.app'
+        )
+      : null
     function pushCandidate(url) {
       if (!url) return
       if (candidates.indexOf(url) === -1) {
@@ -49,6 +77,10 @@
       }
     }
 
+    if (nativeApiOrigin) {
+      pushCandidate(new URL(join(basePath, 'api/env.js'), nativeApiOrigin).toString())
+      pushCandidate(new URL('/api/env.js', nativeApiOrigin).toString())
+    }
     pushCandidate(join(basePath, 'api/env.js'))
     pushCandidate('/api/env.js')
     pushCandidate(join(basePath, 'env.js'))

--- a/plant-swipe/server.js
+++ b/plant-swipe/server.js
@@ -4023,15 +4023,28 @@ function requireCsrfToken(req, res, next) {
   next()
 }
 
+function isTrustedNativeAppOrigin(origin) {
+  if (!origin || typeof origin !== 'string') return false
+  const normalized = origin.trim().toLowerCase()
+  return (
+    normalized === 'capacitor://localhost' ||
+    normalized === 'ionic://localhost' ||
+    normalized === 'http://localhost' ||
+    normalized === 'https://localhost'
+  )
+}
+
 // Global CORS and preflight handling for API routes
 app.use((req, res, next) => {
   try {
     const origin = req.headers.origin
     // Allow all origins by default; optionally restrict via CORS_ALLOW_ORIGINS
     const allowList = (process.env.CORS_ALLOW_ORIGINS || '').split(',').map(s => s.trim()).filter(Boolean)
+    const allowCredentials = !!origin && (allowList.length > 0 || isTrustedNativeAppOrigin(origin))
     if (origin) {
-      if (allowList.length === 0 || allowList.includes(origin)) {
-        res.setHeader('Access-Control-Allow-Origin', allowList.length ? origin : '*')
+      if (allowList.length === 0 || allowList.includes(origin) || isTrustedNativeAppOrigin(origin)) {
+        const allowSpecificOrigin = allowList.length > 0 || isTrustedNativeAppOrigin(origin)
+        res.setHeader('Access-Control-Allow-Origin', allowSpecificOrigin ? origin : '*')
         res.setHeader('Vary', 'Origin')
       }
     } else {
@@ -4041,6 +4054,9 @@ app.use((req, res, next) => {
       res.setHeader('Access-Control-Allow-Methods', 'GET,POST,PUT,DELETE,OPTIONS')
       res.setHeader('Access-Control-Allow-Headers', 'Authorization, Content-Type, X-Admin-Token, X-CSRF-Token')
       res.setHeader('Access-Control-Expose-Headers', 'X-CSRF-Token')
+      if (allowCredentials) {
+        res.setHeader('Access-Control-Allow-Credentials', 'true')
+      }
       if (req.method === 'OPTIONS') {
         res.status(204).end()
         return
@@ -5977,6 +5993,8 @@ app.get(['/api/env.js', '/env.js'], (req, res) => {
     const env = {
       VITE_SUPABASE_URL: process.env.VITE_SUPABASE_URL || process.env.REACT_APP_SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL || '',
       VITE_SUPABASE_ANON_KEY: process.env.VITE_SUPABASE_ANON_KEY || process.env.REACT_APP_SUPABASE_ANON_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY || '',
+      VITE_API_ORIGIN: process.env.VITE_API_ORIGIN || process.env.VITE_SITE_URL || process.env.WEBSITE_URL || 'https://aphylia.app',
+      VITE_SITE_URL: process.env.VITE_SITE_URL || process.env.WEBSITE_URL || 'https://aphylia.app',
       VITE_ADMIN_STATIC_TOKEN: process.env.VITE_ADMIN_STATIC_TOKEN || process.env.ADMIN_STATIC_TOKEN || '',
       VITE_ADMIN_PUBLIC_MODE: String(process.env.VITE_ADMIN_PUBLIC_MODE || process.env.ADMIN_PUBLIC_MODE || '').toLowerCase() === 'true',
       VITE_DISABLE_PWA: disablePwaEnv,

--- a/plant-swipe/src/lib/nativeApiOrigin.ts
+++ b/plant-swipe/src/lib/nativeApiOrigin.ts
@@ -1,0 +1,101 @@
+const DEFAULT_NATIVE_API_ORIGIN = 'https://aphylia.app'
+const HTML_PLACEHOLDER_RE = /^%[A-Z0-9_]+%$/i
+
+type HtmlBootstrapEnv = {
+  nativeBuild?: unknown
+  apiOrigin?: unknown
+  siteUrl?: unknown
+}
+
+type RuntimeWindow = Window & {
+  __ENV__?: Record<string, unknown>
+  __APHYLIA_HTML_ENV__?: HtmlBootstrapEnv
+}
+
+function getRuntimeWindow(): RuntimeWindow | null {
+  if (typeof window === 'undefined') return null
+  return window as RuntimeWindow
+}
+
+export function normalizeConfiguredOrigin(raw: unknown): string | null {
+  if (typeof raw !== 'string') return null
+  const trimmed = raw.trim()
+  if (!trimmed || HTML_PLACEHOLDER_RE.test(trimmed)) return null
+  try {
+    return new URL(trimmed).origin
+  } catch {
+    return null
+  }
+}
+
+function readConfiguredOrigins(): Array<string | null> {
+  const runtimeWindow = getRuntimeWindow()
+  return [
+    normalizeConfiguredOrigin(import.meta.env.VITE_API_ORIGIN),
+    normalizeConfiguredOrigin(import.meta.env.VITE_SITE_URL),
+    normalizeConfiguredOrigin(runtimeWindow?.__ENV__?.VITE_API_ORIGIN),
+    normalizeConfiguredOrigin(runtimeWindow?.__ENV__?.VITE_SITE_URL),
+    normalizeConfiguredOrigin(runtimeWindow?.__APHYLIA_HTML_ENV__?.apiOrigin),
+    normalizeConfiguredOrigin(runtimeWindow?.__APHYLIA_HTML_ENV__?.siteUrl),
+  ]
+}
+
+export function isNativeStoreBuild(): boolean {
+  if (import.meta.env.VITE_APP_NATIVE_BUILD === '1') return true
+  const runtimeWindow = getRuntimeWindow()
+  const raw = runtimeWindow?.__APHYLIA_HTML_ENV__?.nativeBuild
+  if (typeof raw !== 'string') return false
+  const normalized = raw.trim().toLowerCase()
+  return normalized === '1' || normalized === 'true' || normalized === 'yes'
+}
+
+export function getNativeApiOrigin(): string | null {
+  if (!isNativeStoreBuild()) return null
+  for (const candidate of readConfiguredOrigins()) {
+    if (candidate) return candidate
+  }
+  return DEFAULT_NATIVE_API_ORIGIN
+}
+
+export function buildAbsoluteUrl(origin: string, path: string): string {
+  return new URL(path, origin).toString()
+}
+
+export function isApiOriginUrl(rawUrl: string | URL, apiOrigin: string): boolean {
+  const normalizedApiOrigin = normalizeConfiguredOrigin(apiOrigin)
+  if (!normalizedApiOrigin) return false
+  try {
+    const parsed = rawUrl instanceof URL ? rawUrl : new URL(String(rawUrl))
+    return parsed.origin === normalizedApiOrigin
+  } catch {
+    return false
+  }
+}
+
+function isLocalApiPath(pathname: string): boolean {
+  return pathname === '/api' || pathname.startsWith('/api/')
+}
+
+export function rewriteLocalApiUrl(rawUrl: string, apiOrigin: string, currentOrigin?: string): string {
+  const normalizedApiOrigin = normalizeConfiguredOrigin(apiOrigin)
+  if (!normalizedApiOrigin || typeof rawUrl !== 'string' || !rawUrl) return rawUrl
+
+  if (rawUrl === '/api' || rawUrl.startsWith('/api/') || rawUrl.startsWith('/api?')) {
+    return buildAbsoluteUrl(normalizedApiOrigin, rawUrl)
+  }
+
+  const normalizedCurrentOrigin = normalizeConfiguredOrigin(currentOrigin)
+  if (!normalizedCurrentOrigin) return rawUrl
+
+  try {
+    const parsed = new URL(rawUrl, normalizedCurrentOrigin)
+    if (parsed.origin !== normalizedCurrentOrigin || !isLocalApiPath(parsed.pathname)) {
+      return rawUrl
+    }
+    return buildAbsoluteUrl(normalizedApiOrigin, `${parsed.pathname}${parsed.search}${parsed.hash}`)
+  } catch {
+    return rawUrl
+  }
+}
+
+export { DEFAULT_NATIVE_API_ORIGIN }

--- a/plant-swipe/src/lib/nativeNetworkBridge.ts
+++ b/plant-swipe/src/lib/nativeNetworkBridge.ts
@@ -1,0 +1,84 @@
+import { buildAbsoluteUrl, getNativeApiOrigin, isApiOriginUrl, rewriteLocalApiUrl } from '@/lib/nativeApiOrigin'
+
+type FetchLike = typeof fetch
+
+type NativeWindow = Window & typeof globalThis & {
+  __aphyliaNativeFetchPatched__?: boolean
+  __aphyliaNativeEventSourcePatched__?: boolean
+}
+
+function getRuntimeWindow(): NativeWindow | null {
+  if (typeof window === 'undefined') return null
+  return window as NativeWindow
+}
+
+function currentOrigin(): string | undefined {
+  if (typeof window === 'undefined') return undefined
+  return window.location.origin
+}
+
+function shouldSendCredentials(apiOrigin: string): boolean {
+  if (typeof window === 'undefined') return false
+  return isApiOriginUrl(window.location.origin, apiOrigin)
+}
+
+function normalizeFetchInit(url: string, init: RequestInit | undefined, apiOrigin: string): RequestInit | undefined {
+  if (!init) {
+    return shouldSendCredentials(apiOrigin) ? init : { credentials: 'omit' }
+  }
+  if (init.credentials !== undefined || shouldSendCredentials(apiOrigin) || !url.startsWith(apiOrigin)) {
+    return init
+  }
+  return { ...init, credentials: 'omit' }
+}
+
+export function patchNativeFetch(): void {
+  const runtimeWindow = getRuntimeWindow()
+  const apiOrigin = getNativeApiOrigin()
+  if (!runtimeWindow || !apiOrigin || runtimeWindow.__aphyliaNativeFetchPatched__) return
+  const originalFetch = runtimeWindow.fetch.bind(runtimeWindow) as FetchLike
+
+  runtimeWindow.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    if (typeof input === 'string') {
+      const rewritten = rewriteLocalApiUrl(input, apiOrigin, currentOrigin())
+      return originalFetch(rewritten, normalizeFetchInit(rewritten, init, apiOrigin))
+    }
+
+    if (input instanceof URL) {
+      const rewritten = rewriteLocalApiUrl(input.toString(), apiOrigin, currentOrigin())
+      return originalFetch(rewritten, normalizeFetchInit(rewritten, init, apiOrigin))
+    }
+
+    return originalFetch(input, init)
+  }) as typeof fetch
+
+  runtimeWindow.__aphyliaNativeFetchPatched__ = true
+}
+
+export function patchNativeEventSource(): void {
+  const runtimeWindow = getRuntimeWindow()
+  const apiOrigin = getNativeApiOrigin()
+  if (!runtimeWindow || !apiOrigin || runtimeWindow.__aphyliaNativeEventSourcePatched__) return
+  const resolvedApiOrigin = apiOrigin
+  const NativeEventSource = runtimeWindow.EventSource
+  if (typeof NativeEventSource !== 'function') return
+
+  runtimeWindow.EventSource = class NativeApiEventSource extends NativeEventSource {
+    constructor(url: string | URL, eventSourceInitDict?: EventSourceInit) {
+      const rawUrl = url instanceof URL ? url.toString() : String(url)
+      const rewritten = rewriteLocalApiUrl(rawUrl, resolvedApiOrigin, currentOrigin())
+      const normalizedInit =
+        eventSourceInitDict?.withCredentials && !shouldSendCredentials(resolvedApiOrigin)
+          ? { ...eventSourceInitDict, withCredentials: false }
+          : eventSourceInitDict
+      super(rewritten || buildAbsoluteUrl(resolvedApiOrigin, '/api'), normalizedInit)
+    }
+  } as typeof EventSource
+
+  runtimeWindow.__aphyliaNativeEventSourcePatched__ = true
+}
+
+export function installNativeNetworkBridge(): void {
+  patchNativeFetch()
+  patchNativeEventSource()
+}

--- a/plant-swipe/src/lib/runtimeEnvLoader.ts
+++ b/plant-swipe/src/lib/runtimeEnvLoader.ts
@@ -1,6 +1,11 @@
 type RuntimeEnvWindow = Window & {
   __ENV__?: Record<string, unknown>
   __plantswipeEnvBootstrap__?: boolean
+  __APHYLIA_HTML_ENV__?: {
+    nativeBuild?: unknown
+    apiOrigin?: unknown
+    siteUrl?: unknown
+  }
 }
 
 const CACHE_KEY = 'plantswipe.env.inline'
@@ -14,6 +19,26 @@ const normalizeBase = (value?: string) => {
   if (!next.startsWith('/')) next = `/${next}`
   if (!next.endsWith('/')) next = `${next}/`
   return next.replace(/\/{2,}/g, '/')
+}
+
+const normalizeOrigin = (value?: string | null) => {
+  if (!value) return null
+  const trimmed = value.trim()
+  if (!trimmed || /^%[A-Z0-9_]+%$/i.test(trimmed)) return null
+  try {
+    return new URL(trimmed).origin
+  } catch {
+    return null
+  }
+}
+
+const isNativeStoreBuild = () => {
+  if (import.meta.env.VITE_APP_NATIVE_BUILD === '1') return true
+  if (!hasWindow) return false
+  const raw = (window as RuntimeEnvWindow).__APHYLIA_HTML_ENV__?.nativeBuild
+  if (typeof raw !== 'string') return false
+  const normalized = raw.trim().toLowerCase()
+  return normalized === '1' || normalized === 'true' || normalized === 'yes'
 }
 
 const resolveBasePath = () => {
@@ -39,9 +64,28 @@ const joinPath = (base: string, resource: string) => {
   return `${cleanBase}${cleanResource}`.replace(/\/{2,}/g, '/')
 }
 
+const nativeApiOrigin =
+  hasWindow && isNativeStoreBuild()
+    ? normalizeOrigin(
+        (window as RuntimeEnvWindow).__ENV__?.VITE_API_ORIGIN as string | undefined ||
+          ((window as RuntimeEnvWindow).__APHYLIA_HTML_ENV__?.apiOrigin as string | undefined) ||
+          ((window as RuntimeEnvWindow).__ENV__?.VITE_SITE_URL as string | undefined) ||
+          ((window as RuntimeEnvWindow).__APHYLIA_HTML_ENV__?.siteUrl as string | undefined) ||
+          (import.meta.env.VITE_API_ORIGIN as string | undefined) ||
+          (import.meta.env.VITE_SITE_URL as string | undefined) ||
+          'https://aphylia.app'
+      )
+    : null
+
 const candidateUrls = hasWindow
   ? Array.from(
       new Set([
+        ...(nativeApiOrigin
+          ? [
+              new URL(joinPath(basePath, 'api/env.js'), nativeApiOrigin).toString(),
+              new URL('/api/env.js', nativeApiOrigin).toString(),
+            ]
+          : []),
         joinPath(basePath, 'api/env.js'),
         '/api/env.js',
         joinPath(basePath, 'env.js'),

--- a/plant-swipe/src/main.tsx
+++ b/plant-swipe/src/main.tsx
@@ -4,6 +4,7 @@ import { initSentry } from '@/lib/sentry'
 initSentry()
 
 import '@/lib/runtimeEnvLoader'
+import { installNativeNetworkBridge } from '@/lib/nativeNetworkBridge'
 import { patchGoogleTranslateConflict } from '@/lib/googleTranslateFix'
 import './lib/i18n' // Initialize i18n before App
 import './index.scss'
@@ -14,6 +15,7 @@ import { Capacitor } from '@capacitor/core'
 // Apply Google Translate DOM conflict fix before React renders
 // This prevents crashes when users use browser translation extensions
 patchGoogleTranslateConflict()
+installNativeNetworkBridge()
 
 type WindowControlsOverlay = {
   visible?: boolean

--- a/plant-swipe/src/vite-env.d.ts
+++ b/plant-swipe/src/vite-env.d.ts
@@ -5,6 +5,10 @@ interface ImportMetaEnv {
   readonly VITE_DISABLE_PWA?: string
   /** Set to "1" for Capacitor store builds (no service worker in bundle). */
   readonly VITE_APP_NATIVE_BUILD?: string
+  /** Absolute HTTPS API origin used by bundled native builds for `/api/*` requests. */
+  readonly VITE_API_ORIGIN?: string
+  /** Canonical public site URL. */
+  readonly VITE_SITE_URL?: string
 }
 
 interface ImportMeta {

--- a/plant-swipe/vite.config.ts
+++ b/plant-swipe/vite.config.ts
@@ -54,6 +54,7 @@ const isPwaDisabled = disablePwaFlag === 'true' || disablePwaFlag === '1' || dis
 const nativeCapacitorWebBuildFlag = String(process.env.VITE_APP_NATIVE_BUILD || '').trim().toLowerCase()
 const isNativeCapacitorWebBuild =
   nativeCapacitorWebBuildFlag === 'true' || nativeCapacitorWebBuildFlag === '1' || nativeCapacitorWebBuildFlag === 'yes'
+const configuredApiOrigin = String(process.env.VITE_API_ORIGIN || process.env.VITE_SITE_URL || 'https://aphylia.app').trim()
 
 export default defineConfig({
   base: appBase,
@@ -63,6 +64,8 @@ export default defineConfig({
     'import.meta.env.VITE_COMMIT_SHA': JSON.stringify(getGitCommitSha()),
     // "1" when built via build:web:native / build:cap — client skips SW maintenance and enables native recovery UX
     'import.meta.env.VITE_APP_NATIVE_BUILD': JSON.stringify(isNativeCapacitorWebBuild ? '1' : ''),
+    'import.meta.env.VITE_API_ORIGIN': JSON.stringify(configuredApiOrigin),
+    'import.meta.env.VITE_SITE_URL': JSON.stringify(String(process.env.VITE_SITE_URL || 'https://aphylia.app').trim()),
   },
   plugins: [
     react(),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a native-only API origin bridge so Capacitor store builds rewrite local `/api/*` requests to the configured HTTPS backend instead of the WebView localhost origin
- update the runtime env bootstrap and bundled `index.html` bootstrap values so native builds know their API origin before React mounts
- allow trusted Capacitor localhost-style origins through Express CORS (including credentialed preflight) and expose `VITE_API_ORIGIN` from `/api/env.js`

## Testing
- ✅ `bun run build:web:native`
- ⚠️ `bun run lint -- src/main.tsx src/lib/nativeApiOrigin.ts src/lib/nativeNetworkBridge.ts src/lib/runtimeEnvLoader.ts` (repo has pre-existing lint errors in unrelated files like `GardenDashboardPage.tsx`, `GardenListPage.tsx`, `PlantInfoPage.tsx`)
- ✅ `VITE_APP_NATIVE_BUILD=1 VITE_API_ORIGIN=https://aphylia.app bun -e "...nativeApiOrigin smoke test..."`
- ✅ `VITE_APP_NATIVE_BUILD=1 VITE_API_ORIGIN=https://aphylia.app bun -e "...nativeNetworkBridge smoke test..."`

## Notes
- native store bundles now embed `apiOrigin: "https://aphylia.app"` in `dist/index.html` during `build:web:native`
- release builds can override the backend by setting `VITE_API_ORIGIN` during `build:web:native` / `build:cap` if needed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2fb6ff24-1ced-4703-b743-c12420cf472e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2fb6ff24-1ced-4703-b743-c12420cf472e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

