### PR TITLE
⚡ Bolt: Optimize plant stats computation with single-pass loop

### DIFF
--- a/plant-swipe/src/components/garden/GardenAnalyticsSection.tsx
+++ b/plant-swipe/src/components/garden/GardenAnalyticsSection.tsx
@@ -433,6 +433,24 @@ export const GardenAnalyticsSection: React.FC<GardenAnalyticsSectionProps> = ({
       ? Math.round(((thisMonthTasks - lastMonthTasks) / lastMonthTasks) * 100)
       : 0;
 
+    // ⚡ Bolt: Calculate plant stats using a single-pass loop to avoid intermediate array allocations
+    // from .map() and multiple .filter() calls in this hot path
+    let needingAttentionCount = 0;
+    let healthyCount = 0;
+    const speciesSet = new Set<string>();
+
+    for (let i = 0; i < plants.length; i++) {
+      const p = plants[i];
+      const plantId = p.plantId || p.plant?.id;
+      if (plantId) speciesSet.add(plantId);
+
+      if ((p.plantsOnHand || 0) < 1) {
+        needingAttentionCount++;
+      } else {
+        healthyCount++;
+      }
+    }
+
     return {
       dailyStats: dailyStats,
       weeklyStats: {
@@ -455,9 +473,9 @@ export const GardenAnalyticsSection: React.FC<GardenAnalyticsSectionProps> = ({
       })),
       plantStats: {
         total: plants.length,
-        species: new Set(plants.map((p) => p.plantId || p.plant?.id)).size,
-        needingAttention: plants.filter((p) => (p.plantsOnHand || 0) < 1).length,
-        healthy: plants.filter((p) => (p.plantsOnHand || 0) >= 1).length,
+        species: speciesSet.size,
+        needingAttention: needingAttentionCount,
+        healthy: healthyCount,
       },
       streakInfo: {
         current: streak,


### PR DESCRIPTION
💡 **What**: Replaced the chained array methods (`new Set(plants.map(...))` and `plants.filter(...).length`) inside the `plantStats` property computation of `computedAnalytics` `useMemo` block in `GardenAnalyticsSection.tsx` with a single-pass `for` loop.
🎯 **Why**: The previous implementation performed three sequential iterations (O(3N)) over the `plants` array using `.map` and two `.filter`s, which allocated three temporary intermediate arrays on every recalculation. This created unnecessary garbage collection overhead in a frequently recomputed React Hook.
📊 **Impact**: Reduces time complexity for the plant stats block from O(3N) to O(N) and eliminates three intermediate array allocations per hook execution, leading to smoother dashboard interactions and faster garbage collection. Additionally, the species count logic slightly improved by explicitly skipping falsy/undefined plant IDs when populating the Set.
🔬 **Measurement**: Verified the application builds and passes all linter checks. The optimization can be measured by inspecting React Profiler timings for `GardenAnalyticsSection` when dashboard props change, noting the reduced execution time in the `computedAnalytics` calculation phase.

---
*PR created automatically by Jules for task [15934785239201485320](https://jules.google.com/task/15934785239201485320) started by @FrenchFive*