### PR TITLE
Add automatic pruning of old GitHub releases

### DIFF
--- a/.github/workflows/capacitor-mobile.yml
+++ b/.github/workflows/capacitor-mobile.yml
@@ -509,6 +509,7 @@ jobs:
           done
 
       - name: Create or update GitHub Release
+        id: release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.version.outputs.tag }}
@@ -534,8 +535,11 @@ jobs:
       # Keep the 10 most recent releases so rollbacks are cheap, but prune the
       # rest so the releases page doesn't grow unbounded. Tags are preserved
       # (`delete_tags: false`) so `git describe` and historical checkouts still
-      # resolve every version that's ever shipped.
+      # resolve every version that's ever shipped. Only runs when the release
+      # step above actually succeeded — we don't want to prune history if the
+      # new release never landed.
       - name: Prune old releases (keep last 10)
+        if: success() && steps.release.outcome == 'success'
         uses: dev-drprasad/delete-older-releases@v0.3.4
         with:
           keep_latest: 10

--- a/.github/workflows/capacitor-mobile.yml
+++ b/.github/workflows/capacitor-mobile.yml
@@ -530,3 +530,15 @@ jobs:
           files: |
             artifacts/PlantSwipe-*.apk
           make_latest: true
+
+      # Keep the 10 most recent releases so rollbacks are cheap, but prune the
+      # rest so the releases page doesn't grow unbounded. Tags are preserved
+      # (`delete_tags: false`) so `git describe` and historical checkouts still
+      # resolve every version that's ever shipped.
+      - name: Prune old releases (keep last 10)
+        uses: dev-drprasad/delete-older-releases@v0.3.4
+        with:
+          keep_latest: 10
+          delete_tags: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
This change adds automatic cleanup of old GitHub releases to prevent the releases page from growing unbounded, while preserving git tags for historical reference and rollback capability.

## Key Changes
- Added `id: release` to the GitHub Release creation step to track its outcome
- Added a new "Prune old releases" step that:
  - Runs only when the release creation succeeds
  - Keeps the 10 most recent releases for cheap rollbacks
  - Preserves all git tags (`delete_tags: false`) so `git describe` and historical checkouts continue to work
  - Uses the `dev-drprasad/delete-older-releases` action to perform the cleanup

## Implementation Details
- The pruning step is conditional (`if: success() && steps.release.outcome == 'success'`) to ensure we only clean up history after a successful release
- Git tags are intentionally preserved to maintain the ability to reference and checkout any version that has ever shipped
- This approach balances storage/UI cleanliness with the ability to maintain historical references and perform rollbacks

https://claude.ai/code/session_01MgHEWc9r4xF4VR4z7Hzkcj