### PR TITLE
🎨 Palette: Accessible icon-only dismiss buttons in Admin panels

### DIFF
--- a/plant-swipe/src/components/admin/AdminBadgesPanel.tsx
+++ b/plant-swipe/src/components/admin/AdminBadgesPanel.tsx
@@ -788,7 +788,7 @@ export const AdminBadgesPanel: React.FC = () => {
         <div className="flex items-center gap-2 p-3 rounded-xl bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-300 text-sm">
           <AlertCircle className="h-4 w-4 flex-shrink-0" />
           {error}
-          <button onClick={() => setError(null)} className="ml-auto">
+          <button onClick={() => setError(null)} aria-label="Dismiss error" title="Dismiss error" className="ml-auto focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 rounded">
             <X className="h-3.5 w-3.5" />
           </button>
         </div>

--- a/plant-swipe/src/components/admin/AdminColorsPanel.tsx
+++ b/plant-swipe/src/components/admin/AdminColorsPanel.tsx
@@ -929,7 +929,7 @@ export const AdminColorsPanel: React.FC = () => {
         <div className="flex items-center gap-2 p-3 rounded-xl bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-300">
           <AlertCircle className="h-4 w-4" />
           <span className="text-sm">{error}</span>
-          <button onClick={() => setError(null)} className="ml-auto">
+          <button onClick={() => setError(null)} aria-label="Dismiss error" title="Dismiss error" className="ml-auto focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 rounded">
             <X className="h-4 w-4" />
           </button>
         </div>

--- a/plant-swipe/src/components/admin/AdminEventsPanel.tsx
+++ b/plant-swipe/src/components/admin/AdminEventsPanel.tsx
@@ -510,7 +510,7 @@ export const AdminEventsPanel: React.FC = () => {
           <h3 className="text-sm font-semibold text-stone-900 dark:text-white">
             Edit Event
           </h3>
-          <button onClick={handleCancel} className="p-1 rounded-lg hover:bg-stone-100 dark:hover:bg-stone-800 transition-colors">
+          <button onClick={handleCancel} aria-label="Cancel editing" title="Cancel editing" className="p-1 rounded-lg hover:bg-stone-100 dark:hover:bg-stone-800 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-500">
             <X className="h-4 w-4 text-stone-500" />
           </button>
         </div>
@@ -689,7 +689,7 @@ export const AdminEventsPanel: React.FC = () => {
         <div className="flex items-center gap-2 p-3 rounded-xl bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-300 text-sm">
           <AlertCircle className="h-4 w-4 flex-shrink-0" />
           {error}
-          <button onClick={() => setError(null)} className="ml-auto"><X className="h-3.5 w-3.5" /></button>
+          <button onClick={() => setError(null)} aria-label="Dismiss error" title="Dismiss error" className="ml-auto focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 rounded"><X className="h-3.5 w-3.5" /></button>
         </div>
       )}
       {success && (

--- a/plant-swipe/src/components/admin/AdminUploadPanel.tsx
+++ b/plant-swipe/src/components/admin/AdminUploadPanel.tsx
@@ -929,7 +929,7 @@ export const AdminUploadPanel: React.FC = () => {
       {error && (
         <div className="rounded-xl border border-red-200 bg-red-50 dark:bg-red-900/20 px-4 py-3 text-sm text-red-700 dark:text-red-200 flex items-center justify-between">
           <span>{error}</span>
-          <button type="button" onClick={() => setError(null)} className="ml-3 flex-shrink-0">
+          <button type="button" onClick={() => setError(null)} aria-label="Dismiss error" title="Dismiss error" className="ml-3 flex-shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 rounded">
             <X className="h-4 w-4" />
           </button>
         </div>


### PR DESCRIPTION
* 💡 What: Added explicit accessibility attributes (`aria-label`, `title`) and keyboard focus styling (`focus-visible:ring-2`) to icon-only dismiss/cancel buttons (`<X>` icons) in multiple Admin panel components.
* 🎯 Why: Screen reader users and sighted keyboard users lacked context and visual feedback when navigating to these error dismissal buttons, trapping focus or causing confusion.
* ♿ Accessibility: Improves WCAG compliance for Name, Role, Value and Focus Visible.

---
*PR created automatically by Jules for task [15220854466219083559](https://jules.google.com/task/15220854466219083559) started by @FrenchFive*