### PR TITLE
Bridge native push notifications into in-app message toasts

### DIFF
--- a/plant-swipe/src/components/messaging/ConversationView.tsx
+++ b/plant-swipe/src/components/messaging/ConversationView.tsx
@@ -467,7 +467,7 @@ export const ConversationView: React.FC<ConversationViewProps> = ({
       // If there's a pending image, upload it and send as image message
       if (pendingImage) {
         const { url } = await uploadMessageImage(pendingImage.file)
-        await sendImageMessage(conversationId, url, content || '', replyingTo?.id)
+        const imageMsg = await sendImageMessage(conversationId, url, content || '', replyingTo?.id)
         
         // Clean up preview URL
         URL.revokeObjectURL(pendingImage.previewUrl)
@@ -485,13 +485,17 @@ export const ConversationView: React.FC<ConversationViewProps> = ({
         // Broadcast to other devices
         broadcastEvent('message', { type: 'image' })
         
-        // Send push notification to recipient (fire and forget but log result)
+        // Send push notification to recipient (fire and forget but log result).
+        // Passing messageId + senderId lets the recipient's foreground in-app
+        // toast dedup against the matching Supabase realtime INSERT.
         sendMessagePushNotification(
           otherUser.id,
           currentUserDisplayName || 'Someone',
           '📷 ' + t('messages.sentImage', { defaultValue: 'Sent an image' }),
           conversationId,
-          recipientLanguage
+          recipientLanguage,
+          imageMsg?.id,
+          currentUserId
         ).then(result => {
           if (!result.sent) {
             console.log('[conversation] Push notification not delivered:', result.reason)
@@ -534,13 +538,17 @@ export const ConversationView: React.FC<ConversationViewProps> = ({
       // Broadcast to other devices
       broadcastEvent('message', { messageId: msg.id })
       
-      // Send push notification to recipient (fire and forget but log result)
+      // Send push notification to recipient (fire and forget but log result).
+      // Passing messageId + senderId lets the recipient's foreground in-app
+      // toast dedup against the matching Supabase realtime INSERT.
       sendMessagePushNotification(
         otherUser.id,
         currentUserDisplayName || 'Someone',
         content.slice(0, 50),
         conversationId,
-        recipientLanguage
+        recipientLanguage,
+        msg?.id,
+        currentUserId
       ).then(result => {
         if (!result.sent) {
           console.log('[conversation] Push notification not delivered:', result.reason)

--- a/plant-swipe/src/hooks/useMessageNotifications.ts
+++ b/plant-swipe/src/hooks/useMessageNotifications.ts
@@ -1,9 +1,20 @@
 /**
  * useMessageNotifications Hook
- * 
- * Listens for new incoming messages via Supabase realtime
- * and triggers in-app toast notifications when the user is not
- * currently viewing the conversation.
+ *
+ * Listens for new incoming messages via both Supabase realtime AND the native
+ * FCM/APNs push pipeline (`plantswipe:push-received` DOM event emitted by
+ * `src/lib/nativePushRegistration.ts`) and triggers in-app toast notifications
+ * when the user is not currently viewing the conversation.
+ *
+ * Why both sources:
+ *   - Supabase realtime requires a working WebSocket; on Capacitor mobile it
+ *     often drops during sleep/background and silently reconnects minutes
+ *     late, so INSERTs that landed mid-sleep never reach the client.
+ *   - The native push pipeline fires `pushNotificationReceived` while the app
+ *     is in foreground — Android suppresses the system tray UI in that case,
+ *     so without this bridge the user sees nothing even though the FCM push
+ *     was delivered.
+ * Dedup is keyed by message id so the two channels can both fire safely.
  */
 
 import React from 'react'
@@ -31,18 +42,33 @@ export function useMessageNotifications({
   const [activeConversationId, setActiveConversationId] = React.useState<string | null>(currentConversationId || null)
   const notificationQueue = React.useRef<MessageNotification[]>([])
   const isShowingNotification = React.useRef(false)
-  
+  // Dedup window shared between the realtime and native-push sources: both
+  // channels fire for the same message, we only want one toast.
+  const seenMessageIds = React.useRef<Set<string>>(new Set())
+  const SEEN_ID_LIMIT = 100
+
+  const rememberMessageId = React.useCallback((id: string | null | undefined): boolean => {
+    if (!id) return true
+    if (seenMessageIds.current.has(id)) return false
+    seenMessageIds.current.add(id)
+    if (seenMessageIds.current.size > SEEN_ID_LIMIT) {
+      const first = seenMessageIds.current.values().next().value
+      if (first) seenMessageIds.current.delete(first)
+    }
+    return true
+  }, [])
+
   // Update active conversation when prop changes
   React.useEffect(() => {
     setActiveConversationId(currentConversationId || null)
   }, [currentConversationId])
-  
+
   // Process notification queue
   const processQueue = React.useCallback(() => {
     if (isShowingNotification.current || notificationQueue.current.length === 0) {
       return
     }
-    
+
     const nextNotification = notificationQueue.current.shift()
     if (nextNotification) {
       isShowingNotification.current = true
@@ -69,7 +95,7 @@ export function useMessageNotifications({
   // Listen for new messages
   React.useEffect(() => {
     if (!userId || !enabled) return
-    
+
     const channel = supabase
       .channel('message-notifications')
       .on(
@@ -82,17 +108,20 @@ export function useMessageNotifications({
         async (payload) => {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const newMessage = payload.new as any
-          
+
           // Skip if message is from current user
           if (newMessage.sender_id === userId) {
             return
           }
-          
+
           // Skip if user is currently viewing this conversation
           if (activeConversationId === newMessage.conversation_id) {
             return
           }
-          
+
+          // Skip if a native push with the same message id already enqueued a toast
+          if (!rememberMessageId(newMessage.id)) return
+
           // Check if this conversation involves the current user
           try {
             const { data: conversation } = await supabase
@@ -100,21 +129,21 @@ export function useMessageNotifications({
               .select('id, participant_1, participant_2')
               .eq('id', newMessage.conversation_id)
               .single()
-            
+
             if (!conversation) return
-            
+
             // Check if user is a participant
             if (conversation.participant_1 !== userId && conversation.participant_2 !== userId) {
               return
             }
-            
+
             // Get sender profile
             const { data: senderProfile } = await supabase
               .from('profiles')
               .select('id, display_name, avatar_url')
               .eq('id', newMessage.sender_id)
               .single()
-            
+
             // Create notification
             const messageNotification: MessageNotification = {
               id: newMessage.id,
@@ -125,22 +154,79 @@ export function useMessageNotifications({
               content: newMessage.content || '',
               createdAt: newMessage.created_at
             }
-            
+
             // Add to queue
             notificationQueue.current.push(messageNotification)
             processQueue()
-            
+
           } catch (error) {
             console.warn('[message-notifications] Error processing message:', error)
           }
         }
       )
       .subscribe()
-    
+
     return () => {
       supabase.removeChannel(channel)
     }
-  }, [userId, enabled, activeConversationId, processQueue])
+  }, [userId, enabled, activeConversationId, processQueue, rememberMessageId])
+
+  // Bridge native FCM/APNs foreground pushes into the same in-app toast queue.
+  // `nativePushRegistration.ts` emits `plantswipe:push-received` whenever a push
+  // lands while the app is visible — Android suppresses the system tray UI in
+  // that state so without this the user sees nothing.
+  React.useEffect(() => {
+    if (!enabled || typeof window === 'undefined') return
+
+    const handlePushReceived = (ev: Event) => {
+      try {
+        const detail = (ev as CustomEvent).detail as
+          | { title?: string; body?: string; data?: Record<string, unknown> }
+          | undefined
+        const data = detail?.data || {}
+        const type = typeof data.type === 'string' ? data.type : undefined
+        if (type !== 'new_message') return
+
+        const conversationId = typeof data.conversationId === 'string' ? data.conversationId : ''
+        if (!conversationId) return
+        if (activeConversationId && activeConversationId === conversationId) return
+        // `currentConversationId === 'all'` means the user is on the messages
+        // list — suppress toasts for every conversation in that case.
+        if (activeConversationId === 'all') return
+
+        const messageId =
+          (typeof data.messageId === 'string' && data.messageId) ||
+          (typeof data['google.message_id'] === 'string' && data['google.message_id']) ||
+          `push-${conversationId}-${Date.now()}`
+        if (!rememberMessageId(messageId)) return
+
+        const senderDisplayName =
+          (typeof data.senderDisplayName === 'string' && data.senderDisplayName) ||
+          detail?.title ||
+          'Someone'
+        const content = detail?.body || (typeof data.body === 'string' ? data.body : '') || ''
+        const senderId = typeof data.senderId === 'string' ? data.senderId : ''
+
+        notificationQueue.current.push({
+          id: messageId,
+          conversationId,
+          senderId,
+          senderDisplayName,
+          senderAvatarUrl: typeof data.senderAvatarUrl === 'string' ? data.senderAvatarUrl : undefined,
+          content,
+          createdAt: new Date().toISOString(),
+        })
+        processQueue()
+      } catch (err) {
+        console.warn('[message-notifications] push bridge failed:', err)
+      }
+    }
+
+    window.addEventListener('plantswipe:push-received', handlePushReceived)
+    return () => {
+      window.removeEventListener('plantswipe:push-received', handlePushReceived)
+    }
+  }, [enabled, activeConversationId, processQueue, rememberMessageId])
   
   return {
     notification,

--- a/plant-swipe/src/lib/messaging.ts
+++ b/plant-swipe/src/lib/messaging.ts
@@ -1388,7 +1388,9 @@ export async function sendMessagePushNotification(
   senderDisplayName: string,
   messagePreview: string,
   conversationId: string,
-  language: string = 'en'
+  language: string = 'en',
+  messageId?: string,
+  senderId?: string
 ): Promise<{ sent: boolean; reason?: string; devicesReached?: number }> {
   const translations: Record<string, { title: string; body: string }> = {
     en: {
@@ -1432,12 +1434,14 @@ export async function sendMessagePushNotification(
         body: t.body,
         tag: `message-${conversationId}`, // Group notifications by conversation
         renotify: true, // Show new notification even if one exists with same tag
-        data: { 
-          conversationId, 
+        data: {
+          conversationId,
           senderDisplayName,
           type: 'new_message',
           url: conversationUrl,
-          ctaUrl: conversationUrl
+          ctaUrl: conversationUrl,
+          ...(messageId ? { messageId } : {}),
+          ...(senderId ? { senderId } : {}),
         }
       })
     })

--- a/plant-swipe/src/pages/AuthPage.tsx
+++ b/plant-swipe/src/pages/AuthPage.tsx
@@ -311,11 +311,23 @@ export function AuthPage({ mode: initialMode = "login" }: AuthPageProps) {
   const privacyPath = "/privacy"
 
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-b from-stone-100 to-stone-200 dark:from-[#1a1a1c] dark:to-[#141415] px-4 py-8 overflow-hidden relative">
+    <div
+      className="relative flex min-h-[100dvh] w-full flex-col overflow-x-hidden overflow-y-auto bg-gradient-to-b from-stone-100 to-stone-200 dark:from-[#1a1a1c] dark:to-[#141415] px-4 pt-8"
+      style={{
+        // When the on-screen keyboard opens we run with `Keyboard.resize: none`,
+        // so the WebView stays full-height and the form would be hidden behind
+        // the keyboard. Padding the bottom by the live keyboard height lets the
+        // form scroll into the visible area above the keys (and icon strip).
+        paddingBottom: "calc(2rem + var(--keyboard-height, 0px))",
+      }}
+    >
       {/* Decorative background glow */}
       <div className="absolute top-1/4 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[500px] h-[500px] bg-emerald-500/8 dark:bg-emerald-500/5 rounded-full blur-[100px] pointer-events-none" />
 
-      <div className="w-full max-w-sm space-y-6 relative z-10">
+      {/* `my-auto` + flex column centers the form vertically when it fits the
+          viewport, but lets it top-align (scrollable) once the keyboard opens
+          and the remaining space is smaller than the form's natural height. */}
+      <div className="relative z-10 my-auto mx-auto w-full max-w-sm space-y-6">
         {/* Logo / Branding */}
         <motion.div
           initial={{ opacity: 0, y: -10 }}
@@ -376,10 +388,11 @@ export function AuthPage({ mode: initialMode = "login" }: AuthPageProps) {
                     {t("auth.displayName")}
                   </Label>
                   <div className="relative">
-                    <User className="absolute left-3.5 top-1/2 -translate-y-1/2 h-4 w-4 text-stone-400 dark:text-stone-500 pointer-events-none" />
+                    <User className="pointer-events-none absolute left-3.5 top-[calc(1.25rem-1px)] z-10 h-4 w-4 -translate-y-1/2 text-stone-500 dark:text-stone-300" />
                     <ValidatedInput
                       id="auth-name"
                       type="text"
+                      autoComplete="username"
                       placeholder={t("auth.displayNamePlaceholder")}
                       value={displayName}
                       onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
@@ -399,10 +412,12 @@ export function AuthPage({ mode: initialMode = "login" }: AuthPageProps) {
                   {t("auth.email")}
                 </Label>
                 <div className="relative">
-                  <Mail className="absolute left-3.5 top-1/2 -translate-y-1/2 h-4 w-4 text-stone-400 dark:text-stone-500 pointer-events-none" />
+                  <Mail className="pointer-events-none absolute left-3.5 top-[calc(1.25rem-1px)] z-10 h-4 w-4 -translate-y-1/2 text-stone-500 dark:text-stone-300" />
                   <ValidatedInput
                     id="auth-email"
                     type="email"
+                    autoComplete="email"
+                    inputMode="email"
                     placeholder={t("auth.emailPlaceholder")}
                     value={email}
                     onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
@@ -427,10 +442,11 @@ export function AuthPage({ mode: initialMode = "login" }: AuthPageProps) {
                   {t("auth.password")}
                 </Label>
                 <div className="relative">
-                  <Lock className="absolute left-3.5 top-1/2 -translate-y-1/2 h-4 w-4 text-stone-400 dark:text-stone-500 pointer-events-none" />
+                  <Lock className="pointer-events-none absolute left-3.5 top-[calc(1.25rem-1px)] z-10 h-4 w-4 -translate-y-1/2 text-stone-500 dark:text-stone-300" />
                   <ValidatedInput
                     id="auth-password"
                     type="password"
+                    autoComplete={isSignup ? "new-password" : "current-password"}
                     placeholder={t("auth.passwordPlaceholder")}
                     value={password}
                     onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
@@ -459,10 +475,11 @@ export function AuthPage({ mode: initialMode = "login" }: AuthPageProps) {
                     {t("auth.confirmPassword")}
                   </Label>
                   <div className="relative">
-                    <Lock className="absolute left-3.5 top-1/2 -translate-y-1/2 h-4 w-4 text-stone-400 dark:text-stone-500 pointer-events-none" />
+                    <Lock className="pointer-events-none absolute left-3.5 top-[calc(1.25rem-1px)] z-10 h-4 w-4 -translate-y-1/2 text-stone-500 dark:text-stone-300" />
                     <ValidatedInput
                       id="auth-confirm"
                       type="password"
+                      autoComplete="new-password"
                       placeholder={t("auth.confirmPasswordPlaceholder")}
                       value={password2}
                       onChange={(e: React.ChangeEvent<HTMLInputElement>) =>

--- a/plant-swipe/src/pages/SwipePage.tsx
+++ b/plant-swipe/src/pages/SwipePage.tsx
@@ -426,11 +426,16 @@ export const SwipePage = React.memo<SwipePageProps>(({
     // ==================== MOBILE LAYOUT ====================
     if (!isDesktop) {
       return (
-        <div 
+        <div
           className="relative w-full swipe-card-container px-2"
-          style={{ 
-            height: 'calc(100dvh - 120px)',
-            minHeight: '450px',
+          style={{
+            // Reserve top chrome (~120px for TopBar + status bar) AND the fixed
+            // MobileNavBar (5.5rem tall + safe-area-inset-bottom). Without the
+            // nav subtraction, `100dvh` extends behind the bottom nav on Android
+            // Capacitor so the bottom of the card (badges, Info button) sits
+            // under the nav bar.
+            height: 'calc(100dvh - 120px - 5.5rem - env(safe-area-inset-bottom, 0px))',
+            minHeight: '380px',
             marginBottom: '8px',
           }}
         >


### PR DESCRIPTION
## Summary
This PR adds support for displaying in-app toast notifications when native push notifications (FCM/APNs) arrive while the app is in the foreground. It also improves the auth page's keyboard handling on mobile and fixes several UI/UX issues.

## Key Changes

### Message Notifications Bridge
- **Dual-source notification handling**: `useMessageNotifications` now listens to both Supabase realtime and native push events (`plantswipe:push-received` DOM event)
- **Deduplication**: Implemented a message ID-based dedup set (capped at 100 entries) to prevent duplicate toasts when the same message arrives via both channels
- **Native push listener**: Added new effect that bridges FCM/APNs foreground pushes into the in-app notification queue, addressing the Android issue where system tray UI is suppressed when the app is visible
- **Push notification enrichment**: Updated `sendMessagePushNotification()` to include `messageId` and `senderId` in push data payload, enabling proper deduplication on the recipient's device

### Auth Page Mobile Improvements
- **Keyboard-aware layout**: Changed from fixed centering to flexible layout that scrolls when keyboard opens
  - Added `--keyboard-height` CSS variable support for dynamic bottom padding
  - Form now uses `my-auto` to center when viewport is large, but top-aligns and becomes scrollable when keyboard reduces available space
- **Input field improvements**:
  - Added proper `autoComplete` attributes (username, email, new-password, current-password)
  - Added `inputMode="email"` to email field for better mobile keyboard
  - Fixed icon positioning to use `top-[calc(1.25rem-1px)]` for pixel-perfect alignment
  - Improved icon colors and z-index layering
- **Viewport fixes**: Changed from `min-h-screen` to `min-h-[100dvh]` and added `overflow-x-hidden` to prevent layout shift

### Conversation View Updates
- **Message ID tracking**: Capture the returned message ID from `sendImageMessage()` to pass to push notification
- **Push notification context**: Pass `messageId` and `senderId` to `sendMessagePushNotification()` for deduplication on recipient's device
- **Documentation**: Added comments explaining the dedup mechanism

### Swipe Page Layout Fix
- **Mobile card height calculation**: Updated to account for both TopBar (~120px) and fixed MobileNavBar (5.5rem + safe-area-inset-bottom), preventing card content from being hidden behind the bottom navigation on Android Capacitor
- **Minimum height adjustment**: Reduced from 450px to 380px to accommodate smaller devices

## Implementation Details
- The dedup mechanism uses a Set that maintains insertion order, automatically removing the oldest entry when exceeding 100 items
- Native push data includes fallbacks for message ID (checking both `messageId` and `google.message_id` fields) and generates a synthetic ID if neither is present
- The native push listener gracefully handles missing or malformed data and logs warnings without crashing
- All changes maintain backward compatibility with existing Supabase realtime flow

https://claude.ai/code/session_01VABGeiaWP6LvXKjQc28vH5