### PR TITLE
🎨 Palette: Add accessibility to admin panel error dismiss buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -48,3 +48,6 @@
 ## 2024-05-20 - Adding Keyboard Focus and Button Types to Action Buttons
 **Learning:** Adding semantic `type="button"` and `focus-visible` utility classes to interactive components ensures they behave consistently, especially within complex UIs, preventing form submission issues and enabling proper keyboard navigation.
 **Action:** Consistently set `type="button"` and `focus-visible` utility classes (e.g. `focus-visible:ring-2`) on custom buttons inside UIs.
+## 2026-04-17 - Accessible Error Dismissal Buttons
+**Learning:** Icon-only error dismissal buttons (`<X>`) across admin panels lacked `aria-label`/`title` for screen readers and tooltips, and didn't have keyboard focus indicators (`focus-visible:ring-2`). Even text-based "dismiss" buttons missed the focus indicators.
+**Action:** Always add explicit `aria-label` and `title` to icon-only buttons. Add `focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:outline-none rounded-sm` to ensure keyboard users can navigate to and activate these error alert dismissals.

--- a/plant-swipe/src/components/admin/AdminBadgesPanel.tsx
+++ b/plant-swipe/src/components/admin/AdminBadgesPanel.tsx
@@ -788,7 +788,7 @@ export const AdminBadgesPanel: React.FC = () => {
         <div className="flex items-center gap-2 p-3 rounded-xl bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-300 text-sm">
           <AlertCircle className="h-4 w-4 flex-shrink-0" />
           {error}
-          <button onClick={() => setError(null)} className="ml-auto">
+          <button onClick={() => setError(null)} className="ml-auto focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:outline-none rounded-sm" aria-label="Dismiss error" title="Dismiss error">
             <X className="h-3.5 w-3.5" />
           </button>
         </div>

--- a/plant-swipe/src/components/admin/AdminColorsPanel.tsx
+++ b/plant-swipe/src/components/admin/AdminColorsPanel.tsx
@@ -929,7 +929,7 @@ export const AdminColorsPanel: React.FC = () => {
         <div className="flex items-center gap-2 p-3 rounded-xl bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-300">
           <AlertCircle className="h-4 w-4" />
           <span className="text-sm">{error}</span>
-          <button onClick={() => setError(null)} className="ml-auto">
+          <button onClick={() => setError(null)} className="ml-auto focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:outline-none rounded-sm" aria-label="Dismiss error" title="Dismiss error">
             <X className="h-4 w-4" />
           </button>
         </div>

--- a/plant-swipe/src/components/admin/AdminEventsPanel.tsx
+++ b/plant-swipe/src/components/admin/AdminEventsPanel.tsx
@@ -689,7 +689,9 @@ export const AdminEventsPanel: React.FC = () => {
         <div className="flex items-center gap-2 p-3 rounded-xl bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-300 text-sm">
           <AlertCircle className="h-4 w-4 flex-shrink-0" />
           {error}
-          <button onClick={() => setError(null)} className="ml-auto"><X className="h-3.5 w-3.5" /></button>
+          <button onClick={() => setError(null)} className="ml-auto focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:outline-none rounded-sm" aria-label="Dismiss error" title="Dismiss error">
+            <X className="h-3.5 w-3.5" />
+          </button>
         </div>
       )}
       {success && (

--- a/plant-swipe/src/components/admin/AdminUploadPanel.tsx
+++ b/plant-swipe/src/components/admin/AdminUploadPanel.tsx
@@ -439,11 +439,7 @@ function FileExplorer({
       {error && (
         <div className="px-3 py-2 text-xs text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/10 border-b border-red-200 dark:border-red-900/30">
           {error}
-          <button
-            type="button"
-            onClick={() => setError(null)}
-            className="ml-2 underline hover:no-underline"
-          >
+          <button type="button" onClick={() => setError(null)} className="ml-2 underline hover:no-underline focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:outline-none rounded-sm">
             dismiss
           </button>
         </div>
@@ -929,7 +925,7 @@ export const AdminUploadPanel: React.FC = () => {
       {error && (
         <div className="rounded-xl border border-red-200 bg-red-50 dark:bg-red-900/20 px-4 py-3 text-sm text-red-700 dark:text-red-200 flex items-center justify-between">
           <span>{error}</span>
-          <button type="button" onClick={() => setError(null)} className="ml-3 flex-shrink-0">
+          <button type="button" onClick={() => setError(null)} className="ml-3 flex-shrink-0 focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:outline-none rounded-sm" aria-label="Dismiss error" title="Dismiss error">
             <X className="h-4 w-4" />
           </button>
         </div>


### PR DESCRIPTION
💡 What: Added accessible `aria-label`, `title`, and keyboard focus (`focus-visible:ring-2`) to error dismissal buttons across various Admin panels.
🎯 Why: Icon-only `<X>` buttons were inaccessible to screen reader users (missing ARIA labels), sighted mouse users (missing hover tooltips), and keyboard users (missing focus rings). Text-based dismiss buttons also missed clear focus states. This ensures all users can identify and dismiss admin error banners.
♿ Accessibility:
- Added `aria-label="Dismiss error"` and `title="Dismiss error"` to `<X>` buttons.
- Added `focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:outline-none` to all targeted dismiss buttons for keyboard navigability.

---
*PR created automatically by Jules for task [4424196098931175220](https://jules.google.com/task/4424196098931175220) started by @FrenchFive*