### PR TITLE
🎨 Palette: Add keyboard focus state to image upload error dismissal button

### DIFF
--- a/plant-swipe/src/components/ui/image-upload-area.tsx
+++ b/plant-swipe/src/components/ui/image-upload-area.tsx
@@ -67,7 +67,7 @@ export const ImageUploadArea: React.FC<ImageUploadAreaProps> = ({
             <button
               type="button"
               onClick={onClearError}
-              className="ml-auto hover:text-red-900 dark:hover:text-red-100"
+              className="ml-auto hover:text-red-900 dark:hover:text-red-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 rounded-sm"
               aria-label="Dismiss"
             >
               <X className="w-4 h-4" />


### PR DESCRIPTION
💡 **What:** Added missing visual focus outline to the error dismissal button in the generic `ImageUploadArea` UI component.
🎯 **Why:** Improved accessibility for keyboard navigation so users can see which element has focus.
♿ **Accessibility:** Re-used Tailwind UI focus utilities (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500`) to provide proper visual feedback during keyboard interactions.

---
*PR created automatically by Jules for task [3338797593967833614](https://jules.google.com/task/3338797593967833614) started by @FrenchFive*