### PR TITLE
Refactor mobile CI to trigger after version bump workflow

### DIFF
--- a/.github/workflows/capacitor-mobile.yml
+++ b/.github/workflows/capacitor-mobile.yml
@@ -20,19 +20,13 @@ on:
         required: false
         default: 'https://aphylia.app'
         type: string
-  push:
-    branches:
-      - main
-    paths:
-      - 'plant-swipe/android/**'
-      - 'plant-swipe/ios/**'
-      - 'plant-swipe/capacitor.config.*'
-      - 'plant-swipe/package.json'
-      - 'plant-swipe/bun.lock'
-      - 'plant-swipe/scripts/sync-native-version.mjs'
-      - 'plant-swipe/scripts/cap-ci-sync.mjs'
-      - 'plant-swipe/scripts/assert-capacitor-store-bundle.mjs'
-      - '.github/workflows/capacitor-mobile.yml'
+  # Main-branch builds run AFTER Auto Version Increment completes so the bumped
+  # version in package.json / capacitor.config.json / native projects is actually
+  # compiled into the APK / IPA. Running on `push` here would race the bump job.
+  workflow_run:
+    workflows: ["Auto Version Increment"]
+    types: [completed]
+    branches: [main]
   pull_request:
     paths:
       - 'plant-swipe/android/**'
@@ -53,6 +47,9 @@ jobs:
   cap-sync-and-web:
     name: Web build + cap sync (CI-safe)
     runs-on: ubuntu-latest
+    # Skip if the upstream Auto Version Increment run failed — building stale
+    # code with a half-applied bump would just reintroduce the mismatch.
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     outputs:
       has-android: ${{ steps.detect-platforms.outputs.has-android }}
       has-ios: ${{ steps.detect-platforms.outputs.has-ios }}
@@ -60,7 +57,12 @@ jobs:
       run:
         working-directory: plant-swipe
     steps:
+      # For workflow_run triggers actions/checkout defaults to the SHA that started
+      # the upstream run (the PR merge commit, pre-bump). Pin to main so we pick up
+      # the version bump commit that Auto Version Increment just pushed.
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_run' && 'main' || github.ref }}
 
       - name: Detect native platforms
         id: detect-platforms
@@ -123,6 +125,8 @@ jobs:
         working-directory: plant-swipe
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_run' && 'main' || github.ref }}
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -197,6 +201,8 @@ jobs:
         working-directory: plant-swipe
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_run' && 'main' || github.ref }}
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -295,6 +301,8 @@ jobs:
         working-directory: plant-swipe
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_run' && 'main' || github.ref }}
 
       - name: Select Xcode 26
         run: |
@@ -374,11 +382,15 @@ jobs:
     name: Create GitHub Release
     runs-on: ubuntu-latest
     needs: [android-debug, android-release]
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    # Releases only cut from main after Auto Version Increment has bumped and
+    # the build jobs (which now checkout main post-bump) produced versioned APKs.
+    if: github.event_name == 'workflow_run' && github.event.workflow_run.head_branch == 'main' && github.event.workflow_run.conclusion == 'success'
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: main
 
       - name: Get version from package.json
         id: version

--- a/.github/workflows/capacitor-mobile.yml
+++ b/.github/workflows/capacitor-mobile.yml
@@ -382,9 +382,12 @@ jobs:
     name: Create GitHub Release
     runs-on: ubuntu-latest
     needs: [android-debug, android-release]
-    # Releases only cut from main after Auto Version Increment has bumped and
-    # the build jobs (which now checkout main post-bump) produced versioned APKs.
-    if: github.event_name == 'workflow_run' && github.event.workflow_run.head_branch == 'main' && github.event.workflow_run.conclusion == 'success'
+    # Releases cut from main either (a) after Auto Version Increment completes
+    # the bump, or (b) on a manual Run workflow against main. `needs` already
+    # guarantees both APK builds succeeded, so no extra success check is needed.
+    if: >-
+      (github.event_name == 'workflow_run' && github.event.workflow_run.head_branch == 'main' && github.event.workflow_run.conclusion == 'success') ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
## Summary
Refactored the Capacitor mobile CI workflow to trigger after the "Auto Version Increment" workflow completes, rather than on direct pushes to main. This ensures that native builds compile with the bumped version numbers, preventing version mismatches between the app and native artifacts.

## Key Changes
- **Trigger mechanism**: Changed from `push` event with path filters to `workflow_run` trigger that depends on "Auto Version Increment" workflow completion
- **Conditional execution**: Added guard condition to skip jobs if the upstream version bump workflow failed
- **Checkout strategy**: Updated all job checkouts to explicitly reference `main` branch when triggered by `workflow_run`, ensuring builds pick up the version bump commit that was just pushed
- **Release job condition**: Updated release job condition to check `workflow_run` event properties instead of `push` event, maintaining the main-branch-only release behavior

## Implementation Details
- The workflow now waits for the Auto Version Increment workflow to complete successfully before building
- All checkout steps conditionally pin to `main` for workflow_run triggers (post-bump) while respecting the original ref for pull request triggers
- The release job explicitly checks out `main` to ensure it reads the bumped version from package.json
- Added explanatory comments throughout to document the race condition being solved and the checkout behavior

This change ensures version consistency across web, Android, and iOS builds while maintaining the existing pull request CI behavior.

https://claude.ai/code/session_019yPLKPjY9742VgboAhMwS7