### PR TITLE
Lazy load supabaseClient in nativePushRegistration to fix bootstrap

### DIFF
--- a/plant-swipe/src/lib/nativePushRegistration.ts
+++ b/plant-swipe/src/lib/nativePushRegistration.ts
@@ -28,7 +28,12 @@
  * MainActivity.java and src/sw.ts for the belt-and-braces blockers).
  */
 import { Capacitor } from '@capacitor/core'
-import { supabase } from '@/lib/supabaseClient'
+// `supabaseClient` is imported lazily inside `postFcmToken` because this module
+// is dynamically imported from `main.tsx` before the runtime env-loader has
+// populated `window.__ENV__`.  A top-level import would evaluate
+// `supabaseClient.ts` immediately, causing `createClient('', '', …)` to throw
+// "supabaseUrl is required" — which then poisons the module cache so the later
+// static import from `App.tsx` also fails, aborting bootstrap.
 
 /** Last FCM/APNs token the plugin handed us — used for unregister + retry. */
 export let lastNativePushToken: string | null = null
@@ -135,6 +140,7 @@ function readCachedFcmToken(): string | null {
 async function postFcmToken(token: string, attempt = 0): Promise<void> {
   const MAX_ATTEMPTS = 6
   try {
+    const { supabase } = await import('@/lib/supabaseClient')
     const session = (await supabase.auth.getSession()).data.session
     const auth = session?.access_token
     // No session yet? Cache the token and retry when the user signs in.


### PR DESCRIPTION
## Summary
Fixed a bootstrap failure in `nativePushRegistration.ts` by converting the top-level import of `supabaseClient` to a lazy import inside the `postFcmToken` function.

## Problem
The module was being dynamically imported from `main.tsx` before the runtime environment loader had populated `window.__ENV__`. The top-level import of `supabaseClient` would immediately evaluate and attempt to create a Supabase client with empty credentials, throwing "supabaseUrl is required" and poisoning the module cache. This prevented the later static import from `App.tsx` from succeeding, aborting the entire bootstrap process.

## Solution
- Removed the top-level `import { supabase } from '@/lib/supabaseClient'` statement
- Added a lazy dynamic import inside `postFcmToken()`: `const { supabase } = await import('@/lib/supabaseClient')`
- This defers evaluation of `supabaseClient.ts` until after the environment variables are loaded

## Implementation Details
- The lazy import only occurs when `postFcmToken` is actually called, which happens after authentication is ready
- Added explanatory comments documenting why this pattern is necessary
- No functional changes to the token posting logic itself

https://claude.ai/code/session_013ogH5iMHLfY6rKKTyi3LMC