### PR TITLE
fix: increase icon button tap targets from 36px to 44px for mobile

### DIFF
--- a/plant-swipe/src/components/layout/MobileNavBar.tsx
+++ b/plant-swipe/src/components/layout/MobileNavBar.tsx
@@ -218,7 +218,7 @@ const MobileNavBarComponent: React.FC<MobileNavBarProps> = ({ canCreate, onProfi
                 <Button
                   variant="secondary"
                   size="icon"
-                  className="rounded-2xl h-9 w-9"
+                  className="rounded-2xl"
                   onClick={openNotificationsFromMenu}
                   aria-label="Notifications"
                 >

--- a/plant-swipe/src/components/ui/button.tsx
+++ b/plant-swipe/src/components/ui/button.tsx
@@ -25,7 +25,7 @@ const buttonVariants = cva(
         default: "h-9 px-4 py-2",
         sm: "h-8 rounded-md px-3 text-xs",
         lg: "h-10 rounded-md px-8",
-        icon: "h-9 w-9",
+        icon: "h-11 w-11",
       },
     },
     defaultVariants: {


### PR DESCRIPTION
The shared Button component's `icon` size variant was 36×36px (h-9 w-9), below the 44×44px minimum tap target recommended by Apple HIG and WCAG. This affected 103 icon buttons across 24 files. Bumped to h-11 w-11 (44px) and removed the redundant h-9 w-9 override on the MobileNavBar notification bell.

https://claude.ai/code/session_018rRkdKNgBFNeG5RdcpixhV