### PR TITLE
Migrate FCM push from legacy HTTP API to v1 with service account auth

### DIFF
--- a/.github/workflows/capacitor-mobile.yml
+++ b/.github/workflows/capacitor-mobile.yml
@@ -1,8 +1,11 @@
 # Capacitor: cache JS + native tooling, build Android + iOS artifacts.
 # Signing keys must NOT be committed — use GitHub Actions secrets for store builds.
+# The Android jobs also materialise `google-services.json` from the
+# `GOOGLE_SERVICES_JSON` secret so FCM push delivery works in CI-built APKs.
 #
 # Optional secrets:
 #   ANDROID_KEYSTORE_BASE64, ANDROID_KEYSTORE_PASSWORD, ANDROID_KEY_ALIAS, ANDROID_KEY_PASSWORD
+#   GOOGLE_SERVICES_JSON (raw or base64-encoded google-services.json)
 #   APPLE_*, MATCH_*, etc.
 
 name: Capacitor mobile

--- a/.github/workflows/capacitor-mobile.yml
+++ b/.github/workflows/capacitor-mobile.yml
@@ -173,23 +173,52 @@ jobs:
 
       - name: Materialise google-services.json from secret
         # FCM push delivery requires `android/app/google-services.json`, which
-        # is gitignored.  Stored as a base64 GitHub secret
-        # (`GOOGLE_SERVICES_JSON`) so the file lives only on the runner and
-        # never in the repo.  Without the secret the build still completes —
-        # the Gradle `google-services` plugin is applied conditionally and the
-        # runtime stub in `MainActivity.ensureFirebaseAppInitialized()` keeps
-        # the app from crashing — but push notifications won't actually
-        # deliver.
+        # is gitignored.  Stored as a GitHub secret (`GOOGLE_SERVICES_JSON`)
+        # so the file lives only on the runner and never in the repo.
+        #
+        # Accepts either the raw JSON or a base64-encoded blob — whichever
+        # form the operator happened to paste.  Validates the decoded result
+        # is real JSON before handing it to Gradle; the previous version
+        # wrote whatever `base64 -d` produced even when the input was invalid,
+        # which surfaced downstream as a cryptic
+        # `processDebugGoogleServices … EOFException at …android_client_info`.
+        #
+        # Without the secret the build still completes — the Gradle
+        # `google-services` plugin is applied conditionally and the runtime
+        # stub in `MainActivity.ensureFirebaseAppInitialized()` keeps the
+        # app from crashing — push just doesn't deliver.
         env:
           GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
         working-directory: plant-swipe/android/app
         run: |
-          if [ -n "${GOOGLE_SERVICES_JSON:-}" ]; then
-            echo "$GOOGLE_SERVICES_JSON" | base64 -d > google-services.json
-            echo "google-services.json written ($(wc -c < google-services.json) bytes)"
-          else
+          set -euo pipefail
+          if [ -z "${GOOGLE_SERVICES_JSON:-}" ]; then
             echo "::warning::GOOGLE_SERVICES_JSON secret not set — push notifications won't work in this APK"
+            exit 0
           fi
+          tmp=$(mktemp)
+          trimmed=$(printf '%s' "$GOOGLE_SERVICES_JSON" | tr -d '[:space:]')
+          case "$trimmed" in
+            '{'*)
+              # Raw JSON paste — keep whitespace so Gson's error offsets
+              # still line up with the operator's source file.
+              printf '%s' "$GOOGLE_SERVICES_JSON" > "$tmp"
+              echo "Detected raw-JSON secret"
+              ;;
+            *)
+              if ! printf '%s' "$trimmed" | base64 -d > "$tmp" 2>/dev/null; then
+                echo "::error::GOOGLE_SERVICES_JSON is neither valid JSON nor valid base64. Re-encode with: base64 -w0 plant-swipe/android/app/google-services.json"
+                exit 1
+              fi
+              echo "Detected base64 secret"
+              ;;
+          esac
+          if ! jq empty "$tmp" >/dev/null 2>&1; then
+            echo "::error::Decoded GOOGLE_SERVICES_JSON is not valid JSON ($(wc -c < "$tmp") bytes). First 120 chars: $(head -c 120 "$tmp")"
+            exit 1
+          fi
+          mv "$tmp" google-services.json
+          echo "google-services.json written ($(wc -c < google-services.json) bytes, project_number=$(jq -r .project_info.project_number google-services.json))"
 
       - name: Build PWA + cap sync
         run: bun run build:cap
@@ -264,12 +293,32 @@ jobs:
           GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
         working-directory: plant-swipe/android/app
         run: |
-          if [ -n "${GOOGLE_SERVICES_JSON:-}" ]; then
-            echo "$GOOGLE_SERVICES_JSON" | base64 -d > google-services.json
-            echo "google-services.json written ($(wc -c < google-services.json) bytes)"
-          else
+          set -euo pipefail
+          if [ -z "${GOOGLE_SERVICES_JSON:-}" ]; then
             echo "::warning::GOOGLE_SERVICES_JSON secret not set — push notifications won't work in this APK"
+            exit 0
           fi
+          tmp=$(mktemp)
+          trimmed=$(printf '%s' "$GOOGLE_SERVICES_JSON" | tr -d '[:space:]')
+          case "$trimmed" in
+            '{'*)
+              printf '%s' "$GOOGLE_SERVICES_JSON" > "$tmp"
+              echo "Detected raw-JSON secret"
+              ;;
+            *)
+              if ! printf '%s' "$trimmed" | base64 -d > "$tmp" 2>/dev/null; then
+                echo "::error::GOOGLE_SERVICES_JSON is neither valid JSON nor valid base64. Re-encode with: base64 -w0 plant-swipe/android/app/google-services.json"
+                exit 1
+              fi
+              echo "Detected base64 secret"
+              ;;
+          esac
+          if ! jq empty "$tmp" >/dev/null 2>&1; then
+            echo "::error::Decoded GOOGLE_SERVICES_JSON is not valid JSON ($(wc -c < "$tmp") bytes). First 120 chars: $(head -c 120 "$tmp")"
+            exit 1
+          fi
+          mv "$tmp" google-services.json
+          echo "google-services.json written ($(wc -c < google-services.json) bytes, project_number=$(jq -r .project_info.project_number google-services.json))"
 
       - name: Build PWA + cap sync
         run: bun run build:cap

--- a/.github/workflows/capacitor-mobile.yml
+++ b/.github/workflows/capacitor-mobile.yml
@@ -5,7 +5,7 @@
 #
 # Optional secrets:
 #   ANDROID_KEYSTORE_BASE64, ANDROID_KEYSTORE_PASSWORD, ANDROID_KEY_ALIAS, ANDROID_KEY_PASSWORD
-#   GOOGLE_SERVICES_JSON (raw or base64-encoded google-services.json)
+#   GOOGLE_SERVICES_JSON (raw or base64-encoded google-services.json — the file must register package `app.aphylia` in Firebase)
 #   APPLE_*, MATCH_*, etc.
 
 name: Capacitor mobile

--- a/.github/workflows/capacitor-mobile.yml
+++ b/.github/workflows/capacitor-mobile.yml
@@ -171,6 +171,26 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Materialise google-services.json from secret
+        # FCM push delivery requires `android/app/google-services.json`, which
+        # is gitignored.  Stored as a base64 GitHub secret
+        # (`GOOGLE_SERVICES_JSON`) so the file lives only on the runner and
+        # never in the repo.  Without the secret the build still completes —
+        # the Gradle `google-services` plugin is applied conditionally and the
+        # runtime stub in `MainActivity.ensureFirebaseAppInitialized()` keeps
+        # the app from crashing — but push notifications won't actually
+        # deliver.
+        env:
+          GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+        working-directory: plant-swipe/android/app
+        run: |
+          if [ -n "${GOOGLE_SERVICES_JSON:-}" ]; then
+            echo "$GOOGLE_SERVICES_JSON" | base64 -d > google-services.json
+            echo "google-services.json written ($(wc -c < google-services.json) bytes)"
+          else
+            echo "::warning::GOOGLE_SERVICES_JSON secret not set — push notifications won't work in this APK"
+          fi
+
       - name: Build PWA + cap sync
         run: bun run build:cap
         env:
@@ -238,6 +258,18 @@ jobs:
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
+
+      - name: Materialise google-services.json from secret
+        env:
+          GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+        working-directory: plant-swipe/android/app
+        run: |
+          if [ -n "${GOOGLE_SERVICES_JSON:-}" ]; then
+            echo "$GOOGLE_SERVICES_JSON" | base64 -d > google-services.json
+            echo "google-services.json written ($(wc -c < google-services.json) bytes)"
+          else
+            echo "::warning::GOOGLE_SERVICES_JSON secret not set — push notifications won't work in this APK"
+          fi
 
       - name: Build PWA + cap sync
         run: bun run build:cap

--- a/plant-swipe/.gitignore
+++ b/plant-swipe/.gitignore
@@ -26,6 +26,7 @@ package-lock.json
 .env.server
 .env.server.*
 ga4_keyfile.json
+fcm_keyfile.json
 
 # Generated files
 public/sitemap.xml

--- a/plant-swipe/android/app/src/main/java/app/aphylia/MainActivity.java
+++ b/plant-swipe/android/app/src/main/java/app/aphylia/MainActivity.java
@@ -34,6 +34,27 @@ public class MainActivity extends BridgeActivity {
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
+        // The distributed APK is built by CI without a `google-services.json`
+        // (the file is gitignored and no CI secret materialises it).  That means
+        // `FirebaseInitProvider` never finishes wiring up a default
+        // `FirebaseApp`, so the first call to `FirebaseMessaging.getInstance()`
+        // — which Capacitor's push plugin makes from `register()` as soon as the
+        // user grants POST_NOTIFICATIONS — throws `IllegalStateException` on
+        // the UI thread and the OS force-closes the app.  From then on every
+        // launch retries the registration (permission is already granted) and
+        // crashes the same way, producing the reported "accept notifications →
+        // crash loop on every open" behaviour.
+        //
+        // We can't ship a real Firebase config without a Firebase project +
+        // CI secret, so instead we prime a *stub* default FirebaseApp with
+        // harmless placeholder credentials.  That keeps `getInstance()` from
+        // throwing; the subsequent `getToken()` still fails — but *asynchronously*
+        // inside FCM, which the Capacitor plugin surfaces as a benign
+        // `registrationError` event on the JS side.  The app stays up; push
+        // delivery simply doesn't work until a real `google-services.json` is
+        // wired in.  Permission grant no longer kills the app.
+        ensureFirebaseAppInitialized();
+
         // Neuter service workers inside the Capacitor WebView before the bridge
         // starts. Earlier builds of the app registered a PWA service worker
         // whose `notificationclick` handler called `clients.openWindow()` — in
@@ -73,6 +94,61 @@ public class MainActivity extends BridgeActivity {
     protected void onNewIntent(Intent intent) {
         super.onNewIntent(intent);
         consumeFcmNotificationExtras(intent);
+    }
+
+    /**
+     * If the Google Services Gradle plugin didn't run (no `google-services.json`
+     * at build time), the `google_app_id` string resource is absent and
+     * `FirebaseInitProvider` silently skips initialisation.  We then register
+     * a stub default app so downstream code that calls
+     * `FirebaseApp.getInstance()` / `FirebaseMessaging.getInstance()` doesn't
+     * throw.  Done reflectively so this source still compiles in environments
+     * where Firebase classes aren't on the compileOnly classpath.
+     */
+    private void ensureFirebaseAppInitialized() {
+        try {
+            Class<?> firebaseAppCls = Class.forName("com.google.firebase.FirebaseApp");
+            // FirebaseApp.getApps(Context) returns any already-initialised apps.
+            Object apps = firebaseAppCls
+                .getMethod("getApps", android.content.Context.class)
+                .invoke(null, getApplicationContext());
+            if (apps instanceof java.util.List && !((java.util.List<?>) apps).isEmpty()) {
+                return;
+            }
+
+            // Platform already wired Firebase up via the Gradle plugin? Nothing to do.
+            int googleAppIdRes = getResources()
+                .getIdentifier("google_app_id", "string", getPackageName());
+            if (googleAppIdRes != 0) {
+                // Resource exists — let FirebaseInitProvider handle it.
+                return;
+            }
+
+            Class<?> optionsCls = Class.forName("com.google.firebase.FirebaseOptions");
+            Class<?> builderCls = Class.forName("com.google.firebase.FirebaseOptions$Builder");
+            Object builder = builderCls.getConstructor().newInstance();
+            // These values are deliberately placeholders — FCM token retrieval
+            // will fail, but `FirebaseApp.getInstance()` and
+            // `FirebaseMessaging.getInstance()` will no longer throw, so the
+            // Capacitor push plugin can report the failure via its normal
+            // `registrationError` channel instead of crashing the app.
+            // Application ID format: 1:<sender>:android:<hash>.
+            builder = builderCls.getMethod("setApplicationId", String.class)
+                .invoke(builder, "1:000000000000:android:0000000000000000");
+            builder = builderCls.getMethod("setApiKey", String.class)
+                .invoke(builder, "AIzaSy_stub_key_do_not_use_for_real_requests");
+            builder = builderCls.getMethod("setProjectId", String.class)
+                .invoke(builder, "aphylia-stub-no-fcm");
+            Object options = builderCls.getMethod("build").invoke(builder);
+
+            firebaseAppCls
+                .getMethod("initializeApp", android.content.Context.class, optionsCls)
+                .invoke(null, getApplicationContext(), options);
+        } catch (Throwable ignored) {
+            // Firebase classes genuinely missing, or init failed for another
+            // reason — nothing we can do here.  Push won't work but the app
+            // will still launch, which is what matters.
+        }
     }
 
     private static void consumeFcmNotificationExtras(Intent intent) {

--- a/plant-swipe/docs/BUILD_ANDROID.md
+++ b/plant-swipe/docs/BUILD_ANDROID.md
@@ -2,7 +2,7 @@
 
 Prerequisites: **JDK 21** (CI uses Temurin 21; source/target compatibility remains Java 17 in Gradle), **Android SDK**, **`ANDROID_HOME`** or **`ANDROID_SDK_ROOT`** pointing at the SDK root, **Bun**, **Node** (for `npx cap`).
 
-**Push (FCM):** Place **`google-services.json`** from the Firebase console in **`android/app/`** (gitignored) so Gradle applies the Google Services plugin. The server needs **`FCM_LEGACY_SERVER_KEY`** (or equivalent) to deliver to Android tokens stored in **`user_fcm_tokens`**.
+**Push (FCM):** Place **`google-services.json`** from the Firebase console in **`android/app/`** (gitignored) so Gradle applies the Google Services plugin. The server needs **`FCM_SERVICE_ACCOUNT_JSON`** (the service-account JSON from Firebase console → Project settings → Service accounts → Generate new private key) to deliver via the FCM HTTP v1 API to Android tokens stored in **`user_fcm_tokens`**. The legacy `FCM_LEGACY_SERVER_KEY` endpoint was turned down by Google on 2024-06-20 and is no longer supported.
 
 ## One-time / occasional
 

--- a/plant-swipe/docs/BUILD_ANDROID.md
+++ b/plant-swipe/docs/BUILD_ANDROID.md
@@ -2,7 +2,12 @@
 
 Prerequisites: **JDK 21** (CI uses Temurin 21; source/target compatibility remains Java 17 in Gradle), **Android SDK**, **`ANDROID_HOME`** or **`ANDROID_SDK_ROOT`** pointing at the SDK root, **Bun**, **Node** (for `npx cap`).
 
-**Push (FCM):** Place **`google-services.json`** from the Firebase console in **`android/app/`** (gitignored) so Gradle applies the Google Services plugin. The server needs **`FCM_SERVICE_ACCOUNT_JSON`** (the service-account JSON from Firebase console → Project settings → Service accounts → Generate new private key) to deliver via the FCM HTTP v1 API to Android tokens stored in **`user_fcm_tokens`**. The legacy `FCM_LEGACY_SERVER_KEY` endpoint was turned down by Google on 2024-06-20 and is no longer supported.
+**Push (FCM):** Two files, both gitignored:
+
+- **`android/app/google-services.json`** — Firebase console → your Android app → download. Required at build time so Gradle applies the Google Services plugin.
+- **`fcm_keyfile.json`** (at the repo root, next to `server.js`) — Firebase console → Project settings → Service accounts → Generate new private key. Required at runtime so the server can send via the FCM HTTP v1 API. Auto-detected on startup (no env var needed). Override the path with `FCM_SERVICE_ACCOUNT_FILE=/absolute/path/to/keyfile.json` if you keep credentials outside the repo.
+
+The legacy `FCM_LEGACY_SERVER_KEY` endpoint was turned down by Google on 2024-06-20 and is no longer supported.
 
 ## One-time / occasional
 

--- a/plant-swipe/server.js
+++ b/plant-swipe/server.js
@@ -1406,38 +1406,77 @@ if (vapidPublicKey && vapidPrivateKey) {
  * JSON and mint a short-lived OAuth2 access token against
  * `https://fcm.googleapis.com/v1/projects/<project>/messages:send` instead.
  *
- * Configuration — set **one** of the following env vars to the contents of
- * the service-account JSON downloaded from Firebase console → Project
- * settings → Service accounts → Generate new private key:
+ * Configuration — same pattern as GA4's `ga4_keyfile.json`:
  *
- *   - `FCM_SERVICE_ACCOUNT_JSON`      raw JSON (multi-line secret)
- *   - `FCM_SERVICE_ACCOUNT_JSON_B64`  base64-encoded JSON (single line, friendlier for CI)
- *   - `GOOGLE_APPLICATION_CREDENTIALS_JSON` alias accepted so deployments
- *     that already use the Google Cloud convention don't need a second var.
+ *   1. Drop the service-account JSON (Firebase console → Project settings →
+ *      Service accounts → Generate new private key) into
+ *      `plant-swipe/fcm_keyfile.json`.  The file is gitignored.
+ *   2. That's it.  The server auto-detects `./fcm_keyfile.json` relative to
+ *      `server.js` on startup.
  *
- * Optional:
+ * Overrides (rarely needed):
  *
- *   - `FCM_PROJECT_ID`  overrides `project_id` from the JSON (rarely needed).
+ *   - `FCM_SERVICE_ACCOUNT_FILE`   path to the JSON file (absolute or
+ *                                   relative to `server.js`).  Useful if the
+ *                                   file lives outside the repo — e.g.
+ *                                   `/etc/aphylia/fcm_keyfile.json`.
+ *   - `FCM_SERVICE_ACCOUNT_JSON`        raw JSON (multi-line secret), for
+ *                                        hosts that can't mount files.
+ *   - `FCM_SERVICE_ACCOUNT_JSON_B64`    base64 of the raw JSON.
+ *   - `GOOGLE_APPLICATION_CREDENTIALS_JSON`  alias of the inline form.
+ *   - `FCM_PROJECT_ID`             overrides `project_id` from the JSON.
  *
  * Legacy `FCM_LEGACY_SERVER_KEY` is still read but only logs a deprecation
  * warning — the endpoint it talks to is dead.
  *
  * Docs: https://firebase.google.com/docs/cloud-messaging/migrate-v1
  */
+const FCM_DEFAULT_KEYFILE = 'fcm_keyfile.json'
+
 function loadFcmServiceAccount() {
-  const rawJson = process.env.FCM_SERVICE_ACCOUNT_JSON
-    || process.env.GOOGLE_APPLICATION_CREDENTIALS_JSON
-    || ''
-  const b64Json = process.env.FCM_SERVICE_ACCOUNT_JSON_B64 || ''
-  let text = rawJson.trim()
-  if (!text && b64Json) {
-    try { text = Buffer.from(b64Json.trim(), 'base64').toString('utf8') } catch { text = '' }
+  let text = ''
+  let source = ''
+
+  // 1. File on disk — preferred, matches the `ga4_keyfile.json` convention.
+  //    Explicit path wins; otherwise check for the default filename next to
+  //    server.js.  `__dirname` is already defined higher up in this file.
+  const explicitPath = (process.env.FCM_SERVICE_ACCOUNT_FILE || '').trim()
+  const candidatePath = explicitPath
+    ? (path.isAbsolute(explicitPath) ? explicitPath : path.resolve(__dirname, explicitPath))
+    : path.resolve(__dirname, FCM_DEFAULT_KEYFILE)
+  try {
+    if (fsSync.existsSync(candidatePath)) {
+      text = fsSync.readFileSync(candidatePath, 'utf8')
+      source = candidatePath
+    }
+  } catch (err) {
+    console.warn('[notifications] Failed to read FCM keyfile at', candidatePath, '—', err?.message || err)
   }
+
+  // 2. Inline env vars — fallback for platforms that only expose secrets as
+  //    environment variables (Vercel, some Heroku-style PaaS).
+  if (!text) {
+    const rawJson = process.env.FCM_SERVICE_ACCOUNT_JSON
+      || process.env.GOOGLE_APPLICATION_CREDENTIALS_JSON
+      || ''
+    const b64Json = process.env.FCM_SERVICE_ACCOUNT_JSON_B64 || ''
+    text = rawJson.trim()
+    if (text) source = 'FCM_SERVICE_ACCOUNT_JSON env'
+    if (!text && b64Json) {
+      try {
+        text = Buffer.from(b64Json.trim(), 'base64').toString('utf8')
+        source = 'FCM_SERVICE_ACCOUNT_JSON_B64 env'
+      } catch {
+        text = ''
+      }
+    }
+  }
+
   if (!text) return null
   try {
     const sa = JSON.parse(text)
     if (!sa.client_email || !sa.private_key) {
-      console.warn('[notifications] FCM service account JSON missing client_email or private_key')
+      console.warn(`[notifications] FCM service account (${source}) missing client_email or private_key`)
       return null
     }
     return {
@@ -1446,9 +1485,10 @@ function loadFcmServiceAccount() {
       privateKey: String(sa.private_key).replace(/\\n/g, '\n'),
       projectId: String(process.env.FCM_PROJECT_ID || sa.project_id || '').trim(),
       tokenUri: String(sa.token_uri || 'https://oauth2.googleapis.com/token'),
+      source,
     }
   } catch (err) {
-    console.warn('[notifications] FCM service account JSON parse failed:', err?.message || err)
+    console.warn(`[notifications] FCM service account (${source}) parse failed:`, err?.message || err)
     return null
   }
 }
@@ -1459,11 +1499,11 @@ const fcmLegacyServerKey =
 
 let fcmNativePushEnabled = Boolean(fcmServiceAccount && fcmServiceAccount.projectId)
 if (fcmNativePushEnabled) {
-  console.log(`[notifications] ✓ FCM v1 service account loaded — project ${fcmServiceAccount.projectId} — native push ENABLED`)
+  console.log(`[notifications] ✓ FCM v1 service account loaded from ${fcmServiceAccount.source} — project ${fcmServiceAccount.projectId} — native push ENABLED`)
 } else if (fcmLegacyServerKey) {
-  console.warn('[notifications] FCM_LEGACY_SERVER_KEY is set but the legacy /fcm/send endpoint was turned down on 2024-06-20. Migrate to FCM_SERVICE_ACCOUNT_JSON (HTTP v1).')
+  console.warn('[notifications] FCM_LEGACY_SERVER_KEY is set but the legacy /fcm/send endpoint was turned down on 2024-06-20. Drop a service-account JSON at plant-swipe/fcm_keyfile.json (HTTP v1).')
 } else {
-  console.warn('[notifications] No FCM service account — native tokens will be stored but push delivery is disabled until FCM_SERVICE_ACCOUNT_JSON is configured')
+  console.warn('[notifications] No FCM service account — native tokens will be stored but push delivery is disabled. Place the service-account JSON at plant-swipe/fcm_keyfile.json.')
 }
 
 /**

--- a/plant-swipe/server.js
+++ b/plant-swipe/server.js
@@ -1398,14 +1398,72 @@ if (vapidPublicKey && vapidPrivateKey) {
   if (!vapidPrivateKey) console.warn('[notifications]   Missing: VAPID_PRIVATE_KEY')
 }
 
-/** FCM legacy HTTP API (server key) for Capacitor native tokens; optional. See https://firebase.google.com/docs/cloud-messaging/http-server-ref */
+/**
+ * FCM HTTP v1 for Capacitor native tokens.
+ *
+ * The legacy `/fcm/send` endpoint + server-key auth was permanently turned
+ * down by Google on 2024-06-20, so we authenticate with a service-account
+ * JSON and mint a short-lived OAuth2 access token against
+ * `https://fcm.googleapis.com/v1/projects/<project>/messages:send` instead.
+ *
+ * Configuration — set **one** of the following env vars to the contents of
+ * the service-account JSON downloaded from Firebase console → Project
+ * settings → Service accounts → Generate new private key:
+ *
+ *   - `FCM_SERVICE_ACCOUNT_JSON`      raw JSON (multi-line secret)
+ *   - `FCM_SERVICE_ACCOUNT_JSON_B64`  base64-encoded JSON (single line, friendlier for CI)
+ *   - `GOOGLE_APPLICATION_CREDENTIALS_JSON` alias accepted so deployments
+ *     that already use the Google Cloud convention don't need a second var.
+ *
+ * Optional:
+ *
+ *   - `FCM_PROJECT_ID`  overrides `project_id` from the JSON (rarely needed).
+ *
+ * Legacy `FCM_LEGACY_SERVER_KEY` is still read but only logs a deprecation
+ * warning — the endpoint it talks to is dead.
+ *
+ * Docs: https://firebase.google.com/docs/cloud-messaging/migrate-v1
+ */
+function loadFcmServiceAccount() {
+  const rawJson = process.env.FCM_SERVICE_ACCOUNT_JSON
+    || process.env.GOOGLE_APPLICATION_CREDENTIALS_JSON
+    || ''
+  const b64Json = process.env.FCM_SERVICE_ACCOUNT_JSON_B64 || ''
+  let text = rawJson.trim()
+  if (!text && b64Json) {
+    try { text = Buffer.from(b64Json.trim(), 'base64').toString('utf8') } catch { text = '' }
+  }
+  if (!text) return null
+  try {
+    const sa = JSON.parse(text)
+    if (!sa.client_email || !sa.private_key) {
+      console.warn('[notifications] FCM service account JSON missing client_email or private_key')
+      return null
+    }
+    return {
+      clientEmail: String(sa.client_email),
+      // Env vars often arrive with escaped newlines — normalise so jsonwebtoken can parse the PEM.
+      privateKey: String(sa.private_key).replace(/\\n/g, '\n'),
+      projectId: String(process.env.FCM_PROJECT_ID || sa.project_id || '').trim(),
+      tokenUri: String(sa.token_uri || 'https://oauth2.googleapis.com/token'),
+    }
+  } catch (err) {
+    console.warn('[notifications] FCM service account JSON parse failed:', err?.message || err)
+    return null
+  }
+}
+
+const fcmServiceAccount = loadFcmServiceAccount()
 const fcmLegacyServerKey =
   process.env.FCM_LEGACY_SERVER_KEY || process.env.FIREBASE_SERVER_KEY || process.env.GCM_API_KEY || ''
-let fcmNativePushEnabled = Boolean(fcmLegacyServerKey)
+
+let fcmNativePushEnabled = Boolean(fcmServiceAccount && fcmServiceAccount.projectId)
 if (fcmNativePushEnabled) {
-  console.log('[notifications] ✓ FCM legacy server key present — native (Capacitor) push delivery ENABLED')
+  console.log(`[notifications] ✓ FCM v1 service account loaded — project ${fcmServiceAccount.projectId} — native push ENABLED`)
+} else if (fcmLegacyServerKey) {
+  console.warn('[notifications] FCM_LEGACY_SERVER_KEY is set but the legacy /fcm/send endpoint was turned down on 2024-06-20. Migrate to FCM_SERVICE_ACCOUNT_JSON (HTTP v1).')
 } else {
-  console.warn('[notifications] FCM_LEGACY_SERVER_KEY not set — native app tokens stored but server will not send FCM until configured')
+  console.warn('[notifications] No FCM service account — native tokens will be stored but push delivery is disabled until FCM_SERVICE_ACCOUNT_JSON is configured')
 }
 
 /**
@@ -1415,44 +1473,135 @@ if (fcmNativePushEnabled) {
  */
 const FCM_ANDROID_CHANNEL_ID = 'aphylia_priority'
 
-async function sendFcmLegacyToToken(token, { title, body, data }) {
-  if (!fcmLegacyServerKey || !token) return { ok: false }
+/**
+ * Cache the OAuth2 access token for the lifetime the token server gives us
+ * (typically 1 h), minus a 60 s safety margin.  A stale token would just
+ * return 401 on the next send; refreshing proactively avoids that round trip.
+ */
+let fcmAccessTokenCache = { token: '', exp: 0 }
+
+async function getFcmV1AccessToken() {
+  if (!fcmServiceAccount) return null
+  const nowSec = Math.floor(Date.now() / 1000)
+  if (fcmAccessTokenCache.token && fcmAccessTokenCache.exp > nowSec + 60) {
+    return fcmAccessTokenCache.token
+  }
+  let assertion
+  try {
+    assertion = jwt.sign(
+      {
+        iss: fcmServiceAccount.clientEmail,
+        scope: 'https://www.googleapis.com/auth/firebase.messaging',
+        aud: fcmServiceAccount.tokenUri,
+        iat: nowSec,
+        exp: nowSec + 3600,
+      },
+      fcmServiceAccount.privateKey,
+      { algorithm: 'RS256' },
+    )
+  } catch (err) {
+    console.warn('[notifications] FCM JWT sign failed:', err?.message || err)
+    return null
+  }
+  let res
+  try {
+    res = await fetch(fcmServiceAccount.tokenUri, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+        assertion,
+      }).toString(),
+    })
+  } catch (err) {
+    console.warn('[notifications] FCM token exchange network error:', err?.message || err)
+    return null
+  }
+  if (!res.ok) {
+    const body = await res.text().catch(() => '')
+    console.warn('[notifications] FCM token exchange failed:', res.status, body.slice(0, 500))
+    return null
+  }
+  const json = await res.json().catch(() => null)
+  if (!json?.access_token) return null
+  fcmAccessTokenCache = {
+    token: String(json.access_token),
+    exp: nowSec + (Number(json.expires_in) || 3600),
+  }
+  return fcmAccessTokenCache.token
+}
+
+async function sendFcmToToken(token, { title, body, data }) {
+  if (!fcmServiceAccount?.projectId || !token) return { ok: false, error: 'fcm_not_configured' }
+  const access = await getFcmV1AccessToken()
+  if (!access) return { ok: false, error: 'fcm_no_access_token' }
+
+  // The v1 API requires every `data` value to be a string.
   const dataStrings = {}
   if (data && typeof data === 'object') {
     for (const [k, v] of Object.entries(data)) {
       dataStrings[k] = v === undefined || v === null ? '' : String(v)
     }
   }
-  const res = await fetch('https://fcm.googleapis.com/fcm/send', {
-    method: 'POST',
-    headers: {
-      Authorization: `key=${fcmLegacyServerKey}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      to: token,
-      priority: 'high',
-      // `content_available: true` wakes iOS apps from background so the APNs
-      // path can hand off to the Capacitor push listener.  Ignored on Android.
-      content_available: true,
+
+  const message = {
+    token,
+    notification: { title, body },
+    data: dataStrings,
+    android: {
+      priority: 'HIGH',
       // Best-effort delivery window — Doze-mode reminders shouldn't linger
       // more than a day past their schedule.
-      time_to_live: 60 * 60 * 24,
+      ttl: '86400s',
       notification: {
-        title,
-        body,
-        android_channel_id: FCM_ANDROID_CHANNEL_ID,
+        channel_id: FCM_ANDROID_CHANNEL_ID,
         sound: 'default',
       },
-      data: dataStrings,
-    }),
-  })
+    },
+    apns: {
+      headers: { 'apns-priority': '10' },
+      payload: {
+        aps: {
+          alert: { title, body },
+          sound: 'default',
+          // `content-available: 1` wakes an iOS app in the background so the
+          // Capacitor push listener can fire.  The primary iOS path is
+          // `sendApnsToDevice()` below; this only matters if an iOS token
+          // somehow gets routed through FCM.
+          'content-available': 1,
+        },
+      },
+    },
+  }
+
+  const endpoint = `https://fcm.googleapis.com/v1/projects/${encodeURIComponent(fcmServiceAccount.projectId)}/messages:send`
+  let res
+  try {
+    res = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${access}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ message }),
+    })
+  } catch (err) {
+    return { ok: false, error: `network:${err?.message || 'unknown'}` }
+  }
   const json = await res.json().catch(() => ({}))
-  if (!res.ok || json.failure === 1 || json.failure === '1') {
-    return { ok: false, error: json?.results?.[0]?.error || json?.error || res.statusText }
+  if (!res.ok) {
+    // v1 errors: { error: { code, message, status, details: [{ errorCode: 'UNREGISTERED' | … }] } }
+    const errorCode = json?.error?.details?.find?.((d) => d?.errorCode)?.errorCode
+      || json?.error?.status
+      || json?.error?.message
+      || res.statusText
+    return { ok: false, error: String(errorCode) }
   }
   return { ok: true }
 }
+
+// Back-compat alias — older call sites still reference the legacy name.
+const sendFcmLegacyToToken = sendFcmToToken
 
 const apnsKeyId = process.env.APNS_KEY_ID || ''
 const apnsTeamId = process.env.APNS_TEAM_ID || ''
@@ -26139,7 +26288,7 @@ app.post('/api/push/instant', async (req, res) => {
         ok = r.ok
         errMsg = String(r.error || '')
       } else {
-        const r = await sendFcmLegacyToToken(token, {
+        const r = await sendFcmToToken(token, {
           title,
           body,
           data: { ...pushData, tag: notificationTag },
@@ -26151,7 +26300,10 @@ app.post('/api/push/instant', async (req, res) => {
         sent = true
         successCount += 1
       } else {
-        if (/NotRegistered|InvalidRegistration|MismatchSenderId|BadDeviceToken|Unregistered/i.test(errMsg)) {
+        // Covers both legacy and v1 error vocabularies: `NotRegistered` /
+        // `InvalidRegistration` (legacy) and `UNREGISTERED` /
+        // `INVALID_ARGUMENT` / `SENDER_ID_MISMATCH` (v1).
+        if (/NotRegistered|InvalidRegistration|MismatchSenderId|BadDeviceToken|Unregistered|UNREGISTERED|INVALID_ARGUMENT|SENDER_ID_MISMATCH/i.test(errMsg)) {
           staleFcmTokens.push(token)
         }
         console.warn(`[push/instant] native push failed …${token.slice(-8)} (${plat}):`, errMsg)

--- a/plant-swipe/src/hooks/usePushSubscription.ts
+++ b/plant-swipe/src/hooks/usePushSubscription.ts
@@ -259,7 +259,9 @@ export function usePushSubscription(userId: string | null) {
       setOptOut(userId, false)
       if (native) {
         const { registerNativePushForCurrentUser } = await import('@/lib/nativePushRegistration')
-        await registerNativePushForCurrentUser()
+        // Explicit user gesture — clear any previously-recorded failure so a
+        // user who re-enables push after a FCM config fix gets a retry.
+        await registerNativePushForCurrentUser({ force: true })
       } else {
         await requestNotificationPermission()
         await registerPushSubscription()

--- a/plant-swipe/src/lib/nativePushRegistration.ts
+++ b/plant-swipe/src/lib/nativePushRegistration.ts
@@ -51,6 +51,16 @@ const PENDING_TAP_KEY = 'plantswipe.push.pendingTap'
 const PENDING_TAP_TTL_MS = 10 * 60 * 1000 // 10 minutes — enough for a crash-restart
 const FCM_TOKEN_CACHE_KEY = 'plantswipe.push.lastFcmToken'
 const ANDROID_CHANNEL_ID = 'aphylia_priority'
+/**
+ * When `PushNotifications.register()` throws (e.g. the APK was built without a
+ * `google-services.json`, so FCM can't hand us a token), we mark the device as
+ * unsupported and skip every future automatic `register()` call.  Without this
+ * flag the `AuthContext` effect would re-enter the failing path on every cold
+ * launch, which on Android 13+ re-trips whatever native-side instability
+ * caused the first crash.  Cleared if the user explicitly re-enables push
+ * from Settings — see `registerNativePushForCurrentUser({ force: true })`.
+ */
+const PUSH_DISABLED_KEY = 'plantswipe.push.disabledReason'
 
 /**
  * De-duplicate tap events. Android's push plugin reads the FCM extras during
@@ -129,6 +139,36 @@ function readCachedFcmToken(): string | null {
     return v && v.length > 0 ? v : null
   } catch {
     return null
+  }
+}
+
+function markPushDisabled(reason: string): void {
+  const store = safeLocalStorage()
+  if (!store) return
+  try {
+    store.setItem(PUSH_DISABLED_KEY, reason.slice(0, 256))
+  } catch {
+    /* ignore */
+  }
+}
+
+function isPushDisabled(): boolean {
+  const store = safeLocalStorage()
+  if (!store) return false
+  try {
+    return store.getItem(PUSH_DISABLED_KEY) !== null
+  } catch {
+    return false
+  }
+}
+
+function clearPushDisabled(): void {
+  const store = safeLocalStorage()
+  if (!store) return
+  try {
+    store.removeItem(PUSH_DISABLED_KEY)
+  } catch {
+    /* ignore */
   }
 }
 
@@ -337,6 +377,17 @@ export async function initializeNativePushListeners(): Promise<void> {
 
     await PushNotifications.addListener('registrationError', (err) => {
       if (import.meta.env.DEV) console.warn('[native push] registration error', err)
+      // FCM couldn't issue a token — typically because the APK was built
+      // without a valid `google-services.json`. Trip the kill switch so we
+      // don't re-enter `register()` on the next launch (where the same
+      // failure historically crashed the app inside the native Firebase
+      // pipeline on Android 13+).
+      try {
+        const msg = (err as { error?: unknown })?.error
+        markPushDisabled(typeof msg === 'string' ? msg : 'registration-error')
+      } catch {
+        markPushDisabled('registration-error')
+      }
     })
 
     await PushNotifications.addListener('pushNotificationReceived', (notification) => {
@@ -381,11 +432,31 @@ export async function initializeNativePushListeners(): Promise<void> {
  * Register the device with FCM/APNs and upload the token for the signed-in
  * user.  Called from AuthContext after auth resolves.  Safe to call multiple
  * times — the plugin dedupes its own registration internally.
+ *
+ * Pass `{ force: true }` from an explicit user gesture (e.g. toggling the
+ * Settings switch) to clear any previously-recorded registration failure.
+ * Automatic call sites should leave `force` unset so we don't re-trigger a
+ * failing `register()` on every launch.
  */
-export async function registerNativePushForCurrentUser(): Promise<void> {
+export async function registerNativePushForCurrentUser(
+  options: { force?: boolean } = {},
+): Promise<void> {
   if (!Capacitor.isNativePlatform()) return
   // Listeners must be attached before `register()` fires an event.
   await initializeNativePushListeners()
+
+  if (options.force) {
+    clearPushDisabled()
+  } else if (isPushDisabled()) {
+    // A previous attempt errored out (most commonly: the APK shipped without a
+    // real `google-services.json`, so FCM can't mint a token).  Re-entering
+    // `register()` is what crashed the app on every subsequent launch, so
+    // stay out of that path until the user explicitly re-enables push.
+    if (import.meta.env.DEV) {
+      console.info('[native push] skipping register — previously disabled after error')
+    }
+    return
+  }
 
   try {
     const { PushNotifications } = await import('@capacitor/push-notifications')
@@ -395,7 +466,17 @@ export async function registerNativePushForCurrentUser(): Promise<void> {
       const req = await PushNotifications.requestPermissions()
       if (req.receive !== 'granted') return
     }
-    await PushNotifications.register()
+    try {
+      await PushNotifications.register()
+    } catch (registerErr) {
+      // `register()` rejected synchronously (native plugin threw before
+      // dispatching to FCM).  Record the failure so we don't loop back in
+      // here on the next cold launch.
+      markPushDisabled(
+        (registerErr as Error)?.message || 'register-threw',
+      )
+      throw registerErr
+    }
     pushRegisteredForUser = true
 
     // If we cached a token earlier (e.g. before the user signed in) push it

--- a/plant-swipe/src/lib/pushNotifications.ts
+++ b/plant-swipe/src/lib/pushNotifications.ts
@@ -69,7 +69,7 @@ async function syncSubscriptionWithServer(subscription: PushSubscription): Promi
 export async function registerPushSubscription(force = false): Promise<PushSubscription> {
   if (Capacitor.isNativePlatform()) {
     const { registerNativePushForCurrentUser } = await import('@/lib/nativePushRegistration')
-    await registerNativePushForCurrentUser()
+    await registerNativePushForCurrentUser({ force })
     return null as unknown as PushSubscription
   }
   if (typeof window === 'undefined' || !isPlatformWebPushSupported()) {

--- a/plant-swipe/src/pages/SetupPage.tsx
+++ b/plant-swipe/src/pages/SetupPage.tsx
@@ -417,7 +417,9 @@ export function SetupPage() {
       if (isNativeCapacitor()) {
         // Use Capacitor native push API — Web Notification API doesn't control native notifications
         const { registerNativePushForCurrentUser } = await import('@/lib/nativePushRegistration')
-        await registerNativePushForCurrentUser()
+        // Setup is the first explicit user gesture to enable push; treat it
+        // as a fresh opt-in so any previously-recorded failure is cleared.
+        await registerNativePushForCurrentUser({ force: true })
         console.log('[setup] Native push registration completed')
       } else if ('Notification' in window) {
         const permission = await Notification.requestPermission()

--- a/setup.sh
+++ b/setup.sh
@@ -2607,6 +2607,13 @@ if [[ ! -f "$NODE_DIR/ga4_keyfile.json" ]]; then
   log "       Then set GA4_PROPERTY_ID in .env.server"
 fi
 
+if [[ ! -f "$NODE_DIR/fcm_keyfile.json" ]]; then
+  log "[WARN] Missing $NODE_DIR/fcm_keyfile.json — Android (Capacitor) push notifications will not deliver."
+  log "       To enable: Firebase console → Project settings → Service accounts →"
+  log "       Generate new private key, and place the downloaded JSON at"
+  log "       $NODE_DIR/fcm_keyfile.json (no env var needed — auto-detected)."
+fi
+
 # --- Post-setup: Capacitor / mobile pipeline report ---
 print_capacitor_setup_report() {
   local web_disk android_disk ios_disk
@@ -2668,7 +2675,11 @@ Next steps:
    - Add to plant-swipe/.env.server:
      GA4_PROPERTY_ID=<your-numeric-property-id>
      GOOGLE_APPLICATION_CREDENTIALS=./ga4_keyfile.json
-4) Then run:
+4) Android push notifications (optional, required for Capacitor FCM):
+   - Place your Firebase service account key at plant-swipe/fcm_keyfile.json
+     (Firebase console → Project settings → Service accounts → Generate new private key)
+   - The server auto-detects the file; no env var required.
+5) Then run:
    sudo bash scripts/refresh-plant-swipe.sh
 
 Admin API endpoints are proxied at /admin/* per nginx snippet.


### PR DESCRIPTION
## Summary

Migrates Android (Capacitor) push notification delivery from Google's deprecated FCM legacy HTTP API (shut down 2024-06-20) to the current FCM HTTP v1 API with OAuth2 service-account authentication. Also adds resilience to handle APKs built without a valid `google-services.json` by stubbing Firebase initialization on Android.

## Key Changes

**Server-side (Node.js):**
- Replaced `FCM_LEGACY_SERVER_KEY` authentication with service-account JSON loading from `fcm_keyfile.json` or environment variables (`FCM_SERVICE_ACCOUNT_JSON`, `FCM_SERVICE_ACCOUNT_JSON_B64`, `GOOGLE_APPLICATION_CREDENTIALS_JSON`)
- Implemented OAuth2 access token minting via JWT bearer flow with automatic refresh and caching (60s safety margin before expiry)
- Updated FCM message format to v1 API structure with proper Android (`priority: HIGH`, `ttl`, `channel_id`) and APNs (`content-available`, `apns-priority`) payloads
- Updated error handling to recognize both legacy (`NotRegistered`, `InvalidRegistration`) and v1 (`UNREGISTERED`, `INVALID_ARGUMENT`, `SENDER_ID_MISMATCH`) error codes
- Kept `FCM_LEGACY_SERVER_KEY` reading for backward compatibility with deprecation warning

**Client-side (TypeScript/React):**
- Added kill-switch mechanism (`PUSH_DISABLED_KEY`) to prevent crash loops when `PushNotifications.register()` fails (e.g., missing `google-services.json`)
- Tracks registration failures and skips automatic re-registration on subsequent launches unless explicitly forced by user gesture
- Updated `registerNativePushForCurrentUser()` to accept `{ force: true }` option for explicit user re-enablement from Settings

**Android (Java):**
- Added `ensureFirebaseAppInitialized()` stub initialization in `MainActivity.onCreate()` that registers a placeholder Firebase app when `google-services.json` is absent
- Prevents `IllegalStateException` crash when Capacitor's push plugin calls `FirebaseMessaging.getInstance()` without a real Firebase config
- Allows graceful degradation: permission grant no longer crashes the app; push simply fails asynchronously as a `registrationError` event

**CI/Build:**
- Added GitHub Actions step to materialize `google-services.json` from base64-encoded secret (`GOOGLE_SERVICES_JSON`) into `android/app/` at build time
- Applied to both APK and AAB build jobs
- Includes warning when secret is not set (push won't work but build succeeds)

**Documentation & Setup:**
- Updated `setup.sh` to warn about missing `fcm_keyfile.json` and provide Firebase console instructions
- Updated `BUILD_ANDROID.md` to document both required files (`google-services.json` and `fcm_keyfile.json`) and their sources
- Added `fcm_keyfile.json` to `.gitignore`

## Notable Implementation Details

- Service account loading follows the same pattern as existing `ga4_keyfile.json` (file-first, then env var fallback)
- OAuth2 token caching avoids redundant token exchanges; stale tokens are proactively refreshed 60s before expiry
- Android stub Firebase app uses placeholder credentials (`aphylia-stub-no-fcm` project ID) to satisfy `getInstance()` calls without enabling real FCM
- Error vocabulary bridging ensures token cleanup logic works across both legacy and v1 API error responses
- All changes are backward compatible; legacy server key is still read but logs a deprecation notice

https://claude.ai/code/session_01721v6ozdSCyQeKx5pKiuzK