### PR TITLE
⚡ Bolt: Use for...in to prevent intermediate array allocation from Object.values

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -38,3 +38,6 @@
 ## 2024-05-18 - Replacing multiple reduce calls with single-pass for loops
 **Learning:** In data processing functions that iterate over an array multiple times to calculate aggregate values (e.g., maximum required count and sum of completed tasks), using multiple `.reduce()` calls adds unnecessary function call overhead and time complexity.
 **Action:** Use a single-pass `for` loop to compute multiple aggregates simultaneously to avoid intermediate loop allocations and overhead.
+## 2026-04-03 - Prevent array allocation from Object.values() in recursive functions
+**Learning:** Using `Object.values(obj).some(...)` in recursive functions (like `hasMeaningfulContent`) or heavily accessed components creates significant GC pressure by allocating intermediate arrays of values for every object node traversed.
+**Action:** Replace `Object.values(obj).some(...)` with `for...in` loops in recursive checkers and hot path validations to prevent intermediate array allocation and allow for fast early returns.

--- a/plant-swipe/src/components/plant/PlantProfileForm.tsx
+++ b/plant-swipe/src/components/plant/PlantProfileForm.tsx
@@ -1556,10 +1556,16 @@ function renderField(plant: Plant, onChange: (path: string, value: any) => void,
       if (!isAdvice) return false
       if (typeof value === "string") return value.trim().length > 0
       if (Array.isArray(value)) return value.some((entry) => (typeof entry === "string" ? entry.trim().length > 0 : entry !== null && entry !== undefined))
-      if (value && typeof value === "object") return Object.values(value as Record<string, unknown>).some((entry) => {
-        if (typeof entry === "string") return entry.trim().length > 0
-        return entry !== null && entry !== undefined
-      })
+      if (value && typeof value === "object") {
+        // ⚡ Bolt: Replace Object.values().some() with a for...in loop to avoid intermediate array allocation
+        const record = value as Record<string, unknown>
+        for (const key in record) {
+          const entry = record[key]
+          if (typeof entry === "string" && entry.trim().length > 0) return true
+          if (typeof entry !== "string" && entry !== null && entry !== undefined) return true
+        }
+        return false
+      }
       return false
     })()
 

--- a/plant-swipe/src/pages/CreatePlantPage.tsx
+++ b/plant-swipe/src/pages/CreatePlantPage.tsx
@@ -165,7 +165,13 @@ const hasMeaningfulContent = (value: unknown): boolean => {
   if (typeof value === 'boolean') return value === true
   if (Array.isArray(value)) return value.some((entry) => hasMeaningfulContent(entry))
   if (typeof value === 'object') {
-    return Object.values(value as Record<string, unknown>).some((entry) => hasMeaningfulContent(entry))
+    // ⚡ Bolt: Replace Object.values().some() with a for...in loop to avoid intermediate array allocation
+    for (const key in value as Record<string, unknown>) {
+      if (hasMeaningfulContent((value as Record<string, unknown>)[key])) {
+        return true
+      }
+    }
+    return false
   }
   return false
 }


### PR DESCRIPTION
**💡 What**: Replaced `Object.values(obj).some(...)` with `for...in` loops in recursive object checkers (`hasMeaningfulContent`) and component memoized evaluations (`adviceHasValue`).
**🎯 Why**: `Object.values(obj)` creates an intermediate array of all values in the object. In recursive functions evaluating deeply nested forms, this causes a cascade of array allocations, contributing to GC pressure and potential micro-stutters during intensive typing or validation.
**📊 Impact**: Eliminates intermediate array allocations during validation of nested config objects, allowing for zero-allocation early returns.
**🔬 Measurement**: Validate by checking heap snapshots during large form validations to verify reduced Array allocation signatures.

---
*PR created automatically by Jules for task [9188629703719270906](https://jules.google.com/task/9188629703719270906) started by @FrenchFive*