### PR TITLE
Add configurable API origin inputs to Capacitor mobile workflow

### DIFF
--- a/.github/workflows/capacitor-mobile.yml
+++ b/.github/workflows/capacitor-mobile.yml
@@ -9,6 +9,17 @@ name: Capacitor mobile
 
 on:
   workflow_dispatch:
+    inputs:
+      api_origin_debug:
+        description: 'API server for debug builds'
+        required: false
+        default: 'https://dev01.aphylia.app'
+        type: string
+      api_origin_release:
+        description: 'API server for release builds'
+        required: false
+        default: 'https://aphylia.app'
+        type: string
   push:
     branches:
       - main
@@ -159,6 +170,7 @@ jobs:
       - name: Build PWA + cap sync
         run: bun run build:cap
         env:
+          VITE_API_ORIGIN: ${{ inputs.api_origin_debug || 'https://dev01.aphylia.app' }}
           SKIP_SITEMAP_GENERATION: '1'
           NATIVE_BUILD_NUMBER: ${{ github.run_number }}
 
@@ -224,6 +236,7 @@ jobs:
       - name: Build PWA + cap sync
         run: bun run build:cap
         env:
+          VITE_API_ORIGIN: ${{ inputs.api_origin_release || 'https://aphylia.app' }}
           SKIP_SITEMAP_GENERATION: '1'
           NATIVE_BUILD_NUMBER: ${{ github.run_number }}
 
@@ -315,6 +328,7 @@ jobs:
       - name: Build PWA + cap sync
         run: bun run build:cap
         env:
+          VITE_API_ORIGIN: ${{ inputs.api_origin_debug || 'https://dev01.aphylia.app' }}
           SKIP_SITEMAP_GENERATION: '1'
           NATIVE_BUILD_NUMBER: ${{ github.run_number }}
 


### PR DESCRIPTION
## Summary
This PR adds workflow dispatch inputs to the Capacitor mobile CI/CD pipeline, allowing users to specify custom API server endpoints for debug and release builds when manually triggering the workflow.

## Key Changes
- Added `api_origin_debug` and `api_origin_release` workflow inputs with sensible defaults:
  - Debug builds default to `https://dev01.aphylia.app`
  - Release builds default to `https://aphylia.app`
- Updated the PWA build step in all three job variants (debug Android, release Android, and debug iOS) to pass the appropriate `VITE_API_ORIGIN` environment variable based on the build type
- Inputs are optional and fallback to defaults if not provided during manual workflow dispatch

## Implementation Details
- The workflow inputs are only available when using `workflow_dispatch` (manual trigger)
- Each build job uses the corresponding API origin input with a fallback to its default value
- The `VITE_API_ORIGIN` environment variable is injected during the `build:cap` step, allowing the Vite build process to use the correct API endpoint

https://claude.ai/code/session_01FiyoBaDkpxKbFBkyTe9PKK