### PR TITLE
Harden native push delivery against cold-start races and crashes

### DIFF
--- a/plant-swipe/android/app/src/main/java/app/aphylia/MainActivity.java
+++ b/plant-swipe/android/app/src/main/java/app/aphylia/MainActivity.java
@@ -1,5 +1,96 @@
 package app.aphylia;
 
+import android.content.Intent;
+import android.os.Build;
+import android.os.Bundle;
+import android.webkit.ServiceWorkerClient;
+import android.webkit.ServiceWorkerController;
+import android.webkit.WebResourceRequest;
+import android.webkit.WebResourceResponse;
+
 import com.getcapacitor.BridgeActivity;
 
-public class MainActivity extends BridgeActivity {}
+import java.io.ByteArrayInputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+public class MainActivity extends BridgeActivity {
+
+    /**
+     * FCM / GCM extras carried by a notification-tap intent. Once Capacitor's
+     * push plugin has dispatched the JS event for these, we strip them so a
+     * subsequent activity recreation (config change, crash recovery, OS-driven
+     * restart) cannot re-fire the same "pushNotificationActionPerformed" over
+     * and over — that replay loop is the crash-on-restart users reported.
+     */
+    private static final Set<String> FCM_EXTRA_PREFIXES = new HashSet<>(Arrays.asList(
+        "google.", "gcm.", "firebase."
+    ));
+    private static final Set<String> FCM_EXTRA_KEYS = new HashSet<>(Arrays.asList(
+        "from", "collapse_key", "message_type"
+    ));
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        // Neuter service workers inside the Capacitor WebView before the bridge
+        // starts. Earlier builds of the app registered a PWA service worker
+        // whose `notificationclick` handler called `clients.openWindow()` — in
+        // Android's WebView that dispatches an external ACTION_VIEW intent,
+        // yanking the user into Chrome and leaving the shell in a crash loop.
+        // Returning an empty response for every SW-originated fetch keeps any
+        // lingering worker from downloading scripts or running handlers.
+        // The native app never relies on service workers (VitePWA is disabled
+        // in `build:web:native`), so this is safe to apply unconditionally.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            try {
+                ServiceWorkerController.getInstance().setServiceWorkerClient(new ServiceWorkerClient() {
+                    @Override
+                    public WebResourceResponse shouldInterceptRequest(WebResourceRequest request) {
+                        return new WebResourceResponse(
+                            "text/plain",
+                            "utf-8",
+                            new ByteArrayInputStream(new byte[0])
+                        );
+                    }
+                });
+            } catch (Throwable ignored) {
+                // If the platform WebView doesn't expose ServiceWorkerController,
+                // fall through — the JS-side cleanup in main.tsx is still in place.
+            }
+        }
+
+        super.onCreate(savedInstanceState);
+
+        // Capacitor's push plugin reads the FCM extras during bridge init above;
+        // now that it has, drop them from the launch intent so we don't replay
+        // the same tap on a crash restart.
+        consumeFcmNotificationExtras(getIntent());
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        consumeFcmNotificationExtras(intent);
+    }
+
+    private static void consumeFcmNotificationExtras(Intent intent) {
+        if (intent == null) return;
+        Bundle extras = intent.getExtras();
+        if (extras == null || extras.isEmpty()) return;
+        if (!extras.containsKey("google.message_id")) return;
+        for (String key : new ArrayList<>(extras.keySet())) {
+            if (FCM_EXTRA_KEYS.contains(key)) {
+                intent.removeExtra(key);
+                continue;
+            }
+            for (String prefix : FCM_EXTRA_PREFIXES) {
+                if (key.startsWith(prefix)) {
+                    intent.removeExtra(key);
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/plant-swipe/server.js
+++ b/plant-swipe/server.js
@@ -1408,6 +1408,13 @@ if (fcmNativePushEnabled) {
   console.warn('[notifications] FCM_LEGACY_SERVER_KEY not set — native app tokens stored but server will not send FCM until configured')
 }
 
+/**
+ * Android channel created by the client in `nativePushRegistration.ts`. Must
+ * match `ANDROID_CHANNEL_ID` there — without a channel_id, Android 8+ drops
+ * notifications silently on many OEM ROMs (Xiaomi, Huawei, Oppo…).
+ */
+const FCM_ANDROID_CHANNEL_ID = 'aphylia_priority'
+
 async function sendFcmLegacyToToken(token, { title, body, data }) {
   if (!fcmLegacyServerKey || !token) return { ok: false }
   const dataStrings = {}
@@ -1425,7 +1432,18 @@ async function sendFcmLegacyToToken(token, { title, body, data }) {
     body: JSON.stringify({
       to: token,
       priority: 'high',
-      notification: { title, body },
+      // `content_available: true` wakes iOS apps from background so the APNs
+      // path can hand off to the Capacitor push listener.  Ignored on Android.
+      content_available: true,
+      // Best-effort delivery window — Doze-mode reminders shouldn't linger
+      // more than a day past their schedule.
+      time_to_live: 60 * 60 * 24,
+      notification: {
+        title,
+        body,
+        android_channel_id: FCM_ANDROID_CHANNEL_ID,
+        sound: 'default',
+      },
       data: dataStrings,
     }),
   })

--- a/plant-swipe/src/lib/nativePushRegistration.ts
+++ b/plant-swipe/src/lib/nativePushRegistration.ts
@@ -21,11 +21,49 @@ export let lastNativePushToken: string | null = null
 let navigateFn: ((path: string) => void) | null = null
 
 /**
+ * Path buffered from a notification tap that arrived before the React tree
+ * finished mounting (cold-launch from a tap). Flushed as soon as
+ * `registerNativePushNavigation` wires up the router navigator.
+ */
+let pendingPath: string | null = null
+
+/**
+ * De-duplicate tap events. Android's push plugin reads the FCM extras during
+ * bridge init, but in rare races (config change, WebView reload) it can
+ * re-emit `pushNotificationActionPerformed` for the same notification id. We
+ * keep a bounded set so a redelivered tap can't loop-navigate.
+ */
+const processedNotificationIds = new Set<string>()
+const PROCESSED_ID_MAX = 50
+
+function markProcessed(id: string): boolean {
+  if (processedNotificationIds.has(id)) return false
+  processedNotificationIds.add(id)
+  if (processedNotificationIds.size > PROCESSED_ID_MAX) {
+    const first = processedNotificationIds.values().next().value
+    if (first) processedNotificationIds.delete(first)
+  }
+  return true
+}
+
+/**
  * Call once from the root component so that notification taps can navigate
  * inside the app instead of opening Chrome.
  */
 export function registerNativePushNavigation(navigate: (path: string) => void): void {
   navigateFn = navigate
+  // Flush a path captured from a cold-start tap before the router existed.
+  if (pendingPath) {
+    const path = pendingPath
+    pendingPath = null
+    queueMicrotask(() => {
+      try {
+        navigate(path)
+      } catch (err) {
+        if (import.meta.env.DEV) console.warn('[native push] deferred navigate failed', err)
+      }
+    })
+  }
 }
 
 async function postFcmToken(token: string): Promise<void> {
@@ -127,8 +165,24 @@ export async function registerNativePushForCurrentUser(): Promise<void> {
         // Handle notification taps — navigate inside the app instead of opening Chrome
         await PushNotifications.addListener('pushNotificationActionPerformed', (action) => {
           try {
-            const data = action?.notification?.data as Record<string, unknown> | undefined
+            const notification = action?.notification
+            const data = notification?.data as Record<string, unknown> | undefined
+            // Prefer FCM's message id (stable across replays) with an id fallback
+            // so we can drop a redelivered tap that would otherwise re-navigate.
+            const messageId =
+              (data?.['google.message_id'] as string | undefined) ||
+              (notification?.id as string | undefined) ||
+              null
+            if (messageId && !markProcessed(messageId)) return
+
             const path = resolveNotificationPath(data)
+            // Buffer the path if the router navigator hasn't registered yet.
+            // On a cold-start tap the push plugin fires before App.tsx mounts
+            // `CapacitorLinkBridge`, which is when navigateFn is populated.
+            if (!navigateFn) {
+              pendingPath = path
+              return
+            }
             // Defer to the next microtask so we never re-enter React Router
             // mid-render if the tap arrives while it's still mounting.
             queueMicrotask(() => {

--- a/plant-swipe/src/lib/nativePushRegistration.ts
+++ b/plant-swipe/src/lib/nativePushRegistration.ts
@@ -1,37 +1,56 @@
 /**
- * Capacitor: FCM/APNs token registration for native push.
+ * Capacitor: FCM/APNs notification pipeline.
+ *
+ * Push is critical — a missed watering reminder can kill a user's plants — so
+ * this module is structured so that every delivery path survives the worst
+ * conditions we've seen in production:
+ *
+ *   1. Listeners are attached at app boot (`initializeNativePushListeners`)
+ *      regardless of auth state.  Capacitor's plugin queues any retained
+ *      `pushNotificationActionPerformed` events until a listener shows up, so
+ *      attaching early guarantees cold-start taps are never dropped.
+ *   2. A tap that arrives before React mounts is buffered in memory AND
+ *      persisted to `localStorage`, so even a crash between the tap and the
+ *      first render still routes the user to the right screen on the next
+ *      launch.
+ *   3. FCM token uploads retry with exponential backoff (network drop during
+ *      first launch is common) and the token is cached so we can re-post on
+ *      the next online session.
+ *   4. A dedicated Android notification channel is provisioned on init so
+ *      reminders can bypass Doze and show even under battery-optimised
+ *      defaults.
+ *   5. Foreground pushes are still surfaced — Android suppresses the system
+ *      notification UI when the app is visible, so we re-emit the payload to
+ *      the rest of the app via a `plantswipe:push-received` DOM event.
  *
  * Native push uses @capacitor/push-notifications exclusively — no web service
- * worker is registered.  The previous implementation called
- * registerNativeMinimalServiceWorker() which registered sw-native.js inside the
- * Capacitor WebView.  On Android that service-worker's `notificationclick`
- * handler called `self.clients.openWindow()` which opened Chrome instead of
- * navigating inside the app, and on some devices the SW registration itself
- * caused a redirect out of the WebView.
+ * worker is ever registered inside the Capacitor WebView (see
+ * MainActivity.java and src/sw.ts for the belt-and-braces blockers).
  */
 import { Capacitor } from '@capacitor/core'
 import { supabase } from '@/lib/supabaseClient'
 
-let registeredListeners = false
-let listenersPromise: Promise<void> | null = null
-/** Last FCM/APNs token from the plugin (for unregister). */
+/** Last FCM/APNs token the plugin handed us — used for unregister + retry. */
 export let lastNativePushToken: string | null = null
 
-/** Reference to the in-app navigate function (set by registerNativePushNavigation). */
 let navigateFn: ((path: string) => void) | null = null
 
-/**
- * Path buffered from a notification tap that arrived before the React tree
- * finished mounting (cold-launch from a tap). Flushed as soon as
- * `registerNativePushNavigation` wires up the router navigator.
- */
+/** In-memory buffer for a tap whose path hasn't been consumed by the router yet. */
 let pendingPath: string | null = null
+
+/** Memo flags so repeated calls during render don't reattach listeners. */
+let listenersInitialized = false
+let pushRegisteredForUser = false
+
+const PENDING_TAP_KEY = 'plantswipe.push.pendingTap'
+const PENDING_TAP_TTL_MS = 10 * 60 * 1000 // 10 minutes — enough for a crash-restart
+const FCM_TOKEN_CACHE_KEY = 'plantswipe.push.lastFcmToken'
+const ANDROID_CHANNEL_ID = 'aphylia_priority'
 
 /**
  * De-duplicate tap events. Android's push plugin reads the FCM extras during
  * bridge init, but in rare races (config change, WebView reload) it can
- * re-emit `pushNotificationActionPerformed` for the same notification id. We
- * keep a bounded set so a redelivered tap can't loop-navigate.
+ * re-emit `pushNotificationActionPerformed` for the same notification id.
  */
 const processedNotificationIds = new Set<string>()
 const PROCESSED_ID_MAX = 50
@@ -46,59 +65,119 @@ function markProcessed(id: string): boolean {
   return true
 }
 
-/**
- * Call once from the root component so that notification taps can navigate
- * inside the app instead of opening Chrome.
- */
-export function registerNativePushNavigation(navigate: (path: string) => void): void {
-  navigateFn = navigate
-  // Flush a path captured from a cold-start tap before the router existed.
-  if (pendingPath) {
-    const path = pendingPath
-    pendingPath = null
-    queueMicrotask(() => {
-      try {
-        navigate(path)
-      } catch (err) {
-        if (import.meta.env.DEV) console.warn('[native push] deferred navigate failed', err)
-      }
-    })
+function safeLocalStorage(): Storage | null {
+  try {
+    if (typeof localStorage === 'undefined') return null
+    return localStorage
+  } catch {
+    return null
   }
 }
 
-async function postFcmToken(token: string): Promise<void> {
-  const session = (await supabase.auth.getSession()).data.session
-  const auth = session?.access_token
-  if (!auth || !token) return
-  await fetch('/api/push/fcm-token', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${auth}` },
-    credentials: 'same-origin',
-    body: JSON.stringify({
-      token,
-      platform: Capacitor.getPlatform(),
-    }),
-  })
+function savePendingTapPath(path: string): void {
+  if (!path || !path.startsWith('/')) return
+  const store = safeLocalStorage()
+  if (!store) return
+  try {
+    store.setItem(PENDING_TAP_KEY, JSON.stringify({ path, ts: Date.now() }))
+  } catch {
+    /* storage quota / privacy mode */
+  }
+}
+
+function consumePendingTapPath(): string | null {
+  const store = safeLocalStorage()
+  if (!store) return null
+  try {
+    const raw = store.getItem(PENDING_TAP_KEY)
+    if (!raw) return null
+    store.removeItem(PENDING_TAP_KEY)
+    const parsed = JSON.parse(raw) as { path?: unknown; ts?: unknown }
+    const path = typeof parsed?.path === 'string' ? parsed.path : ''
+    const ts = typeof parsed?.ts === 'number' ? parsed.ts : 0
+    if (!path.startsWith('/')) return null
+    // Expired taps are dropped so a user who ignored a stale notification
+    // isn't teleported out of the home screen on their next launch.
+    if (Date.now() - ts > PENDING_TAP_TTL_MS) return null
+    return path
+  } catch {
+    try { store.removeItem(PENDING_TAP_KEY) } catch { /* ignore */ }
+    return null
+  }
+}
+
+function cacheFcmToken(token: string): void {
+  const store = safeLocalStorage()
+  if (!store) return
+  try {
+    store.setItem(FCM_TOKEN_CACHE_KEY, token)
+  } catch {
+    /* ignore */
+  }
+}
+
+function readCachedFcmToken(): string | null {
+  const store = safeLocalStorage()
+  if (!store) return null
+  try {
+    const v = store.getItem(FCM_TOKEN_CACHE_KEY)
+    return v && v.length > 0 ? v : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * POST the FCM/APNs token to the server with bounded exponential backoff.
+ * Network on cold-launch mobile is unreliable — a single miss historically
+ * meant the server never learned about the device, so push never arrived.
+ */
+async function postFcmToken(token: string, attempt = 0): Promise<void> {
+  const MAX_ATTEMPTS = 6
+  try {
+    const session = (await supabase.auth.getSession()).data.session
+    const auth = session?.access_token
+    // No session yet? Cache the token and retry when the user signs in.
+    if (!auth || !token) {
+      cacheFcmToken(token)
+      return
+    }
+    const res = await fetch('/api/push/fcm-token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${auth}` },
+      credentials: 'same-origin',
+      body: JSON.stringify({ token, platform: Capacitor.getPlatform() }),
+    })
+    if (!res.ok) throw new Error(`http ${res.status}`)
+    cacheFcmToken(token)
+  } catch (err) {
+    if (attempt >= MAX_ATTEMPTS) {
+      // Keep the token cached so we can retry on the next successful launch.
+      cacheFcmToken(token)
+      if (import.meta.env.DEV) console.warn('[native push] token post gave up', err)
+      return
+    }
+    const delayMs = Math.min(1000 * Math.pow(2, attempt), 30_000)
+    setTimeout(() => { void postFcmToken(token, attempt + 1) }, delayMs)
+  }
 }
 
 /**
  * Convert any incoming notification target (relative path or full URL) into a
  * safe in-app path.  Returning a full URL with a different origin would cause
  * React Router to no-op (or, worse, the WebView to navigate cross-origin and
- * spawn Chrome on Android — the exact crash-loop the user reported).
+ * spawn Chrome on Android — the exact crash-loop this module exists to stop).
  */
 function sanitizeInAppTarget(raw: unknown): string | null {
   if (typeof raw !== 'string' || raw.length === 0) return null
   // Block protocol handlers that would launch external apps.
   if (/^(?:javascript|data|blob|file|mailto|tel|sms|intent):/i.test(raw)) return null
-  // Already a clean in-app path.
   if (raw.startsWith('/')) return raw
   try {
     const base = typeof window !== 'undefined' && window.location
       ? window.location.origin
       : 'http://localhost'
     const u = new URL(raw, base)
-    // Only http(s) targets are forwarded — everything else is unsafe.
     if (u.protocol !== 'http:' && u.protocol !== 'https:') return null
     return `${u.pathname || '/'}${u.search}${u.hash}`
   } catch {
@@ -106,7 +185,6 @@ function sanitizeInAppTarget(raw: unknown): string | null {
   }
 }
 
-/** Resolve notification data to an in-app path. */
 function resolveNotificationPath(data: Record<string, unknown> | undefined): string {
   if (!data) return '/'
   const fromUrl = sanitizeInAppTarget(data.url)
@@ -126,11 +204,9 @@ function resolveNotificationPath(data: Record<string, unknown> | undefined): str
 }
 
 /**
- * Tear down any service worker that may have been registered by a previous
- * build of the app while running inside the Capacitor WebView.  An orphaned
- * SW's `notificationclick` handler can still call `clients.openWindow()` after
- * an upgrade — which on Android boots Chrome and leaves the user trapped in a
- * crash loop.  Best-effort and silent on failure.
+ * Clear any service worker the WebView may have inherited from a previous
+ * build.  Belt-and-braces alongside the Android `ServiceWorkerController`
+ * reject-all client installed in MainActivity.java.
  */
 async function cleanupStaleServiceWorkers(): Promise<void> {
   try {
@@ -142,63 +218,171 @@ async function cleanupStaleServiceWorkers(): Promise<void> {
   }
 }
 
+function dispatchNavigate(path: string): void {
+  if (!path || !path.startsWith('/')) return
+  if (!navigateFn) {
+    // Router hasn't mounted yet — stash in memory AND localStorage so a
+    // crash between here and the first render still recovers on next launch.
+    pendingPath = path
+    savePendingTapPath(path)
+    return
+  }
+  // Defer to the next microtask so we never re-enter React Router
+  // mid-render if the tap arrives while it's still mounting.
+  queueMicrotask(() => {
+    try {
+      if (navigateFn) navigateFn(path)
+    } catch (navErr) {
+      // Navigation failed — persist the path so the next (hopefully cleaner)
+      // launch can retry.  Better to ship the user late than never.
+      savePendingTapPath(path)
+      if (import.meta.env.DEV) console.warn('[native push] navigate failed', navErr)
+    }
+  })
+}
+
+function emitReceivedEvent(detail: Record<string, unknown>): void {
+  try {
+    if (typeof window === 'undefined') return
+    window.dispatchEvent(new CustomEvent('plantswipe:push-received', { detail }))
+  } catch {
+    /* ignore */
+  }
+}
+
+/**
+ * Called by the React root once the Router is mounted.  Flushes any path we
+ * captured from a cold-start tap (from memory first, then from localStorage
+ * for crash-recovery).
+ */
+export function registerNativePushNavigation(navigate: (path: string) => void): void {
+  navigateFn = navigate
+  const inMemory = pendingPath
+  pendingPath = null
+  // Always drain the persisted marker here — even if we found an in-memory
+  // path, a stale entry in storage would otherwise replay on the next cold
+  // launch and teleport the user to an old target.
+  const persisted = consumePendingTapPath()
+  const path = inMemory || persisted
+  if (!path) return
+  queueMicrotask(() => {
+    try {
+      navigate(path)
+    } catch (err) {
+      // Navigation blew up — re-persist so the next launch can retry.
+      savePendingTapPath(path)
+      if (import.meta.env.DEV) console.warn('[native push] deferred navigate failed', err)
+    }
+  })
+}
+
+async function ensureAndroidNotificationChannel(
+  PushNotifications: typeof import('@capacitor/push-notifications').PushNotifications,
+): Promise<void> {
+  if (Capacitor.getPlatform() !== 'android') return
+  try {
+    // @capacitor/push-notifications v8 exposes createChannel on Android only.
+    // Idempotent: the OS reuses an existing channel with the same id, we just
+    // (re)upsert the metadata.  Missing channel = many OEMs silently drop the
+    // notification on Android 8+.
+    const api = PushNotifications as unknown as {
+      createChannel?: (opts: Record<string, unknown>) => Promise<void>
+    }
+    if (typeof api.createChannel !== 'function') return
+    await api.createChannel({
+      id: ANDROID_CHANNEL_ID,
+      name: 'Reminders & messages',
+      description: 'Plant care reminders, friend activity, and direct messages',
+      importance: 4, // IMPORTANCE_HIGH — heads-up + sound + vibration
+      visibility: 1, // VISIBILITY_PUBLIC
+      sound: 'default',
+      lights: true,
+      lightColor: '#22c55e',
+      vibration: true,
+    })
+  } catch (err) {
+    if (import.meta.env.DEV) console.warn('[native push] channel setup failed', err)
+  }
+}
+
+/**
+ * Attach the three push listeners as early as possible — before auth has
+ * resolved.  Capacitor retains any `pushNotificationActionPerformed` emitted
+ * during bridge init until a listener shows up, so doing this on app boot
+ * guarantees that cold-start taps route correctly even for a logged-out
+ * user (they land on `/` instead of disappearing).
+ */
+export async function initializeNativePushListeners(): Promise<void> {
+  if (!Capacitor.isNativePlatform() || listenersInitialized) return
+  listenersInitialized = true
+
+  try {
+    await cleanupStaleServiceWorkers()
+    const mod = await import('@capacitor/push-notifications')
+    const { PushNotifications } = mod
+    await ensureAndroidNotificationChannel(PushNotifications)
+
+    await PushNotifications.addListener('registration', (ev) => {
+      const tok = ev?.value
+      if (!tok) return
+      lastNativePushToken = tok
+      void postFcmToken(tok)
+    })
+
+    await PushNotifications.addListener('registrationError', (err) => {
+      if (import.meta.env.DEV) console.warn('[native push] registration error', err)
+    })
+
+    await PushNotifications.addListener('pushNotificationReceived', (notification) => {
+      // Foreground delivery: Android suppresses the system tray UI while the
+      // app is visible, so we surface the payload to the rest of the app and
+      // let UI code decide what to do (toast, badge, list refresh, …).
+      try {
+        const data = (notification?.data || {}) as Record<string, unknown>
+        emitReceivedEvent({
+          title: notification?.title,
+          body: notification?.body,
+          data,
+        })
+      } catch (e) {
+        if (import.meta.env.DEV) console.warn('[native push] received handler failed', e)
+      }
+    })
+
+    await PushNotifications.addListener('pushNotificationActionPerformed', (action) => {
+      try {
+        const notification = action?.notification
+        const data = notification?.data as Record<string, unknown> | undefined
+        const messageId =
+          (data?.['google.message_id'] as string | undefined) ||
+          (notification?.id as string | undefined) ||
+          null
+        if (messageId && !markProcessed(messageId)) return
+        dispatchNavigate(resolveNotificationPath(data))
+      } catch (e) {
+        if (import.meta.env.DEV) console.warn('[native push] action handler failed', e)
+      }
+    })
+  } catch (e) {
+    if (import.meta.env.DEV) console.warn('[native push] listener init failed', e)
+    // Reset so a subsequent call can retry — don't leave the app in a silent
+    // "notifications are broken" state if the first import failed transiently.
+    listenersInitialized = false
+  }
+}
+
+/**
+ * Register the device with FCM/APNs and upload the token for the signed-in
+ * user.  Called from AuthContext after auth resolves.  Safe to call multiple
+ * times — the plugin dedupes its own registration internally.
+ */
 export async function registerNativePushForCurrentUser(): Promise<void> {
   if (!Capacitor.isNativePlatform()) return
-  // Remove any leftover SW registration from older builds before wiring listeners.
-  await cleanupStaleServiceWorkers()
+  // Listeners must be attached before `register()` fires an event.
+  await initializeNativePushListeners()
+
   try {
     const { PushNotifications } = await import('@capacitor/push-notifications')
-
-    if (!registeredListeners) {
-      registeredListeners = true
-      listenersPromise = (async () => {
-        await PushNotifications.addListener('registration', (ev) => {
-          const tok = ev?.value
-          if (tok) {
-            lastNativePushToken = tok
-            void postFcmToken(tok)
-          }
-        })
-        await PushNotifications.addListener('registrationError', (err) => {
-          if (import.meta.env.DEV) console.warn('[native push] registration error', err)
-        })
-        // Handle notification taps — navigate inside the app instead of opening Chrome
-        await PushNotifications.addListener('pushNotificationActionPerformed', (action) => {
-          try {
-            const notification = action?.notification
-            const data = notification?.data as Record<string, unknown> | undefined
-            // Prefer FCM's message id (stable across replays) with an id fallback
-            // so we can drop a redelivered tap that would otherwise re-navigate.
-            const messageId =
-              (data?.['google.message_id'] as string | undefined) ||
-              (notification?.id as string | undefined) ||
-              null
-            if (messageId && !markProcessed(messageId)) return
-
-            const path = resolveNotificationPath(data)
-            // Buffer the path if the router navigator hasn't registered yet.
-            // On a cold-start tap the push plugin fires before App.tsx mounts
-            // `CapacitorLinkBridge`, which is when navigateFn is populated.
-            if (!navigateFn) {
-              pendingPath = path
-              return
-            }
-            // Defer to the next microtask so we never re-enter React Router
-            // mid-render if the tap arrives while it's still mounting.
-            queueMicrotask(() => {
-              try {
-                if (navigateFn) navigateFn(path)
-              } catch (navErr) {
-                if (import.meta.env.DEV) console.warn('[native push] navigate failed', navErr)
-              }
-            })
-          } catch (e) {
-            if (import.meta.env.DEV) console.warn('[native push] action handler failed', e)
-          }
-        })
-      })()
-    }
-    if (listenersPromise) await listenersPromise
 
     const perm = await PushNotifications.checkPermissions()
     if (perm.receive !== 'granted') {
@@ -206,7 +390,22 @@ export async function registerNativePushForCurrentUser(): Promise<void> {
       if (req.receive !== 'granted') return
     }
     await PushNotifications.register()
+    pushRegisteredForUser = true
+
+    // If we cached a token earlier (e.g. before the user signed in) push it
+    // to the server now that we have a session.
+    const cached = readCachedFcmToken()
+    if (cached) {
+      lastNativePushToken = cached
+      void postFcmToken(cached)
+    }
   } catch (e) {
     if (import.meta.env.DEV) console.warn('[native push] setup failed', e)
+    pushRegisteredForUser = false
   }
+}
+
+/** Exposed for diagnostics / settings UI. */
+export function isNativePushRegisteredForUser(): boolean {
+  return pushRegisteredForUser
 }

--- a/plant-swipe/src/main.tsx
+++ b/plant-swipe/src/main.tsx
@@ -131,19 +131,29 @@ if (typeof window !== 'undefined' && Capacitor.isNativePlatform()) {
   }).catch(() => { /* plugin unavailable */ })
 }
 
-if (typeof window !== 'undefined' && 'serviceWorker' in navigator) {
+if (typeof window !== 'undefined') {
   const isNativeShell =
     import.meta.env.VITE_APP_NATIVE_BUILD === '1' || Capacitor.isNativePlatform()
   if (isNativeShell) {
-    // Tear down any service worker left over from a previous build (e.g. the
-    // old `sw-native.js` whose `notificationclick` called `clients.openWindow()`
-    // and booted the user into Chrome). Run immediately — a queued push can
-    // fire the stale SW before React mounts, so we can't wait for `load`.
-    navigator.serviceWorker
-      .getRegistrations()
-      .then((regs) => Promise.all((regs || []).map((r) => r.unregister().catch(() => false))))
-      .catch(() => {})
-  } else {
+    if ('serviceWorker' in navigator) {
+      // Tear down any service worker left over from a previous build (e.g. the
+      // old `sw-native.js` whose `notificationclick` called `clients.openWindow()`
+      // and booted the user into Chrome). Run immediately — a queued push can
+      // fire the stale SW before React mounts, so we can't wait for `load`.
+      navigator.serviceWorker
+        .getRegistrations()
+        .then((regs) => Promise.all((regs || []).map((r) => r.unregister().catch(() => false))))
+        .catch(() => {})
+    }
+    // Attach push listeners right now, before React mounts.  Cold-start taps
+    // emit `pushNotificationActionPerformed` during Capacitor bridge init;
+    // the plugin retains the event until a listener shows up, but getting
+    // the handler in place ASAP also gives us a chance to buffer the target
+    // path before React mounts — critical for a crash-free handoff.
+    void import('@/lib/nativePushRegistration')
+      .then((m) => m.initializeNativePushListeners())
+      .catch(() => { /* handled inside */ })
+  } else if ('serviceWorker' in navigator) {
     window.addEventListener('load', () => {
       navigator.serviceWorker
         .getRegistration()

--- a/plant-swipe/src/sw.ts
+++ b/plant-swipe/src/sw.ts
@@ -68,6 +68,23 @@ const notificationBadgeUrl = new URL('icons/icon-192x192.png', self.registration
 const transparentIconDataUri = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
 const defaultNotificationTarget = new URL('.', self.registration.scope).href
 
+/**
+ * A stale copy of this worker can persist inside an Android Capacitor WebView
+ * after an app upgrade. Its `notificationclick` used to call
+ * `clients.openWindow()`, which in a WebView dispatches ACTION_VIEW to the
+ * system browser and boots the user out of the native shell. When we detect
+ * we're running under a Capacitor-like origin (localhost), we keep the worker
+ * idle for push handling and let `@capacitor/push-notifications` do the work.
+ */
+const isCapacitorLikeOrigin = (() => {
+  try {
+    const host = self.location.hostname.toLowerCase()
+    return host === 'localhost' || host === '127.0.0.1' || host === '::1'
+  } catch {
+    return false
+  }
+})()
+
 const resolveNotificationUrl = (target?: string | null) => {
   if (!target) return defaultNotificationTarget
   try {
@@ -309,6 +326,10 @@ self.addEventListener('message', (event) => {
 })
 
 self.addEventListener('push', (event) => {
+  // Capacitor Android: a stale SW registration survives app upgrades; the
+  // native plugin will display and route the notification, so silently drop
+  // the push here instead of spawning a second UI the user can't dismiss.
+  if (isCapacitorLikeOrigin) return
   if (typeof Notification === 'undefined' || Notification.permission !== 'granted') {
     return
   }
@@ -406,20 +427,28 @@ self.addEventListener('push', (event) => {
 })
 
 self.addEventListener('notificationclick', (event) => {
-  const notificationData = (event.notification?.data || {}) as { 
+  // See `isCapacitorLikeOrigin` above: inside the native shell,
+  // `clients.openWindow()` would dispatch an ACTION_VIEW intent that launches
+  // Chrome and crashes the Capacitor app. Close and bail — the native plugin
+  // owns tap routing.
+  if (isCapacitorLikeOrigin) {
+    event.notification?.close()
+    return
+  }
+  const notificationData = (event.notification?.data || {}) as {
     ctaUrl?: string
     url?: string
     conversationId?: string
     type?: string
   }
   const action = event.action
-  
+
   // Handle dismiss action - just close the notification
   if (action === 'dismiss') {
     event.notification?.close()
     return
   }
-  
+
   // Close notification first
   event.notification?.close()
   


### PR DESCRIPTION
## Summary

This PR significantly hardens the native push notification pipeline to survive the worst conditions seen in production: cold-start tap races, app crashes between notification receipt and navigation, network failures during token registration, and Android's aggressive background task killing.

## Key Changes

- **Early listener attachment**: Push listeners are now attached at app boot in `initializeNativePushListeners()` (called from `main.tsx` before React mounts), ensuring cold-start taps queued by Capacitor's plugin are never dropped.

- **Dual-layer tap buffering**: Notification taps that arrive before the router mounts are buffered both in memory and persisted to `localStorage` with a 10-minute TTL. If the app crashes between tap and first render, the path is recovered on the next launch.

- **Exponential backoff for token registration**: `postFcmToken()` now retries with bounded exponential backoff (up to 6 attempts, capped at 30s) and caches the token locally. This handles common cold-launch network drops that previously left devices permanently unregistered.

- **Android notification channel provisioning**: A dedicated high-priority channel (`aphylia_priority`) is created on init with proper importance/visibility flags, bypassing Doze mode and OEM battery-optimization defaults that silently drop notifications.

- **Foreground push surface**: Added `pushNotificationReceived` listener that emits a `plantswipe:push-received` DOM event so the UI can surface foreground notifications (Android suppresses the system tray UI while the app is visible).

- **Duplicate tap deduplication**: Notification IDs are tracked in a bounded set to prevent re-emission of the same tap during config changes or WebView reloads.

- **Android FCM extra stripping**: `MainActivity.java` now strips FCM/GCM extras from the launch intent after Capacitor's plugin has processed them, preventing replay loops on crash restarts.

- **Service worker neutering**: Both `MainActivity.java` (via `ServiceWorkerController`) and `sw.ts` (via `isCapacitorLikeOrigin` check) block stale service workers from calling `clients.openWindow()`, which would launch Chrome and crash the Capacitor shell.

- **Server-side channel ID**: FCM payloads now include `android_channel_id` and improved metadata (content_available for iOS, time_to_live, sound) to ensure delivery on Android 8+ and iOS background modes.

## Notable Implementation Details

- Tap paths are validated with `sanitizeInAppTarget()` to block protocol handlers and cross-origin URLs that could escape the WebView.
- All localStorage operations are wrapped in try-catch to handle quota limits and privacy mode.
- Navigation is deferred to the next microtask to avoid re-entering React Router mid-render.
- The module includes extensive comments documenting the production crash patterns it addresses.
- Diagnostic export `isNativePushRegisteredForUser()` added for settings UI.

https://claude.ai/code/session_01T9MuP9zsEKUt9dKSwXhTTn