### PR TITLE
Add FileDropZone component for reusable drag-and-drop uploads

### DIFF
--- a/plant-swipe/src/REUSABLE_COMPONENTS.md
+++ b/plant-swipe/src/REUSABLE_COMPONENTS.md
@@ -626,6 +626,65 @@ const images = photos.map(p => ({ src: p.url, alt: p.name }))
 
 ---
 
+### `FileDropZone`
+
+**File:** `src/components/ui/file-drop-zone.tsx`
+
+Shared drag-and-drop upload zone. Wraps any content with drag/drop handlers plus an optional click-to-browse hidden file input. Consumers own the visuals and read drag state via a render prop or `data-dragging` attribute. Behavior is built on top of the `useFileDrop` hook; drag-and-drop is auto-disabled on native Capacitor.
+
+**Props:**
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `onFiles` | `(files: File[]) => void` | — | Receives files that passed `accept` / `maxBytes` filters |
+| `accept` | `string[]` | — | MIME-type prefixes for drop filter (e.g. `["image/"]`) |
+| `acceptInput` | `string` | — | `accept` attribute for the hidden `<input type="file">` |
+| `maxBytes` | `number` | — | Max size per file (oversize files are silently skipped) |
+| `multiple` | `boolean` | `false` | Allow multi-file selection in the picker |
+| `disabled` | `boolean` | `false` | Disable drag and click interactions |
+| `dragEnabled` | `boolean` | `!isNativeCapacitor()` | Force-enable or disable drag handlers |
+| `clickToBrowse` | `boolean` | `true` | Clicking the zone opens the file picker |
+| `dragActiveClassName` | `string` | — | Extra classes applied while a drag is active |
+| `children` | `ReactNode \| (state) => ReactNode` | — | Node or render prop receiving `{ isDragging, openFilePicker }` |
+
+**Imperative handle:** `{ openFilePicker(): void }` (via `ref`).
+
+**Example (render prop):**
+
+```tsx
+import { FileDropZone } from "@/components/ui/file-drop-zone"
+
+<FileDropZone
+  onFiles={(files) => handleUpload(files[0])}
+  accept={["image/"]}
+  acceptInput="image/*"
+  dragActiveClassName="border-emerald-500 bg-emerald-50"
+>
+  {({ isDragging, openFilePicker }) => (
+    <div>
+      <p>{isDragging ? "Drop here" : "Drag a file"}</p>
+      <button onClick={openFilePicker}>Browse</button>
+    </div>
+  )}
+</FileDropZone>
+```
+
+**Example (programmatic picker):**
+
+```tsx
+const ref = React.useRef<FileDropZoneHandle>(null)
+
+<FileDropZone ref={ref} clickToBrowse={false} onFiles={upload}>
+  <Card>…</Card>
+</FileDropZone>
+
+<Button onClick={() => ref.current?.openFilePicker()}>Upload more</Button>
+```
+
+**Used in:** ScanPage (green scan card), AdminUploadPanel (admin media upload).
+
+---
+
 ## Layout Components
 
 ### `TopBar` / `BottomBar` / `MobileNavBar` / `Footer`

--- a/plant-swipe/src/components/admin/AdminUploadPanel.tsx
+++ b/plant-swipe/src/components/admin/AdminUploadPanel.tsx
@@ -9,6 +9,7 @@ import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Switch } from "@/components/ui/switch"
+import { FileDropZone } from "@/components/ui/file-drop-zone"
 import {
   Dialog,
   DialogContent,
@@ -643,14 +644,13 @@ export const AdminUploadPanel: React.FC = () => {
   const [uploadTargetPath, setUploadTargetPath] = React.useState<string | null>(null)
 
   // Upload state
-  const [dragActive, setDragActive] = React.useState(false)
   const [uploading, setUploading] = React.useState(false)
   const [error, setError] = React.useState<string | null>(null)
   const [results, setResults] = React.useState<UploadResult[]>([])
   const [fileQueue, setFileQueue] = React.useState<FileUploadStatus[]>([])
   const [copiedField, setCopiedField] = React.useState<string | null>(null)
   const [optimize, setOptimize] = React.useState(true)
-  const inputRef = React.useRef<HTMLInputElement | null>(null)
+  const dropZoneRef = React.useRef<React.ComponentRef<typeof FileDropZone>>(null)
 
   // Sync upload target with explorer navigation
   const handleNavigate = React.useCallback((path: string) => {
@@ -767,28 +767,6 @@ export const AdminUploadPanel: React.FC = () => {
     [uploadSingleFile],
   )
 
-  const handleDrop = React.useCallback(
-    (event: React.DragEvent<HTMLDivElement>) => {
-      event.preventDefault()
-      event.stopPropagation()
-      setDragActive(false)
-      void handleFiles(Array.from(event.dataTransfer.files || []))
-    },
-    [handleFiles],
-  )
-
-  const handleBrowseClick = React.useCallback(() => {
-    inputRef.current?.click()
-  }, [])
-
-  const handleFileChange = React.useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
-      void handleFiles(Array.from(event.target.files || []))
-      if (inputRef.current) inputRef.current.value = ""
-    },
-    [handleFiles],
-  )
-
   const displayedTarget =
     uploadTargetPath === null
       ? `UTILITY/${ADMIN_UPLOAD_PREFIX} (default)`
@@ -871,55 +849,47 @@ export const AdminUploadPanel: React.FC = () => {
       </div>
 
       {/* Drop Zone */}
-      <div
-        onDragOver={(e) => { e.preventDefault(); e.stopPropagation(); if (!dragActive) setDragActive(true) }}
-        onDragEnter={(e) => { e.preventDefault(); e.stopPropagation(); setDragActive(true) }}
-        onDragLeave={(e) => { e.preventDefault(); e.stopPropagation(); setDragActive(false) }}
-        onDrop={handleDrop}
+      <FileDropZone
+        ref={dropZoneRef}
+        onFiles={(files) => void handleFiles(files)}
+        acceptInput={ACCEPT_STRING}
+        multiple
+        disabled={uploading}
         className={cn(
-          "relative rounded-2xl border-2 border-dashed p-10 text-center transition-all cursor-pointer",
-          dragActive
-            ? "border-emerald-500 bg-emerald-50/70 dark:bg-emerald-500/10 scale-[1.01]"
-            : "border-stone-200 dark:border-[#3e3e42] bg-white dark:bg-[#1e1e20] hover:border-emerald-300 dark:hover:border-emerald-800",
+          "relative rounded-2xl border-2 border-dashed p-10 text-center transition-all cursor-pointer border-stone-200 dark:border-[#3e3e42] bg-white dark:bg-[#1e1e20] hover:border-emerald-300 dark:hover:border-emerald-800",
           uploading && "opacity-70 pointer-events-none",
         )}
-        onClick={handleBrowseClick}
+        dragActiveClassName="!border-emerald-500 bg-emerald-50/70 dark:bg-emerald-500/10 scale-[1.01]"
         aria-disabled={uploading}
       >
-        <input
-          ref={inputRef}
-          type="file"
-          accept={ACCEPT_STRING}
-          multiple
-          hidden
-          onChange={handleFileChange}
-          disabled={uploading}
-        />
+        {({ isDragging }) => (
+          <>
+            <div className={cn(
+              "mx-auto mb-4 w-16 h-16 rounded-2xl flex items-center justify-center transition-colors",
+              isDragging
+                ? "bg-emerald-500 text-white"
+                : "bg-gradient-to-br from-emerald-100 to-teal-100 dark:from-emerald-900/30 dark:to-teal-900/30 text-emerald-600 dark:text-emerald-400",
+            )}>
+              {uploading ? <Loader2 className="h-8 w-8 animate-spin" /> : <UploadCloud className="h-8 w-8" />}
+            </div>
 
-        <div className={cn(
-          "mx-auto mb-4 w-16 h-16 rounded-2xl flex items-center justify-center transition-colors",
-          dragActive
-            ? "bg-emerald-500 text-white"
-            : "bg-gradient-to-br from-emerald-100 to-teal-100 dark:from-emerald-900/30 dark:to-teal-900/30 text-emerald-600 dark:text-emerald-400",
-        )}>
-          {uploading ? <Loader2 className="h-8 w-8 animate-spin" /> : <UploadCloud className="h-8 w-8" />}
-        </div>
+            <div className="text-base font-semibold text-stone-900 dark:text-white mb-1.5">
+              {isDragging ? "Drop your files here" : uploading ? "Uploading..." : (
+                <>Drag & drop files or <span className="text-emerald-600 dark:text-emerald-400">browse</span></>
+              )}
+            </div>
 
-        <div className="text-base font-semibold text-stone-900 dark:text-white mb-1.5">
-          {dragActive ? "Drop your files here" : uploading ? "Uploading..." : (
-            <>Drag & drop files or <span className="text-emerald-600 dark:text-emerald-400">browse</span></>
-          )}
-        </div>
-
-        <p className="text-sm text-stone-500 dark:text-stone-400 max-w-md mx-auto">
-          Images, PDF, video, audio, CSV, JSON, TXT, ZIP, OBJ. Max {DEFAULT_MAX_MB} MB per file.
-          <br />
-          <span className="text-emerald-600 dark:text-emerald-400">Multiple files supported</span>
-          {optimize && (
-            <> {"\u00b7"} <span className="text-emerald-600 dark:text-emerald-400">Auto-optimization enabled</span></>
-          )}
-        </p>
-      </div>
+            <p className="text-sm text-stone-500 dark:text-stone-400 max-w-md mx-auto">
+              Images, PDF, video, audio, CSV, JSON, TXT, ZIP, OBJ. Max {DEFAULT_MAX_MB} MB per file.
+              <br />
+              <span className="text-emerald-600 dark:text-emerald-400">Multiple files supported</span>
+              {optimize && (
+                <> {"\u00b7"} <span className="text-emerald-600 dark:text-emerald-400">Auto-optimization enabled</span></>
+              )}
+            </p>
+          </>
+        )}
+      </FileDropZone>
 
       {/* Error */}
       {error && (
@@ -1011,7 +981,7 @@ export const AdminUploadPanel: React.FC = () => {
             onClick={() => {
               setResults([])
               setFileQueue([])
-              inputRef.current?.click()
+              dropZoneRef.current?.openFilePicker()
             }}
           >
             <UploadCloud className="mr-2 h-4 w-4" />

--- a/plant-swipe/src/components/ui/file-drop-zone.tsx
+++ b/plant-swipe/src/components/ui/file-drop-zone.tsx
@@ -1,0 +1,183 @@
+/**
+ * FileDropZone
+ *
+ * Shared drag-and-drop upload zone. Wraps children with drag/drop handlers
+ * and an optional click-to-browse hidden file input. Consumers control the
+ * visuals; the component only provides behavior + drag-active state.
+ *
+ * Behavior is built on top of {@link useFileDrop}. Drag-and-drop is
+ * automatically disabled on native Capacitor (no drag affordance on mobile)
+ * unless the caller overrides `dragEnabled`.
+ *
+ * Usage (children as a node — consumer styles via `dragActiveClassName` or
+ * the `data-dragging` attribute):
+ *
+ *   <FileDropZone onFiles={handleFiles} accept={["image/"]} acceptInput="image/*">
+ *     <DropZoneContent />
+ *   </FileDropZone>
+ *
+ * Usage (render prop — read `isDragging` / call `openFilePicker`):
+ *
+ *   <FileDropZone onFiles={handleFiles}>
+ *     {({ isDragging, openFilePicker }) => (
+ *       <button onClick={openFilePicker}>{isDragging ? "Drop" : "Browse"}</button>
+ *     )}
+ *   </FileDropZone>
+ *
+ * Imperative access:
+ *
+ *   const ref = React.useRef<FileDropZoneHandle>(null)
+ *   <FileDropZone ref={ref} clickToBrowse={false} onFiles={...}>...</FileDropZone>
+ *   ref.current?.openFilePicker()
+ */
+
+import * as React from "react"
+import { cn } from "@/lib/utils"
+import { useFileDrop } from "@/hooks/useFileDrop"
+import { isNativeCapacitor } from "@/platform"
+
+export interface FileDropZoneRenderProps {
+  isDragging: boolean
+  openFilePicker: () => void
+}
+
+export interface FileDropZoneHandle {
+  openFilePicker: () => void
+}
+
+export interface FileDropZoneProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, "onDrop" | "children"> {
+  /** Receives files that passed the `accept` / `maxBytes` filters. */
+  onFiles: (files: File[]) => void
+  /** MIME-type prefixes used to filter dropped files (e.g. `["image/"]`). */
+  accept?: string[]
+  /** `accept` attribute forwarded to the hidden `<input type="file" />`. */
+  acceptInput?: string
+  /** Max file size per file, in bytes. Oversize files are silently skipped. */
+  maxBytes?: number
+  /** Allow multiple file selection through the file picker. */
+  multiple?: boolean
+  /** Disable all interactions (drag and click). */
+  disabled?: boolean
+  /** Enable drag handlers. Defaults to true on web, false on native Capacitor. */
+  dragEnabled?: boolean
+  /** If true, a click on the zone opens the file picker. Defaults to true. */
+  clickToBrowse?: boolean
+  /** Extra classes applied to the wrapper while a drag is active. */
+  dragActiveClassName?: string
+  /** Children (node or render prop). */
+  children:
+    | React.ReactNode
+    | ((state: FileDropZoneRenderProps) => React.ReactNode)
+}
+
+export const FileDropZone = React.forwardRef<FileDropZoneHandle, FileDropZoneProps>(
+  function FileDropZone(
+    {
+      onFiles,
+      accept,
+      acceptInput,
+      maxBytes,
+      multiple = false,
+      disabled = false,
+      dragEnabled,
+      clickToBrowse = true,
+      className,
+      dragActiveClassName,
+      onClick,
+      onKeyDown,
+      children,
+      ...rest
+    },
+    ref,
+  ) {
+    const inputRef = React.useRef<HTMLInputElement>(null)
+
+    const resolvedDragEnabled =
+      (dragEnabled ?? !isNativeCapacitor()) && !disabled
+
+    const { isDragging, bind } = useFileDrop({
+      accept,
+      maxBytes,
+      enabled: resolvedDragEnabled,
+      onFiles,
+    })
+
+    const openFilePicker = React.useCallback(() => {
+      if (disabled) return
+      inputRef.current?.click()
+    }, [disabled])
+
+    React.useImperativeHandle(ref, () => ({ openFilePicker }), [openFilePicker])
+
+    const handleChange = React.useCallback(
+      (event: React.ChangeEvent<HTMLInputElement>) => {
+        const picked = Array.from(event.target.files ?? [])
+        if (inputRef.current) inputRef.current.value = ""
+        if (picked.length === 0) return
+        const filtered = picked.filter((file) => {
+          if (maxBytes && file.size > maxBytes) return false
+          if (!accept || accept.length === 0) return true
+          return accept.some((prefix) => file.type.startsWith(prefix))
+        })
+        if (filtered.length > 0) onFiles(filtered)
+      },
+      [accept, maxBytes, onFiles],
+    )
+
+    const handleClick = React.useCallback(
+      (event: React.MouseEvent<HTMLDivElement>) => {
+        onClick?.(event)
+        if (event.defaultPrevented) return
+        if (!clickToBrowse || disabled) return
+        openFilePicker()
+      },
+      [clickToBrowse, disabled, onClick, openFilePicker],
+    )
+
+    const handleKeyDown = React.useCallback(
+      (event: React.KeyboardEvent<HTMLDivElement>) => {
+        onKeyDown?.(event)
+        if (event.defaultPrevented) return
+        if (!clickToBrowse || disabled) return
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault()
+          openFilePicker()
+        }
+      },
+      [clickToBrowse, disabled, onKeyDown, openFilePicker],
+    )
+
+    const content =
+      typeof children === "function"
+        ? children({ isDragging, openFilePicker })
+        : children
+
+    return (
+      <div
+        {...rest}
+        {...bind}
+        onClick={handleClick}
+        onKeyDown={handleKeyDown}
+        aria-disabled={disabled || undefined}
+        data-dragging={isDragging || undefined}
+        className={cn(className, isDragging && dragActiveClassName)}
+      >
+        {content}
+        <input
+          ref={inputRef}
+          type="file"
+          accept={acceptInput}
+          multiple={multiple}
+          onChange={handleChange}
+          disabled={disabled}
+          className="hidden"
+          aria-hidden="true"
+          tabIndex={-1}
+        />
+      </div>
+    )
+  },
+)
+
+export default FileDropZone

--- a/plant-swipe/src/pages/ScanPage.tsx
+++ b/plant-swipe/src/pages/ScanPage.tsx
@@ -35,6 +35,7 @@ import { cn } from '@/lib/utils'
 import { useImageViewer, ImageViewer } from '@/components/ui/image-viewer'
 import { CameraCapture } from '@/components/messaging/CameraCapture'
 import { ImageSourcePicker } from '@/components/ui/image-source-picker'
+import { FileDropZone } from '@/components/ui/file-drop-zone'
 import { RequestPlantDialog } from '@/components/plant/RequestPlantDialog'
 import { 
   uploadAndIdentifyPlant, 
@@ -386,28 +387,42 @@ export const ScanPage: React.FC = () => {
         </p>
       </div>
       
-      {/* New Scan Card */}
-      <Card
-        data-tutorial="scan-card"
-        role={!isIdentifying && !identifyError ? 'button' : undefined}
-        tabIndex={!isIdentifying && !identifyError ? 0 : undefined}
-        onClick={() => {
-          if (isIdentifying || identifyError) return
-          setSourcePickerOpen(true)
+      {/* New Scan Card — supports click (opens source picker) and drag-and-drop */}
+      <FileDropZone
+        onFiles={(files) => {
+          const file = files[0]
+          if (file) void processSelectedFile(file)
         }}
-        onKeyDown={(e) => {
-          if (isIdentifying || identifyError) return
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault()
-            setSourcePickerOpen(true)
-          }
-        }}
-        className={cn(
-          'mb-8 p-4 rounded-3xl border-2 border-dashed border-emerald-200 dark:border-emerald-800/50 bg-gradient-to-br from-emerald-50/50 to-teal-50/50 dark:from-emerald-900/10 dark:to-teal-900/10 transition-colors',
-          !isIdentifying && !identifyError &&
-            'cursor-pointer hover:border-emerald-400 dark:hover:border-emerald-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500',
-        )}
+        accept={['image/']}
+        acceptInput="image/*"
+        clickToBrowse={false}
+        disabled={isIdentifying || !!identifyError}
+        className="mb-8 rounded-3xl"
       >
+        {({ isDragging }) => (
+        <Card
+          data-tutorial="scan-card"
+          role={!isIdentifying && !identifyError ? 'button' : undefined}
+          tabIndex={!isIdentifying && !identifyError ? 0 : undefined}
+          onClick={() => {
+            if (isIdentifying || identifyError) return
+            setSourcePickerOpen(true)
+          }}
+          onKeyDown={(e) => {
+            if (isIdentifying || identifyError) return
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault()
+              setSourcePickerOpen(true)
+            }
+          }}
+          className={cn(
+            'p-4 rounded-3xl border-2 border-dashed border-emerald-200 dark:border-emerald-800/50 bg-gradient-to-br from-emerald-50/50 to-teal-50/50 dark:from-emerald-900/10 dark:to-teal-900/10 transition-all',
+            !isIdentifying && !identifyError &&
+              'cursor-pointer hover:border-emerald-400 dark:hover:border-emerald-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500',
+            isDragging &&
+              'border-emerald-500 dark:border-emerald-500 bg-emerald-100/70 dark:bg-emerald-500/10 scale-[1.01] shadow-lg',
+          )}
+        >
         {isIdentifying ? (
           // Loading state
           <div className="flex flex-col items-center justify-center py-8">
@@ -454,7 +469,9 @@ export const ScanPage: React.FC = () => {
               <Camera className="h-7 w-7 text-emerald-600 dark:text-emerald-400" />
             </div>
             <h3 className="text-base font-semibold text-stone-900 dark:text-white">
-              {t('scan.newScanTitle', { defaultValue: 'Identify a Plant' })}
+              {isDragging
+                ? t('scan.dropHere', { defaultValue: 'Drop your image to scan' })
+                : t('scan.newScanTitle', { defaultValue: 'Identify a Plant' })}
             </h3>
 
             <a
@@ -483,6 +500,10 @@ export const ScanPage: React.FC = () => {
               {t('scan.uploadImage', { defaultValue: 'Upload' })}
             </Button>
 
+            <p className="text-xs text-stone-500 dark:text-stone-400 text-center">
+              {t('scan.orDragAndDrop', { defaultValue: 'or drag and drop an image' })}
+            </p>
+
             <input
               ref={fileInputRef}
               type="file"
@@ -492,8 +513,10 @@ export const ScanPage: React.FC = () => {
             />
           </div>
         )}
-      </Card>
-      
+        </Card>
+        )}
+      </FileDropZone>
+
       {/* Scan History */}
       <div className="mb-4 flex items-center gap-2">
         <History className="h-5 w-5 text-stone-400" />


### PR DESCRIPTION
## Summary

Introduces a new `FileDropZone` component that provides reusable drag-and-drop file upload functionality with flexible styling and behavior control. This component consolidates file handling logic and is now used in both the ScanPage and AdminUploadPanel.

## Key Changes

- **New component:** `FileDropZone` (`src/components/ui/file-drop-zone.tsx`)
  - Wraps children with drag/drop handlers and optional click-to-browse file input
  - Supports both node and render-prop children patterns
  - Exposes `isDragging` state and `openFilePicker()` method via render prop
  - Provides imperative handle for programmatic file picker access
  - Auto-disables drag on native Capacitor (mobile) unless explicitly enabled
  - Filters files by MIME type and size before passing to `onFiles` callback

- **AdminUploadPanel refactor:**
  - Replaced manual drag/drop handlers with `FileDropZone`
  - Removed `dragActive` state and `inputRef` in favor of `dropZoneRef`
  - Simplified upload zone markup using render prop pattern
  - Maintains all existing styling and behavior

- **ScanPage enhancement:**
  - Wrapped scan card with `FileDropZone` to support drag-and-drop image uploads
  - Added visual feedback when dragging files over the card
  - Added new i18n keys for drag-and-drop messaging
  - Preserved existing click-to-open-source-picker behavior

- **Documentation:** Updated `REUSABLE_COMPONENTS.md` with full `FileDropZone` API reference and usage examples

## Implementation Details

- Built on top of existing `useFileDrop` hook for consistent behavior
- Supports both controlled styling (via `dragActiveClassName`) and data attributes (`data-dragging`)
- Handles file filtering (MIME type and size) consistently across both consumers
- Maintains accessibility with proper `aria-disabled` and keyboard support (Enter/Space to open picker)
- Hidden file input is automatically reset after selection to allow re-uploading the same file

https://claude.ai/code/session_01Uro2jxbT37nRaGH7MNWgWr