### PR TITLE
⚡ Bolt: Replace Map/Set map() initializations with single-pass loops in data fetching

### DIFF
--- a/plant-swipe/server.js
+++ b/plant-swipe/server.js
@@ -14474,7 +14474,12 @@ app.get('/api/admin/member-messages', async (req, res) => {
           )
           if (profileResp.ok) {
             const profiles = await profileResp.json().catch(() => [])
-            const profileMap = new Map(profiles.map(p => [p.id, p.display_name]))
+            // ⚡ Bolt: Replace new Map(arr.map()) with single-pass for loop
+            const profileMap = new Map()
+            for (let i = 0; i < profiles.length; i++) {
+              const p = profiles[i]
+              profileMap.set(p.id, p.display_name)
+            }
             conversations = conversations.map(c => ({
               ...c,
               participant_1_name: profileMap.get(c.participant_1) || null,

--- a/plant-swipe/src/lib/gardens.ts
+++ b/plant-swipe/src/lib/gardens.ts
@@ -3702,7 +3702,12 @@ export async function getGardensByIds(gardenIds: string[]): Promise<PublicGarden
   
   // Build result with preview data - maintain original order
   /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-  const gardensById = new Map(gardens.map((g: any) => [String(g.id), g]))
+  // ⚡ Bolt: Replace new Map(arr.map()) with single-pass for loop
+  const gardensById = new Map<string, any>()
+  for (let i = 0; i < gardens.length; i++) {
+    const g = gardens[i]
+    gardensById.set(String(g.id), g)
+  }
   
   return gardenIds
     .filter(id => gardensById.has(id))
@@ -3940,7 +3945,12 @@ export async function resizeSeedlingTray(gardenId: string, newRows: number, newC
     .from('seedling_tray_cells')
     .select('position')
     .eq('garden_id', gardenId)
-  const existingPositions = new Set((existing || []).map((r: any) => r.position))
+  // ⚡ Bolt: Replace new Set(arr.map()) with single-pass for loop
+  const existingPositions = new Set<any>()
+  const existingArr = existing || []
+  for (let i = 0; i < existingArr.length; i++) {
+    existingPositions.add(existingArr[i].position)
+  }
 
   // Insert missing positions
   const missing = []

--- a/plant-swipe/src/lib/notifications.ts
+++ b/plant-swipe/src/lib/notifications.ts
@@ -181,13 +181,24 @@ export async function getPendingGardenInvites(userId: string): Promise<GardenInv
   if (!data || data.length === 0) return []
 
   // Get inviter profiles
-  const inviterIds = [...new Set(data.map(d => d.inviter_id))]
+  // ⚡ Bolt: Replace new Set(arr.map()) and new Map(arr.map()) with single-pass loops
+  const inviterIdsSet = new Set<string>()
+  for (let i = 0; i < data.length; i++) {
+    inviterIdsSet.add(data[i].inviter_id)
+  }
+  const inviterIds = Array.from(inviterIdsSet)
+
   const { data: profiles } = await supabase
     .from('profiles')
     .select('id, display_name')
     .in('id', inviterIds)
 
-  const profileMap = new Map((profiles || []).map(p => [p.id, p.display_name]))
+  const profileMap = new Map<string, string>()
+  const profArr = profiles || []
+  for (let i = 0; i < profArr.length; i++) {
+    const p = profArr[i]
+    profileMap.set(p.id, p.display_name)
+  }
 
   return data.map(row => ({
     id: String(row.id),
@@ -237,13 +248,24 @@ export async function getSentGardenInvites(userId: string): Promise<GardenInvite
   if (!data || data.length === 0) return []
 
   // Get invitee profiles
-  const inviteeIds = [...new Set(data.map(d => d.invitee_id))]
+  // ⚡ Bolt: Replace new Set(arr.map()) and new Map(arr.map()) with single-pass loops
+  const inviteeIdsSet = new Set<string>()
+  for (let i = 0; i < data.length; i++) {
+    inviteeIdsSet.add(data[i].invitee_id)
+  }
+  const inviteeIds = Array.from(inviteeIdsSet)
+
   const { data: profiles } = await supabase
     .from('profiles')
     .select('id, display_name')
     .in('id', inviteeIds)
 
-  const profileMap = new Map((profiles || []).map(p => [p.id, p.display_name]))
+  const profileMap = new Map<string, string>()
+  const profArr = profiles || []
+  for (let i = 0; i < profArr.length; i++) {
+    const p = profArr[i]
+    profileMap.set(p.id, p.display_name)
+  }
 
   return data.map(row => ({
     id: String(row.id),

--- a/plant-swipe/src/lib/plantScan.ts
+++ b/plant-swipe/src/lib/plantScan.ts
@@ -591,7 +591,12 @@ export async function getUserScans(options?: {
       }
       
       // Merge successfully rechecked scans back into the list
-      const recheckedMap = new Map(recheckedScans.map(s => [s.id, s]))
+      // ⚡ Bolt: Replace new Map(arr.map()) with single-pass for loop
+      const recheckedMap = new Map<string, any>()
+      for (let i = 0; i < recheckedScans.length; i++) {
+        const s = recheckedScans[i]
+        recheckedMap.set(s.id, s)
+      }
       scans = scans.map(s => recheckedMap.get(s.id) || s)
     }
   }


### PR DESCRIPTION
💡 What: Replaced `.map()` initializations for `Map` and `Set` collections with single-pass `for` loops.
🎯 Why: To avoid allocating intermediate arrays, reducing garbage collection overhead and improving performance in data processing loops.
📊 Impact: Eliminates N unnecessary memory allocations per mapped array, slightly reducing peak memory usage in API data processing hot paths.
🔬 Measurement: Verify tests run smoothly without errors and the `bun run build:low-mem` completes successfully without any memory regressions.

---
*PR created automatically by Jules for task [2413407814862993960](https://jules.google.com/task/2413407814862993960) started by @FrenchFive*