### PR TITLE
gdpr: weekly compliance audit — 2026-04-15

### DIFF
--- a/plant-swipe/docs/gdpr-audit/2026-04-15.md
+++ b/plant-swipe/docs/gdpr-audit/2026-04-15.md
@@ -1,0 +1,180 @@
+# GDPR Compliance Audit — 2026-04-15
+
+**PRs reviewed:** 16
+**Commits reviewed:** 22
+**New data surfaces found:** 1
+
+---
+
+## PRs Reviewed
+
+| PR | Title | Merged | GDPR Relevant |
+|----|-------|--------|---------------|
+| #1389 | Fix mobile tap targets in TodaysTasksWidget | Apr 8 | No |
+| #1390 | Accessibility: interactive elements in profile sections | Apr 8 | No |
+| #1391 | Expand GDPR deletion to cover additional user data tables | Apr 8 | Yes (improvement) |
+| #1388 | Clean and prevent bad plant relation data from legacy AI fills | Apr 8 | No |
+| #1332 | PWA / Capacitor native compatibility | Apr 9 | **Yes** |
+| #1392 | Enhance bookmark header with owner info and metadata cards | Apr 9 | No |
+| #1393 | Combine multiple aggregations in GardenAnalyticsSection | Apr 14 | No |
+| #1395 | Improve keyboard accessibility and button semantics | Apr 14 | No |
+| #1396 | docs: weekly documentation sync | Apr 14 | No |
+| #1397 | Add missing ARIA labels to Admin Panel icon buttons | Apr 14 | No |
+| #1398 | Combine multiple status count aggregations into a single loop | Apr 14 | No |
+| #1399 | fix(mobile): make bookmark plant cards usable on touch devices | Apr 14 | No |
+| #1400 | Fix streaks and advice showing for gardens with no plants/tasks | Apr 14 | No |
+| #1401 | Refactor platform detection in CI workflow | Apr 14 | No |
+| #1402 | Upgrade Java to 21 and improve iOS build caching | Apr 14 | No |
+| #1403 | Add automatic GitHub release creation on main branch push | Apr 14 | No |
+
+---
+
+## New Data Surfaces
+
+### `user_fcm_tokens` (PR #1332)
+
+- **What data is stored:** `id` (uuid), `user_id` (uuid), `token` (text — FCM/APNs device push token), `platform` (text — e.g. "android", "ios"), `created_at`, `updated_at`
+- **Where it is stored:** PostgreSQL table `public.user_fcm_tokens`
+- **Which user it belongs to:** Linked via `user_id` FK to `auth.users(id)`
+- **Contains PII:** Yes — device push tokens are device identifiers tied to a specific user
+- **Introduced by:** PR #1332 (PWA / Capacitor native compatibility), merged Apr 9
+- **Table definition:** `plant-swipe/server.js:7067`, `plant-swipe/supabase/sync_parts/11_notifications_and_tasks.sql:319`
+- **FK constraint:** `user_id uuid not null references auth.users(id) on delete cascade`
+
+---
+
+## Export Coverage
+
+### Covered
+
+- `garden_roadmap_completions` (PR #1391 expanded deletion; already in export) — included in export handler
+- `user_badges` (PR #1391 expanded deletion; already in export) — included in export handler
+- `event_registrations` (PR #1391 expanded deletion; already in export) — included in export handler
+- `event_user_progress` (PR #1391 expanded deletion; already in export) — included in export handler
+- `user_action_status` (PR #1391 expanded deletion; already in export) — included in export handler
+- `garden_user_activity` (PR #1391 expanded deletion; already in export) — included in export handler
+- `garden_task_user_completions` (PR #1391 expanded deletion; already in export) — included in export handler
+- `requested_plants` (PR #1391 expanded deletion; already in export) — included in export handler
+- `bug_action_responses` (PR #1391 expanded deletion; already in export) — included in export handler
+- `bug_points_history` (PR #1391 expanded deletion; already in export) — included in export handler
+- `profiles.tutorial_completed` (PR #1332 added column) — profile is fully exported (`SELECT *`)
+
+### Export Gaps
+
+- **`user_fcm_tokens`** (added in PR #1332) — **NOT found in export handler**
+  - The GDPR data export endpoint (`GET /api/account/export`, `server.js:18675`) does not query `user_fcm_tokens`
+  - Fix: Add a parallel query for `user_fcm_tokens` by `user_id` in the export handler and include results in the export payload as `fcmTokens`
+  - Suggested code location: `server.js:~19145` (add as item 27 in the `Promise.allSettled` parallel block)
+  - Suggested query:
+    ```js
+    // 27. FCM tokens (native push)
+    (async () => {
+      if (sql) {
+        return await sql`SELECT token, platform, created_at, updated_at FROM public.user_fcm_tokens WHERE user_id = ${userId}`
+      } else {
+        const { data } = await supabaseServiceClient
+          .from('user_fcm_tokens').select('token, platform, created_at, updated_at')
+          .eq('user_id', userId)
+        return data || []
+      }
+    })(),
+    ```
+  - Also update `gdprKeys` and `gdprLabels` arrays to include `'fcmTokens'` and `'FCM tokens'`
+  - Also add `fcmTokens: []` to the initial `exportData` object at `server.js:18688`
+
+---
+
+## Deletion Coverage
+
+### Covered
+
+All 10 tables added by PR #1391 are now explicitly deleted in the GDPR deletion handler (`POST /api/account/delete-gdpr`):
+- `garden_roadmap_completions` (step 14c, line 18412)
+- `user_badges` (step 14d, line 18422)
+- `event_registrations` (step 14e, line 18433)
+- `event_user_progress` (step 14f, line 18444)
+- `user_action_status` (step 14g, line 18455)
+- `garden_user_activity` (step 14h, line 18466)
+- `garden_task_user_completions` (step 14i, line 18477)
+- `requested_plants` (step 14j, line 18488)
+- `bug_action_responses` (step 14k, line 18499)
+- `bug_points_history` (step 14l, line 18510)
+
+### Deletion Gaps
+
+- **`user_fcm_tokens`** (added in PR #1332) — **NOT explicitly deleted in GDPR handler**
+  - **Mitigating factor:** The table FK is defined as `user_id uuid not null references auth.users(id) on delete cascade`. When the auth user is deleted at step 18 (`server.js:18643`), PostgreSQL cascade-deletes the FCM tokens automatically.
+  - **Risk:** If auth user deletion fails (which the handler catches at line 18647), FCM tokens remain in the database with no subsequent cleanup path. The handler returns a 500 error and logs a partial deletion, but does not retry or clean up `user_fcm_tokens`.
+  - **Recommendation:** Add explicit deletion of `user_fcm_tokens` before auth user deletion for defense-in-depth, consistent with how `user_push_subscriptions` (the web push equivalent) is explicitly deleted at step 5 (line 18221).
+  - Fix location: `server.js:~18519` (add after step 14l, before step 15)
+  - Suggested code:
+    ```js
+    try {
+      // 14m. Delete FCM tokens (native push)
+      if (sql) {
+        const result = await sql`DELETE FROM public.user_fcm_tokens WHERE user_id = ${userId}`
+        stats.fcmTokensDeleted = result?.count || 0
+      } else {
+        const { count } = await supabaseServiceClient.from('user_fcm_tokens').delete().eq('user_id', userId)
+        stats.fcmTokensDeleted = count || 0
+      }
+    } catch (err) { console.warn('[gdpr] FCM tokens deletion partial:', err?.message) }
+    ```
+  - Also add `fcmTokensDeleted: 0` to the `stats` object at `server.js:18143`
+
+---
+
+## Third-Party Services
+
+### FCM — Firebase Cloud Messaging (PR #1332)
+
+- **Data sent:** Device push tokens (platform-specific identifiers)
+- **Purpose:** Deliver push notifications to native Android/iOS apps
+- **Server key env var:** `FCM_LEGACY_SERVER_KEY`
+- **PII stored by Google:** FCM tokens are opaque identifiers; Google maps them to device installations internally
+- **Deletion API:** Firebase Admin SDK provides `admin.messaging().unsubscribeFromTopic()` and token invalidation, but FCM tokens are inherently transient — they become invalid when the app is uninstalled or the user clears app data
+- **Current state:** No explicit FCM token invalidation API call during account deletion. Tokens are deleted from the local database (via cascade), but Google's FCM server still holds the token-to-device mapping until it expires naturally.
+- **Flagged for human review:** Confirm whether Google's FCM DPA covers automatic token expiry as sufficient for GDPR erasure, or whether explicit server-side token invalidation via Firebase Admin SDK is required
+
+### APNs — Apple Push Notification service (PR #1332)
+
+- **Data sent:** Device push tokens (via APNs HTTP/2 API)
+- **Configuration env vars:** `APNS_KEY_ID`, `APNS_TEAM_ID`, `APNS_KEY_P8`, `APNS_BUNDLE_ID`, `APNS_USE_SANDBOX`
+- **PII stored by Apple:** APNs device tokens are opaque; Apple maps them to device installations
+- **Deletion API:** Apple does not provide a "delete token" API. Tokens become invalid when the app is uninstalled.
+- **Current state:** No explicit APNs token invalidation during account deletion. Local tokens are cascade-deleted.
+- **Flagged for human review:** Confirm DPA obligations with Apple regarding push token data retention after user account deletion
+
+---
+
+## Flagged for Human Review
+
+1. **FCM integration (PR #1332)** — Requires manual review of Google Firebase DPA to confirm whether cascade-deleting local tokens is sufficient for GDPR compliance, or whether explicit server-side token de-registration is needed via Firebase Admin SDK
+2. **APNs integration (PR #1332)** — Requires manual review of Apple's push notification DPA to confirm token lifecycle obligations after account deletion
+3. **`user_fcm_tokens` in export** — Missing from data export; straightforward code fix needed (see Export Gaps section above)
+4. **`user_fcm_tokens` in deletion** — Covered by FK cascade but not explicitly handled; defense-in-depth fix recommended (see Deletion Gaps section above)
+
+---
+
+## No Issues Found
+
+- `profiles.tutorial_completed` (PR #1332) — boolean column on `profiles` table; already covered by profile export (full `SELECT`) and profile deletion (step 15)
+- `seedling_tray_cells` — linked to `gardens` via `garden_id` with `ON DELETE CASCADE`; handled when gardens are deleted during account deletion (step 16)
+- All 10 tables from PR #1391 — explicitly added to both deletion and export handlers this week
+- `BookmarkOwner` interface (PR #1392) — read-only query joining existing `profiles` data; no new data storage
+- UI/accessibility PRs (#1389, #1390, #1393, #1395, #1397, #1398, #1399) — no data model changes
+- CI/build PRs (#1400, #1401, #1402, #1403) — no data model changes
+- Documentation PR (#1396) — no data model changes
+
+---
+
+## Summary
+
+This week's most significant change from a GDPR perspective is **PR #1332** (PWA / Capacitor native compatibility), which introduced the `user_fcm_tokens` table for native push notification support via FCM and APNs. This table stores device-specific push tokens linked to user accounts.
+
+**Action required:**
+1. Add `user_fcm_tokens` to the GDPR data export handler (`GET /api/account/export`)
+2. Add explicit `user_fcm_tokens` deletion to the GDPR deletion handler (`POST /api/account/delete-gdpr`) for defense-in-depth
+3. Human review needed for FCM and APNs DPA obligations regarding server-side token de-registration
+
+**Positive note:** PR #1391 significantly improved GDPR compliance this week by adding explicit deletion coverage for 10 previously uncovered user data tables.


### PR DESCRIPTION
## GDPR Weekly Audit — 2026-04-15

Auto-generated compliance review based on this week's merged PRs.

**PRs reviewed:** 16
**Commits reviewed:** 22
**New data surfaces found:** 1

---

### Export Coverage

- 10 tables added by PR #1391 are fully covered in the export handler
- `profiles.tutorial_completed` (PR #1332) covered via full profile export
- `seedling_tray_cells` — garden-level data, cascades with garden deletion

**Gap found:** `user_fcm_tokens` (PR #1332) is **NOT** included in the data export handler (`GET /api/account/export`). This table stores device push tokens (PII) linked to user accounts.

### Deletion Coverage

- All 10 tables from PR #1391 are now explicitly deleted in the GDPR deletion handler
- `seedling_tray_cells` — covered by `ON DELETE CASCADE` on `gardens`

**Gap found:** `user_fcm_tokens` (PR #1332) is **NOT explicitly** deleted in the GDPR handler. It is covered by `ON DELETE CASCADE` on `auth.users`, but this is inconsistent with how `user_push_subscriptions` (web push) is handled (explicit deletion at step 5). If auth user deletion fails, FCM tokens remain.

### Third-Party Services

- **FCM (Google Firebase Cloud Messaging)** — new in PR #1332. Device tokens sent to Google for push delivery. No server-side token invalidation API call during account deletion. **Flagged for human review:** confirm Google FCM DPA covers automatic token expiry as sufficient for GDPR erasure.
- **APNs (Apple Push Notification service)** — new in PR #1332. Device tokens sent to Apple for push delivery. No "delete token" API exists. **Flagged for human review:** confirm Apple DPA obligations for token data retention.

### Action Required

1. **Add `user_fcm_tokens` to GDPR data export** (`server.js:~19145`, add query #27 in `Promise.allSettled` block)
2. **Add explicit `user_fcm_tokens` deletion to GDPR handler** (`server.js:~18519`, add step 14m for defense-in-depth)
3. Update `stats` object and `exportData` initializer accordingly

### Flagged for Human Review

- FCM integration — manual DPA review needed before confirming erasure compliance
- APNs integration — manual DPA review needed for token lifecycle obligations
- Both are standard push notification services with transient token semantics, but formal DPA sign-off is required

### No Issues Found

- `profiles.tutorial_completed` (PR #1332) — already in export and deletion
- `seedling_tray_cells` — cascade-deleted with gardens
- All UI/accessibility PRs (#1389, #1390, #1393, #1395, #1397, #1398, #1399) — no data changes
- All CI/build PRs (#1400, #1401, #1402, #1403) — no data changes
- Documentation PR (#1396) — no data changes
- PR #1391 significantly improved compliance by covering 10 previously missing tables

---

Full audit report: `plant-swipe/docs/gdpr-audit/2026-04-15.md`

https://claude.ai/code/session_01XqysSAdtnrd8P8uddzXMAP