### PR TITLE
fix(ops): stop prod going dark when nginx reloads during a DNS hiccup

### DIFF
--- a/plant-swipe.conf
+++ b/plant-swipe.conf
@@ -21,12 +21,23 @@ server {
     ssl_ciphers HIGH:!aNULL:!MD5;
     ssl_prefer_server_ciphers on;
 
+    # Resolve Supabase at request time, not at boot. Without this, a single
+    # transient DNS failure during a reload (e.g. apt-daily-upgrade restarting
+    # nginx, or certbot's post-renewal deploy hook) crashes nginx with
+    # "host not found in upstream" and the whole site goes dark until someone
+    # manually runs `systemctl start nginx`. systemd-resolved is tried first
+    # so /etc/resolv.conf overrides still work; 1.1.1.1 / 8.8.8.8 are fallbacks.
+    resolver 127.0.0.53 1.1.1.1 8.8.8.8 valid=60s ipv4=on;
+    resolver_timeout 5s;
+
     # Proxy all requests to Supabase storage
     location / {
-        proxy_pass https://lxnkcguwewrskqnyzjwi.supabase.co/storage/v1/object/public/;
+        # Variable usage forces per-request DNS resolution instead of boot-time.
+        set $supabase_upstream lxnkcguwewrskqnyzjwi.supabase.co;
+        proxy_pass https://$supabase_upstream:443/storage/v1/object/public$request_uri;
         proxy_http_version 1.1;
         proxy_ssl_server_name on;
-        proxy_set_header Host lxnkcguwewrskqnyzjwi.supabase.co;
+        proxy_set_header Host $supabase_upstream;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;

--- a/scripts/refresh-plant-swipe.sh
+++ b/scripts/refresh-plant-swipe.sh
@@ -886,12 +886,20 @@ else
   deploy_supabase_functions
 fi
 
-# Validate and reload nginx
+# Validate and reload nginx. Self-heal if nginx is currently inactive — a bare
+# `reload` refuses to act on a stopped service, which is exactly what left prod
+# offline on 2026-04-22 when apt-daily-upgrade restarted nginx during a transient
+# DNS failure. Previously this script would error out and give up.
 log "Testing nginx configuration…"
 $SUDO nginx -t
 
-log "Reloading nginx…"
-$SUDO systemctl reload "$SERVICE_NGINX"
+if $SUDO systemctl is-active --quiet "$SERVICE_NGINX"; then
+  log "Reloading nginx…"
+  $SUDO systemctl reload "$SERVICE_NGINX"
+else
+  log "Nginx is inactive — starting it instead of reloading"
+  $SUDO systemctl start "$SERVICE_NGINX"
+fi
 
 # Keep service environment in sync with repo .env for plug‑and‑play deployment
 render_service_env() {

--- a/scripts/restart-services.sh
+++ b/scripts/restart-services.sh
@@ -88,7 +88,14 @@ fi
 if [[ "$cmd" == "nginx" || "$cmd" == "all" ]]; then
   echo "[+] Reloading $SERVICE_NGINX…"
   $SUDO nginx -t
-  $SUDO systemctl reload "$SERVICE_NGINX"
+  # Self-heal: if nginx is stopped (previous reload crashed it), start instead.
+  # `systemctl reload` on an inactive service exits non-zero with "cannot reload".
+  if $SUDO systemctl is-active --quiet "$SERVICE_NGINX"; then
+    $SUDO systemctl reload "$SERVICE_NGINX"
+  else
+    echo "[!] $SERVICE_NGINX is inactive — starting it instead"
+    $SUDO systemctl start "$SERVICE_NGINX"
+  fi
 fi
 
 echo "[✓] Done."

--- a/setup.sh
+++ b/setup.sh
@@ -334,9 +334,22 @@ Unattended-Upgrade::Allowed-Origins {
     \"\${distro_id}ESM:\${distro_codename}-infra-security\";
 };
 
-// Packages to never update automatically (add any critical packages here)
+// Packages to never update automatically (add any critical packages here).
+// nginx is blacklisted because its .deb postinst restarts nginx, and a
+// restart re-parses the config from scratch — which resolves upstream
+// hostnames at boot time. If DNS is flaky for even a second during that
+// restart, nginx refuses to come back up (\"host not found in upstream\")
+// and the entire site goes dark until a human manually runs
+// \`systemctl start nginx\`. Prod went down exactly this way on 2026-04-22
+// when apt-daily-upgrade upgraded nginx at 06:22 UTC.
+// We pin security updates for nginx to a manual \`setup.sh\` run instead.
 Unattended-Upgrade::Package-Blacklist {
-    // \"nginx\";  // Uncomment to prevent nginx auto-updates
+    \"nginx\";
+    \"nginx-common\";
+    \"nginx-core\";
+    \"nginx-full\";
+    \"nginx-extras\";
+    \"nginx-light\";
 };
 
 // Automatically reboot at 5:00 AM if required (e.g., kernel updates)
@@ -2196,13 +2209,27 @@ PY
     
     log "Nginx configuration is valid with SSL certificates"
     
-    # Reload nginx to apply SSL configuration
+    # Reload nginx to apply SSL configuration.
+    # `reload` only works on a running service — if nginx was left stopped by a
+    # previous failed reload (e.g. transient DNS failure during apt-daily-upgrade
+    # restarting nginx), `reload` will refuse and the site stays dark. Detect
+    # inactive state and `start` instead so setup.sh always converges to running.
     log "Reloading nginx to apply SSL configuration…"
-    if $SUDO systemctl reload nginx; then
-      log "Nginx reloaded successfully with SSL certificates"
+    if $SUDO systemctl is-active --quiet nginx; then
+      if $SUDO systemctl reload nginx; then
+        log "Nginx reloaded successfully with SSL certificates"
+      else
+        log "[ERROR] Failed to reload nginx. Check status with: systemctl status nginx"
+        return 1
+      fi
     else
-      log "[ERROR] Failed to reload nginx. Check status with: systemctl status nginx"
-      return 1
+      log "Nginx is not active — starting it fresh with SSL configuration"
+      if $SUDO systemctl start nginx; then
+        log "Nginx started successfully with SSL certificates"
+      else
+        log "[ERROR] Failed to start nginx. Check status with: systemctl status nginx"
+        return 1
+      fi
     fi
     
     # Set up auto-renewal
@@ -2214,12 +2241,30 @@ PY
       $SUDO systemctl start certbot.timer
     fi
     
-    # Add renewal hook to reload nginx
+    # Add renewal hook to reload nginx after every successful cert renewal.
+    # certbot.timer fires twice daily — if nginx happens to be stopped at that
+    # moment (or DNS hiccups during the reload), a bare `systemctl reload` fails
+    # silently and the site stays dark. Self-heal: start if inactive, reload if
+    # active, log so we can correlate with outages.
     local renewal_hook="/etc/letsencrypt/renewal-hooks/deploy/reload-nginx.sh"
     $SUDO mkdir -p "$(dirname "$renewal_hook")"
     $SUDO bash -c "cat > '$renewal_hook' <<'EOF'
 #!/bin/bash
-systemctl reload nginx
+# Installed by PlantSwipe setup.sh. Reload-or-start nginx after certbot
+# renews a certificate. See plant-swipe.conf for the media proxy upstream
+# resolver fix that lets this reload survive transient DNS failures.
+set -e
+if ! nginx -t >/dev/null 2>&1; then
+  logger -t certbot-deploy \"nginx config invalid after certbot renewal; refusing to reload\"
+  exit 1
+fi
+if systemctl is-active --quiet nginx; then
+  systemctl reload nginx
+  logger -t certbot-deploy \"nginx reloaded after cert renewal\"
+else
+  systemctl start nginx
+  logger -t certbot-deploy \"nginx was inactive; started after cert renewal\"
+fi
 EOF
 "
     $SUDO chmod +x "$renewal_hook"
@@ -2536,10 +2581,19 @@ if [[ -x "$SITEMAP_GENERATOR_BIN" ]]; then
   fi
 fi
 
-# Final nginx reload to apply site links (only if nginx config is valid)
+# Final nginx reload to apply site links (only if nginx config is valid).
+# Self-healing: if nginx is currently inactive (e.g. left stopped by a prior
+# failed reload), start it instead of trying to reload. Plain `reload` returns
+# "service is not active, cannot reload" and setup.sh would previously just
+# warn and exit, leaving the whole site offline.
 log "Reloading nginx…"
 if $SUDO nginx -t >/dev/null 2>&1; then
-  $SUDO systemctl reload "$SERVICE_NGINX" || log "[WARN] Nginx reload failed, but continuing"
+  if $SUDO systemctl is-active --quiet "$SERVICE_NGINX"; then
+    $SUDO systemctl reload "$SERVICE_NGINX" || log "[WARN] Nginx reload failed, but continuing"
+  else
+    log "[INFO] Nginx is inactive — starting it instead of reloading"
+    $SUDO systemctl start "$SERVICE_NGINX" || log "[WARN] Nginx start failed, but continuing"
+  fi
 else
   log "[WARN] Nginx configuration has errors. Skipping reload."
   log "[INFO] Fix nginx configuration or complete SSL setup, then run: sudo systemctl reload nginx"


### PR DESCRIPTION
## What broke

Prod was offline from **06:22 UTC to ~15:14 UTC on 2026-04-22** (≈8h45). Blog images, `media.aphylia.app`, the admin panel, and every `aphylia.app` host refused connections. Nothing in the app code changed — nginx was simply dead.

## Root cause (exact sequence, from journalctl)

```
Apr 22 06:22:04 localhost systemd[1]: Stopping nginx.service …
Apr 22 06:22:05 localhost nginx[75314]: [emerg] host not found in upstream
                 "lxnkcguwewrskqnyzjwi.supabase.co"
                 in /etc/nginx/sites-enabled/plant-swipe.conf:25
Apr 22 06:22:05 localhost systemd[1]: nginx.service: Failed with result 'exit-code'.
```

1. `apt-daily-upgrade.timer` (Ubuntu default, ~06:00 UTC + up to 60m random delay) fired.
2. Unattended-upgrades upgraded the `nginx` package. nginx had been on the default allowlist because the `Package-Blacklist { "nginx"; }` line in `setup.sh` was commented out.
3. The `nginx` .deb postinst restarted nginx. A restart re-parses `plant-swipe.conf` from scratch.
4. `plant-swipe.conf:25-26` had the Supabase hostname literally in `proxy_pass`:
   ```nginx
   proxy_pass https://lxnkcguwewrskqnyzjwi.supabase.co/storage/v1/object/public/;
   ```
   nginx resolves hostnames in `proxy_pass` **at config load time** (not per request) when there's no variable and no `upstream {}` block.
5. DNS for `lxnkcguwewrskqnyzjwi.supabase.co` was unreachable for that one moment. nginx refused to start.
6. No auto-recovery. Everything downstream (main site, admin, `media.aphylia.app`) refused TCP.
7. Every subsequent `systemctl reload nginx` in our deploy scripts (`setup.sh:2542`, `scripts/refresh-plant-swipe.sh:894`, `scripts/restart-services.sh:91`) printed `service is not active, cannot reload` and gave up, so re-running `setup.sh` didn't fix it either.

## Fixes in this PR (end-to-end, one bite)

### 1. `plant-swipe.conf` — survive DNS hiccups on the media vhost

Added a `resolver` and put the Supabase hostname behind a variable so nginx resolves it **per request** instead of at boot. A DNS blip now costs one slow image, not an 8-hour outage.

```nginx
resolver 127.0.0.53 1.1.1.1 8.8.8.8 valid=60s ipv4=on;
resolver_timeout 5s;

location / {
    set $supabase_upstream lxnkcguwewrskqnyzjwi.supabase.co;
    proxy_pass https://$supabase_upstream:443/storage/v1/object/public$request_uri;
    proxy_set_header Host $supabase_upstream;
    ...
}
```

### 2. `setup.sh` — every `reload` is now `reload-if-active, start-if-inactive`

The previous code ran a plain `systemctl reload nginx`. systemd refuses to reload a stopped service, so whenever nginx was left dead by a prior failure, `setup.sh` logged a WARN and exited, leaving prod down.

Patched in three places:
- Final reload at end of `setup.sh` (was the "cannot reload" we saw today).
- Post-SSL reload after certbot issuance.
- The certbot `/etc/letsencrypt/renewal-hooks/deploy/reload-nginx.sh` it installs — now does `nginx -t` first, reload-or-start, and logs each action via `logger -t certbot-deploy` so future outages correlate with cert renewals in syslog.

### 3. `setup.sh` — blacklist nginx from unattended-upgrades

This is the specific line that killed prod today. Added `nginx`, `nginx-common`, `nginx-core`, `nginx-full`, `nginx-extras`, `nginx-light` to `Unattended-Upgrade::Package-Blacklist`. nginx security updates now ride in on a manual `setup.sh` run, where we control the restart window.

### 4. Helper scripts (`scripts/refresh-plant-swipe.sh`, `scripts/restart-services.sh`)

Same reload-or-start pattern. The refresh script previously exited non-zero mid-deploy if nginx happened to be stopped — which is exactly what happened at 15:13 UTC today before it was fixed by hand.

## Cron / timer audit — every scheduled thing on the server that can touch nginx or apt

| Unit | When | Risk | Mitigation |
|---|---|---|---|
| `apt-daily-upgrade.timer` (Ubuntu default) | ~06:00 UTC + up to 60m jitter | **HIGH** — root cause of today's outage. Silently upgrades nginx and runs postinst restart. | ✅ nginx blacklisted in `Package-Blacklist` (fix #3) |
| `apt-daily.timer` (Ubuntu default) | ~06:00 UTC | LOW — downloads packages only, does not install. | No change needed. |
| `certbot.timer` (Ubuntu default) | twice daily (00:00 + 12:00 UTC + jitter) | **MEDIUM** — runs `renewal-hooks/deploy/reload-nginx.sh`. A DNS hiccup during a renewal reload would have the same effect as today. | ✅ Deploy hook rewritten to `nginx -t` + reload-or-start + syslog (fix #2) |
| `plantswipe-ca-update.timer` (this repo, `setup.sh:2477`) | Sundays 04:00 UTC | LOW — upgrades `ca-certificates` only. Does not touch nginx. | No change. |
| `plantswipe-sitemap-refresh.timer` (this repo) | daily | NONE — writes `public/sitemap.xml`. No service interaction. | No change. |
| `plantswipe.service` / `plant-swipe-admin-api.service` (systemd units) | on-demand (Restart=on-failure) | LOW — crash-loop protection; restart doesn't cascade to nginx. | No change. |
| `refresh-plant-swipe.sh` / `plantswipe-restart` helper | manual / admin-API triggered | MEDIUM — bare `reload` would compound an existing outage. | ✅ Reload-or-start (fix #4) |
| `cron.daily/apt-listchanges` etc. | daily | LOW — diagnostic only, no package changes. | No change. |

## Verification

Local `bash -n` syntax check passes on all three touched shell files. On the server after merging:

```bash
# Nginx config parses and survives a restart
sudo nginx -t
sudo systemctl restart nginx
curl -sI https://media.aphylia.app/UTILITY/admin/uploads/png/icon-500_transparent_white.png   # -> 200

# Unattended-upgrades won't touch nginx any more
sudo unattended-upgrades --dry-run -d 2>&1 | grep -i nginx   # -> "Package nginx is kept back"

# Certbot deploy hook is self-healing
sudo systemctl stop nginx
sudo /etc/letsencrypt/renewal-hooks/deploy/reload-nginx.sh
sudo systemctl is-active nginx   # -> "active"

# Post-merge redeploy
cd /var/www/PlantSwipe && sudo ./setup.sh   # -> finishes without "cannot reload" warning
```

## What is NOT in this PR

- No application code changed. Blog rendering, the `/api/blog/upload-image` path, the DB schema, RLS policies — all untouched.
- No Supabase bucket changes. The `UTILITY` bucket and its contents are fine; they were only unreachable because the proxy was down.
- No rollback of the 2026-04-22 GDPR commit. It is unrelated to this outage.

## Test plan

- [ ] CI passes.
- [ ] Merge to `main`, then on the prod box: `cd /var/www/PlantSwipe && git pull && sudo ./setup.sh`.
- [ ] Confirm `systemctl is-active nginx` returns `active` and `curl https://media.aphylia.app/...icon-500_transparent_white.png` returns `200`.
- [ ] Spot-check `/etc/apt/apt.conf.d/50unattended-upgrades` contains the nginx lines in `Package-Blacklist`.
- [ ] Spot-check `/etc/letsencrypt/renewal-hooks/deploy/reload-nginx.sh` is the new version (contains `logger -t certbot-deploy`).

https://claude.ai/code/session_0133xGnY2tVPzJcdng7QQsFH