### PR TITLE
Defer App import and add env-loading timeout for Capacitor

### DIFF
--- a/plant-swipe/public/env-loader.js
+++ b/plant-swipe/public/env-loader.js
@@ -104,10 +104,17 @@
       }
     }
 
+    var ENV_FETCH_TIMEOUT = 8000
+
     function loadFrom(url, onDone) {
       try {
-        fetch(url, { cache: 'no-store', credentials: 'same-origin' })
+        var controller = typeof AbortController === 'function' ? new AbortController() : null
+        var timeoutId = controller ? setTimeout(function () { controller.abort() }, ENV_FETCH_TIMEOUT) : null
+        var fetchOpts = { cache: 'no-store', credentials: 'same-origin' }
+        if (controller) fetchOpts.signal = controller.signal
+        fetch(url, fetchOpts)
           .then(function (res) {
+            if (timeoutId) clearTimeout(timeoutId)
             if (!res.ok) throw new Error('status ' + res.status)
             var ct = (res.headers.get('content-type') || '').toLowerCase()
             return res.text().then(function (txt) {
@@ -120,7 +127,7 @@
               }, 0)
             })
           })
-          .catch(function () { onDone(false) })
+          .catch(function () { if (timeoutId) clearTimeout(timeoutId); onDone(false) })
       } catch (e) { onDone(false) }
     }
 

--- a/plant-swipe/src/lib/runtimeEnvLoader.ts
+++ b/plant-swipe/src/lib/runtimeEnvLoader.ts
@@ -156,15 +156,27 @@ const ensureEnvObject = (target: RuntimeEnvWindow) => {
   }
 }
 
+const ENV_FETCH_TIMEOUT_MS = 8_000
+
 const fetchAndApply = async (url: string) => {
-  const response = await fetch(url, { cache: 'no-store', credentials: 'same-origin' })
-  if (!response.ok) throw new Error(`Bad status ${response.status}`)
-  const text = await response.text()
-  if (isProbablyHtml(text)) throw new Error('Unexpected HTML payload')
-  injectInlineScript(text, `runtime-env:${url}`)
-  persistCache(text)
-  dispatchReady({ source: url, cached: false })
-  return true
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), ENV_FETCH_TIMEOUT_MS)
+  try {
+    const response = await fetch(url, {
+      cache: 'no-store',
+      credentials: 'same-origin',
+      signal: controller.signal,
+    })
+    if (!response.ok) throw new Error(`Bad status ${response.status}`)
+    const text = await response.text()
+    if (isProbablyHtml(text)) throw new Error('Unexpected HTML payload')
+    injectInlineScript(text, `runtime-env:${url}`)
+    persistCache(text)
+    dispatchReady({ source: url, cached: false })
+    return true
+  } finally {
+    clearTimeout(timeoutId)
+  }
 }
 
 const hydrateRuntimeEnv = async () => {

--- a/plant-swipe/src/lib/supabaseClient.ts
+++ b/plant-swipe/src/lib/supabaseClient.ts
@@ -3,16 +3,20 @@ import { getEnvAny } from '@/lib/utils'
 import type { JSONContent } from '@tiptap/core'
 
 // Frontend should only consume public env vars. Accept common prefixes for portability.
+// Empty-string fallback prevents a hard crash in Capacitor native builds where env vars
+// are loaded asynchronously from the remote API and may not yet be available at module
+// init time.  The dynamic-import guard in main.tsx normally ensures vars are ready, but
+// this fallback acts as a safety net so the app can still render in guest/offline mode.
 const supabaseUrl = getEnvAny([
   'VITE_SUPABASE_URL',
   'REACT_APP_SUPABASE_URL',
   'NEXT_PUBLIC_SUPABASE_URL',
-])
+], '')
 const supabaseAnonKey = getEnvAny([
   'VITE_SUPABASE_ANON_KEY',
   'REACT_APP_SUPABASE_ANON_KEY',
   'NEXT_PUBLIC_SUPABASE_ANON_KEY',
-])
+], '')
 
 /** Only treat URL as Supabase auth callback (avoids false positives with other #fragments). */
 function isSupabaseAuthCallbackUrl(url: URL, params: Record<string, string>): boolean {

--- a/plant-swipe/src/main.tsx
+++ b/plant-swipe/src/main.tsx
@@ -8,7 +8,12 @@ import { installNativeNetworkBridge } from '@/lib/nativeNetworkBridge'
 import { patchGoogleTranslateConflict } from '@/lib/googleTranslateFix'
 import './lib/i18n' // Initialize i18n before App
 import './index.scss'
-import App from './App.tsx'
+// App is dynamically imported in bootstrap() below.
+// In Capacitor native builds, environment variables (Supabase credentials, etc.) are
+// loaded asynchronously from the remote API.  Static imports execute at module-init
+// time — before those async fetches complete — so supabaseClient.ts would crash with
+// "Missing environment variable".  Deferring the import gives the env-loader time to
+// finish, while the loading spinner in index.html keeps the user informed.
 import { initAccentFromStorage } from '@/lib/accent'
 import { Capacitor } from '@capacitor/core'
 
@@ -106,6 +111,61 @@ if (import.meta.env.PROD) {
   }
 }
 
-createRoot(document.getElementById('root')!).render(
-  <App />,
-)
+/**
+ * Wait for runtime environment variables to be available before mounting.
+ *
+ * In Capacitor native builds the JS bundle loads instantly from local assets,
+ * but critical env vars (Supabase URL/key) are fetched asynchronously from the
+ * remote API (`/api/env.js`).  Without waiting, module-level code in
+ * supabaseClient.ts would reference an empty `window.__ENV__` and fail.
+ *
+ * On the web the bundle is also downloaded over the network, so by the time it
+ * evaluates the env-loader has almost always finished — no wait is needed.
+ */
+function waitForNativeEnv(): Promise<void> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const w = window as any
+
+  // If env vars already have Supabase credentials, proceed immediately.
+  if (w.__ENV__?.VITE_SUPABASE_URL) return Promise.resolve()
+
+  // Also skip waiting if the credentials were baked in at build time.
+  if (import.meta.env.VITE_SUPABASE_URL) return Promise.resolve()
+
+  return new Promise<void>((resolve) => {
+    let settled = false
+    const settle = () => { if (settled) return; settled = true; resolve() }
+
+    const onReady = () => { clearTimeout(tid); settle() }
+    window.addEventListener('plantswipe:env-ready', onReady, { once: true })
+
+    // Safety: don't block forever if env loading fails (e.g. no internet).
+    // After 8 s the app mounts anyway in guest / offline mode.
+    const tid = setTimeout(() => {
+      window.removeEventListener('plantswipe:env-ready', onReady)
+      settle()
+    }, 8_000)
+  })
+}
+
+async function bootstrap() {
+  // On native Capacitor, wait for the env-loader to fetch credentials from the
+  // remote API before importing App (which triggers supabaseClient.ts init).
+  if (Capacitor.isNativePlatform()) {
+    await waitForNativeEnv()
+  }
+
+  const { default: App } = await import('./App.tsx')
+  createRoot(document.getElementById('root')!).render(<App />)
+}
+
+bootstrap().catch((err) => {
+  // Last resort: render error info so the user doesn't stare at a spinner forever.
+  console.error('[Aphylia] bootstrap failed', err)
+  const root = document.getElementById('root')
+  if (root) {
+    root.innerHTML =
+      '<div style="display:flex;align-items:center;justify-content:center;min-height:100vh;font-family:system-ui;padding:2rem;text-align:center">' +
+      '<p>Something went wrong while starting the app. Please restart or reinstall.</p></div>'
+  }
+})


### PR DESCRIPTION
## Summary
This PR fixes a critical initialization issue in Capacitor native builds where environment variables (Supabase credentials) are loaded asynchronously from a remote API, but the app was trying to use them synchronously at module-init time. The solution defers the App import until after environment variables are guaranteed to be available, with a safety timeout to prevent indefinite blocking.

## Key Changes

- **Dynamic App import in main.tsx**: Moved the static `import App from './App.tsx'` to a dynamic import inside an async `bootstrap()` function that waits for environment variables to be ready before importing the App module.

- **Environment loading synchronization**: Added `waitForNativeEnv()` function that:
  - Checks if Supabase credentials are already available (either from remote API or build-time injection)
  - Listens for the `plantswipe:env-ready` event dispatched by the env-loader
  - Implements an 8-second timeout safety net to prevent indefinite blocking if env loading fails

- **Timeout enforcement across env-loaders**: Added consistent 8-second timeout handling to:
  - `src/lib/runtimeEnvLoader.ts`: Uses `AbortController` to cancel fetch requests that exceed the timeout
  - `public/env-loader.js`: Implements timeout with fallback for older browsers without `AbortController` support

- **Graceful error handling**: Added error boundary in `bootstrap()` that renders a user-friendly message if the bootstrap process fails, preventing a blank spinner screen.

- **Safe fallback in supabaseClient.ts**: Updated `getEnvAny()` calls to provide empty-string defaults, allowing the app to render in guest/offline mode even if credentials aren't available.

## Implementation Details

- The 8-second timeout is consistent across all env-loading paths (main bootstrap, runtime env loader, and public env-loader script)
- On web builds, the timeout is effectively a no-op since the env-loader typically completes before the bundle evaluates
- On native Capacitor builds, the deferred import ensures the env-loader has time to fetch credentials from the remote API before `supabaseClient.ts` module initialization
- The solution maintains backward compatibility with build-time environment variable injection

https://claude.ai/code/session_01AfykoHELuJN8tX6g4xSr1V