### PR TITLE
docs: weekly documentation sync — 2026-04-20

### DIFF
--- a/EXTERNAL_APIS.md
+++ b/EXTERNAL_APIS.md
@@ -1,7 +1,7 @@
 # External APIs Used in Aphylia
 
 > **Comprehensive list of all third-party services and APIs**  
-> Last updated: February 16, 2026
+> Last updated: April 20, 2026
 
 ---
 
@@ -266,6 +266,7 @@ const response = await openaiClient.responses.create({
 - Dynamic loading after cookie consent
 - Graceful fallback when consent not given
 - v3 invisible captcha (no user interaction)
+- **Skipped entirely on native Capacitor apps** — native builds bypass reCAPTCHA since bot risk is lower in store-distributed binaries
 
 **API Endpoints:**
 ```
@@ -667,4 +668,4 @@ For API-related questions:
 
 ---
 
-*Last updated: February 16, 2026*
+*Last updated: April 20, 2026*

--- a/plant-swipe/SECURITY_AUDIT_REPORT.md
+++ b/plant-swipe/SECURITY_AUDIT_REPORT.md
@@ -218,6 +218,9 @@ Key dependencies are up-to-date:
 - `react`: 19.1.1
 - `jsonwebtoken`: 9.0.2
 
+#### ✅ Command Injection Remediation (April 2026)
+- Admin **`/api/admin/system-health`** endpoint previously used `child_process.exec()` for disk stats, which was vulnerable to shell injection via crafted input. Replaced with `child_process.execFile()` which bypasses shell interpolation entirely.
+
 #### ⚠️ Potential Concerns
 - No automated dependency vulnerability scanning in CI/CD (recommend adding)
 - `'unsafe-eval'` in CSP (required for some libraries but increases risk)

--- a/plant-swipe/docs/BUILD_ANDROID.md
+++ b/plant-swipe/docs/BUILD_ANDROID.md
@@ -1,6 +1,6 @@
 # Building the Android app (Capacitor)
 
-Prerequisites: **JDK 17** (match `android/` Gradle config), **Android SDK**, **`ANDROID_HOME`** or **`ANDROID_SDK_ROOT`** pointing at the SDK root, **Bun**, **Node** (for `npx cap`).
+Prerequisites: **JDK 21** (CI uses Temurin 21; source/target compatibility remains Java 17 in Gradle), **Android SDK**, **`ANDROID_HOME`** or **`ANDROID_SDK_ROOT`** pointing at the SDK root, **Bun**, **Node** (for `npx cap`).
 
 **Push (FCM):** Place **`google-services.json`** from the Firebase console in **`android/app/`** (gitignored) so Gradle applies the Google Services plugin. The server needs **`FCM_LEGACY_SERVER_KEY`** (or equivalent) to deliver to Android tokens stored in **`user_fcm_tokens`**.
 
@@ -53,6 +53,8 @@ cd android
 # or
 ./gradlew bundleRelease      # AAB for Play Console (if configured in project)
 ```
+
+**Release builds** enable **R8 minification** (`minifyEnabled true`, `shrinkResources true`) with `proguard-android-optimize.txt`. Verify your ProGuard rules cover any reflection-based libraries before your first signed release.
 
 **Signing:** Keystores and passwords must **not** be committed. Use Play App Signing and CI secrets, or local `~/.gradle` / env-injected signing config per your org.
 

--- a/plant-swipe/docs/CAPACITOR_SETUP_NOTES.md
+++ b/plant-swipe/docs/CAPACITOR_SETUP_NOTES.md
@@ -31,7 +31,7 @@ Order is fixed in `setup.sh`:
 8. **`npx cap add android`** if **`android/`** is missing.
 9. **`npx cap add ios`** — **macOS only** if **`ios/`** is missing; skipped on Linux with a log line.
 10. **Ownership** — If **`SERVICE_USER`** is set and not `root`, **`chown -R`** on `android/` and `ios/` to that user.
-11. **`node scripts/assert-capacitor-store-bundle.mjs && node scripts/sync-native-version.mjs && npx cap sync`** with `ANDROID_HOME`/`ANDROID_SDK_ROOT` exported to the resolved SDK.
+11. **`node scripts/assert-capacitor-store-bundle.mjs && node scripts/sync-native-version.mjs && npx cap sync && node scripts/normalize-capacitor-generated-files.mjs`** with `ANDROID_HOME`/`ANDROID_SDK_ROOT` exported to the resolved SDK.
 
 After this block, if the Capacitor pipeline ran, the main PlantSwipe web build later in `setup.sh` is **skipped** (“already built during Capacitor pipeline”).
 

--- a/plant-swipe/docs/MOBILE_ARCHITECTURE.md
+++ b/plant-swipe/docs/MOBILE_ARCHITECTURE.md
@@ -10,7 +10,7 @@ These align with Capacitor’s own guidance and App Store policy; treat them as 
 2. **Do not assume a Linux server can produce signed iOS builds.** **codesign, provisioning, and App Store distribution require macOS + Xcode** (or a macOS CI runner). Linux can sync web assets and build Android; iOS signing/archives are **mac-only**.
 3. **Do not treat remote web updates as permission to ship major new features without App Store review.** Apple **guideline 2.5.2** limits downloading or executing code that **changes features or functionality** in ways that bypass review. Server-driven **data**, **copy**, and **flags** inside **already-shipped** code paths are fine; **new product surface** shipped only over the wire is not a loophole. Details: `docs/LIVE_UPDATES_STORE_POLICY.md`.
 4. **Do not duplicate app features in separate web vs native implementations** unless there is **no** reasonable way to do it in shared web code (or a tiny native bridge). One React app, one set of routes and business logic.
-5. **Do not add many native plugins early “just in case.”** Add **`@capacitor/*`** plugins when a **concrete** need is proven; otherwise use **`src/platform/`** and web APIs first. Fewer plugins means less maintenance and less App Review surface.
+5. **Do not add native plugins without a concrete need.** Add **`@capacitor/*`** plugins when a proven use case exists; wrap them behind **`src/platform/`** with web-first fallbacks. The current plugin set includes `camera`, `haptics`, `push-notifications`, `share`, `browser`, `dialog`, `geolocation`, `keyboard`, `network`, `status-bar`, and `app` — each justified by a specific native gap. New additions still need the same bar.
 
 ## PWA-first philosophy
 
@@ -43,7 +43,7 @@ Native (or native-adjacent) changes are appropriate when they:
 Avoid:
 
 - Reimplementing screens or API clients in Kotlin/Swift when React can do it.
-- Adding Capacitor plugins “just in case”; prefer `src/platform/` with feature detection. See `package.json` for the current minimal plugin set.
+- Adding Capacitor plugins “just in case”; prefer `src/platform/` with feature detection. See `package.json` for the current plugin set.
 
 ## Hot update rules
 

--- a/plant-swipe/docs/SERVICE_WORKER_CAPACITOR.md
+++ b/plant-swipe/docs/SERVICE_WORKER_CAPACITOR.md
@@ -22,7 +22,7 @@ That limits cross-version mismatches after a normal PWA refresh/update cycle.
 
 `ServiceWorkerToast` listens for **dynamic import / chunk load failures** (typical when HTML points at new hashed chunks but an old cache or SW still serves an older graph). It shows **“Clear cache & reload”**, which unregisters any service workers, deletes `CacheStorage` entries, and reloads.
 
-On **native store builds**, if a developer-installed SW remains from a previous dev build, the app attempts to **unregister** registrations on startup so nothing intercepts `capacitor://` requests.
+On **native store builds**, if a developer-installed SW remains from a previous dev build, the app attempts to **unregister** registrations on startup so nothing intercepts `capacitor://` requests. The startup code also proactively **deletes stale `sw-native.js`** files via `Cache.delete` to prevent upgraded apps from serving an old service worker that redirects notification taps to Chrome instead of handling them in-app.
 
 ## Operational notes
 

--- a/plant-swipe/src/REUSABLE_COMPONENTS.md
+++ b/plant-swipe/src/REUSABLE_COMPONENTS.md
@@ -34,11 +34,13 @@ Use this layer from UI for device capabilities so shared web code stays the defa
 
 | Module | Use for | Behavior |
 |--------|---------|----------|
-| `platformShare` / `isPlatformShareSupported` | Share sheet | Web Share API → clipboard (no Capacitor Share plugin) |
+| `platformShare` / `isPlatformShareSupported` | Share sheet | Native: `@capacitor/share` (OS share sheet); web: Web Share API → clipboard |
 | `platformHapticTap` / `isHapticsAvailable` | Light haptics | `navigator.vibrate` → `@capacitor/haptics` on native |
+| `isHapticsEnabled` / `setHapticsEnabled` | Haptics preference | User-togglable localStorage preference; `platformHapticTap` no-ops when disabled |
 | `platformPickCameraPhoto` / `platformGetCameraStream` | Camera | Native: `@capacitor/camera`; web: getUserMedia / file input |
+| `platformPickCameraPhotoWithOutcome` / `openNativeAppSettings` | Camera (detailed) | Returns `PlatformPhotoOutcome` with `ok`/`cancelled`/`denied`/`error` discriminant; `openNativeAppSettings` opens OS settings for denied permissions |
 | `platformGetCameraStream` / `platformEnumerateVideoDevices` | Camera | `getUserMedia` (same UI on web and typical WebViews) |
-| `isPlatformWebPushSupported` | Web push UI | Service worker + PushManager; `false` on Capacitor native until a native push path exists |
+| `isPlatformWebPushSupported` | Web push UI | Service worker + PushManager on web; always `false` on Capacitor native (native push uses FCM/APNs via `@capacitor/push-notifications`) |
 | `platformStorage` | Key/value | `localStorage` / `sessionStorage` (swap for Preferences later if needed) |
 | `isNativeCapacitor` | Runtime check | `Capacitor.isNativePlatform()` |
 


### PR DESCRIPTION
## Weekly Docs Sync — 2026-04-20

Auto-generated documentation updates based on this week's merged PRs and commits.

### Summary

**PRs reviewed:** 35
**Commits reviewed:** 80+

Updates cover the Capacitor native expansion (6 new plugins, JDK 21 CI upgrade, R8 minification), a HIGH-severity command injection fix, platform layer API additions, and reCAPTCHA/push behavior changes on native builds.

### Files Updated
- `EXTERNAL_APIS.md` — Updated last-updated date; added note that reCAPTCHA is skipped on native Capacitor apps
- `plant-swipe/SECURITY_AUDIT_REPORT.md` — Added remediation entry for command injection fix (`exec` → `execFile` in `/api/admin/system-health`, PR #1426)
- `plant-swipe/docs/BUILD_ANDROID.md` — Updated JDK prerequisite from 17 to 21; added note about R8 minification in release builds
- `plant-swipe/docs/CAPACITOR_SETUP_NOTES.md` — Updated `sync:cap` pipeline description to include `normalize-capacitor-generated-files.mjs`
- `plant-swipe/docs/MOBILE_ARCHITECTURE.md` — Updated non-negotiable #5 to list the current Capacitor plugin set; adjusted "minimal plugin set" wording
- `plant-swipe/docs/SERVICE_WORKER_CAPACITOR.md` — Added note about proactive `sw-native.js` purge on native startup (PR #1423)
- `plant-swipe/src/REUSABLE_COMPONENTS.md` — Updated platform layer table: native share via `@capacitor/share`, haptics user preference APIs, camera outcome types, web push disabled on native

### No update needed
- `README.md` (root) — Feature descriptions and roadmap still accurate
- `AGENTS.md` — Repository layout, commands, and guidelines still accurate
- `plant-swipe/README.md` — Technical docs, architecture, and API reference still accurate
- `plant-swipe/docs/BUILD_IOS.md` — Orientation and safe area descriptions still accurate
- `plant-swipe/supabase/DATABASE_SCHEMA.md` — No schema changes this week
- `plant-swipe/CACHE_IMPLEMENTATION.md` — No cache changes
- `plant-swipe/GARDEN_TASK_CACHE.md` — No cache changes
- `plant-swipe/DEEPL_API_SETUP.md` — No translation config changes
- `plant-swipe/BUN_MIGRATION.md` — Still accurate
- `plant-swipe/docs/EVENTS.md` — No event system changes
- `plant-swipe/docs/APP_STORE_READINESS.md` — Still accurate
- `plant-swipe/docs/APP_STORE_REVIEW_CHECKLIST.md` — Still accurate
- `plant-swipe/docs/LIVE_UPDATES_STORE_POLICY.md` — Still accurate
- `plant-swipe/docs/PWA_NATIVE_COMPATIBILITY_PHASE1.md` — Still accurate
- `plant-swipe/GARDEN_TYPES.md` — No garden type changes

### Flagged for human review
- **Garden journal rework** (PRs #1404, #1410) — Major UX change: journal now uses plant tags instead of free-text tags, added interactive timeline chart, plant filters, and search. High-level docs ("Journal Entries: Document your gardening journey") are still accurate but don't reflect the new capabilities. Consider adding a dedicated journal feature doc if the feature stabilizes.
- **Dedicated login/signup page** (PR #1416) — New `AuthPage.tsx` adds a standalone auth page with Framer Motion animations. Not yet referenced in any docs. May warrant a mention in the Screens & Capabilities table if it becomes the primary auth entry point.
- **Dependabot vulnerabilities** — GitHub flagged 11 vulnerabilities (1 critical, 5 high, 5 moderate) on the default branch. Not a docs issue but worth investigating.

https://claude.ai/code/session_01ACk7dKgamRukoEZc4ipFU6