### PR TITLE
Add plant change history and admin notes thread

### DIFF
--- a/plant-swipe/server.js
+++ b/plant-swipe/server.js
@@ -13629,7 +13629,7 @@ app.get('/api/admin/member', async (req, res) => {
       }
 
       try {
-        const fr = await fetch(`${supabaseUrlEnv}/rest/v1/garden_plant_images?uploaded_by=eq.${encodeURIComponent(targetId)}&select=id,image_url,caption,uploaded_at,garden_plant_id,garden_plants(plant_id,plants(name,admin_commentary))&order=uploaded_at.desc&limit=25`, {
+        const fr = await fetch(`${supabaseUrlEnv}/rest/v1/garden_plant_images?uploaded_by=eq.${encodeURIComponent(targetId)}&select=id,image_url,caption,uploaded_at,garden_plant_id,garden_plants(plant_id,plants(name))&order=uploaded_at.desc&limit=25`, {
           headers: baseHeaders,
         })
         if (fr.ok) {
@@ -13642,7 +13642,6 @@ app.get('/api/admin/member', async (req, res) => {
                 uploadedAt: r.uploaded_at || null,
                 gardenPlantId: r?.garden_plant_id || null,
                 plantName: r?.garden_plants?.plants?.name || null,
-                adminCommentary: r?.garden_plants?.plants?.admin_commentary || null,
               }))
             : []
         }
@@ -14120,8 +14119,7 @@ app.get('/api/admin/member', async (req, res) => {
                gpi.caption,
                gpi.uploaded_at,
                gp.id as garden_plant_id,
-               p.name as plant_name,
-               p.admin_commentary
+               p.name as plant_name
         from public.garden_plant_images gpi
         left join public.garden_plants gp on gp.id = gpi.garden_plant_id
         left join public.plants p on p.id = gp.plant_id
@@ -14137,7 +14135,6 @@ app.get('/api/admin/member', async (req, res) => {
             uploadedAt: r.uploaded_at || null,
             gardenPlantId: r.garden_plant_id || null,
             plantName: r.plant_name || null,
-            adminCommentary: r.admin_commentary || null,
           }))
         : []
     } catch { }
@@ -21929,19 +21926,14 @@ app.post('/api/admin/plant-reports/:id/complete', async (req, res) => {
       return
     }
 
-    // Get user display name for contributor record
-    let contributorName = 'Anonymous'
-    try {
-      const { data: profile } = await client.from('profiles').select('display_name, username').eq('id', report.user_id).maybeSingle()
-      if (profile) contributorName = profile.display_name || profile.username || 'Anonymous'
-    } catch { }
-
-    // Add user as contributor (ignore conflict if already exists)
-    try {
-      await client
-        .from('plant_contributors')
-        .insert({ plant_id: report.plant_id, contributor_name: contributorName })
-    } catch { }
+    // Add the reporter as a contributor (by profile id; ignore conflicts).
+    if (report.user_id) {
+      try {
+        await client
+          .from('plant_contributors')
+          .insert({ plant_id: report.plant_id, contributor_id: report.user_id })
+      } catch { }
+    }
 
     // Delete the report image from storage if it exists
     if (report.image_url) {

--- a/plant-swipe/src/components/plant/AdminNotesThread.tsx
+++ b/plant-swipe/src/components/plant/AdminNotesThread.tsx
@@ -13,7 +13,6 @@ import { fetchDisplayNames } from '@/lib/displayNameLookup'
 
 interface Actor {
   id: string | null
-  name: string | null
 }
 
 interface Props {
@@ -66,7 +65,7 @@ export const AdminNotesThread: React.FC<Props> = ({ plantId, actor, refreshVersi
   React.useEffect(() => { void refresh() }, [refresh, refreshVersion])
 
   const resolveName = (note: PlantAdminNote): string =>
-    (note.authorId && nameById.get(note.authorId)) || note.authorName || 'Unknown'
+    (note.authorId && nameById.get(note.authorId)) || 'Unknown'
 
   const handleSubmit = async () => {
     if (!plantId || posting) return
@@ -74,7 +73,7 @@ export const AdminNotesThread: React.FC<Props> = ({ plantId, actor, refreshVersi
     if (!body) return
     setPosting(true)
     try {
-      const note = await createPlantAdminNote(plantId, body, { authorId: actor.id, authorName: actor.name })
+      const note = await createPlantAdminNote(plantId, body, { authorId: actor.id })
       if (note) {
         setNotes((prev) => [...prev, note])
         setDraft('')
@@ -98,7 +97,7 @@ export const AdminNotesThread: React.FC<Props> = ({ plantId, actor, refreshVersi
   const commitEdit = async (note: PlantAdminNote) => {
     const next = editDraft.trim()
     if (!next || next === note.body) { cancelEdit(); return }
-    const updated = await updatePlantAdminNote(note, next, { authorId: actor.id, authorName: actor.name })
+    const updated = await updatePlantAdminNote(note, next, { authorId: actor.id })
     if (updated) {
       setNotes((prev) => prev.map((n) => (n.id === note.id ? updated : n)))
       onChanged?.()
@@ -107,7 +106,7 @@ export const AdminNotesThread: React.FC<Props> = ({ plantId, actor, refreshVersi
   }
 
   const remove = async (note: PlantAdminNote) => {
-    const ok = await deletePlantAdminNote(note, { authorId: actor.id, authorName: actor.name })
+    const ok = await deletePlantAdminNote(note, { authorId: actor.id })
     if (ok) {
       setNotes((prev) => prev.filter((n) => n.id !== note.id))
       onChanged?.()

--- a/plant-swipe/src/components/plant/AdminNotesThread.tsx
+++ b/plant-swipe/src/components/plant/AdminNotesThread.tsx
@@ -9,6 +9,7 @@ import {
   fetchPlantAdminNotes,
   updatePlantAdminNote,
 } from '@/lib/plantAdminNotes'
+import { fetchDisplayNames } from '@/lib/displayNameLookup'
 
 interface Actor {
   id: string | null
@@ -47,18 +48,25 @@ export const AdminNotesThread: React.FC<Props> = ({ plantId, actor, refreshVersi
   const [posting, setPosting] = React.useState(false)
   const [editingId, setEditingId] = React.useState<string | null>(null)
   const [editDraft, setEditDraft] = React.useState('')
+  const [nameById, setNameById] = React.useState<Map<string, string>>(new Map())
 
   const refresh = React.useCallback(async () => {
     if (!plantId) { setNotes([]); return }
     setLoading(true)
     try {
-      setNotes(await fetchPlantAdminNotes(plantId))
+      const rows = await fetchPlantAdminNotes(plantId)
+      setNotes(rows)
+      const ids = rows.map((r) => r.authorId).filter((x): x is string => Boolean(x))
+      setNameById(await fetchDisplayNames(ids))
     } finally {
       setLoading(false)
     }
   }, [plantId])
 
   React.useEffect(() => { void refresh() }, [refresh, refreshVersion])
+
+  const resolveName = (note: PlantAdminNote): string =>
+    (note.authorId && nameById.get(note.authorId)) || note.authorName || 'Unknown'
 
   const handleSubmit = async () => {
     if (!plantId || posting) return
@@ -139,12 +147,12 @@ export const AdminNotesThread: React.FC<Props> = ({ plantId, actor, refreshVersi
           return (
             <div key={note.id} className="flex gap-3">
               <div className="h-8 w-8 rounded-full bg-sky-600 text-white flex items-center justify-center text-xs font-semibold flex-shrink-0">
-                {initialsFor(note.authorName)}
+                {initialsFor(resolveName(note))}
               </div>
               <div className="flex-1 min-w-0">
                 <div className="flex items-baseline flex-wrap gap-2">
                   <span className="text-sm font-medium text-sky-900 dark:text-sky-100">
-                    {note.authorName || 'Unknown'}
+                    {resolveName(note)}
                   </span>
                   <span className="text-[11px] text-muted-foreground">
                     {formatStamp(note.createdAt)}

--- a/plant-swipe/src/components/plant/AdminNotesThread.tsx
+++ b/plant-swipe/src/components/plant/AdminNotesThread.tsx
@@ -1,0 +1,226 @@
+import React from 'react'
+import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
+import { MessageSquare, Pencil, Trash2, Check, X, Send } from 'lucide-react'
+import type { PlantAdminNote } from '@/types/plantHistory'
+import {
+  createPlantAdminNote,
+  deletePlantAdminNote,
+  fetchPlantAdminNotes,
+  updatePlantAdminNote,
+} from '@/lib/plantAdminNotes'
+
+interface Actor {
+  id: string | null
+  name: string | null
+}
+
+interface Props {
+  plantId: string | null | undefined
+  actor: Actor
+  /** Bumped by parent when external events (history panel refresh) should also refresh notes. */
+  refreshVersion?: number
+  /** Notify parent of changes (so the history panel can refetch). */
+  onChanged?: () => void
+}
+
+const formatStamp = (iso: string): string => {
+  const d = new Date(iso)
+  return d.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+const initialsFor = (name: string | null): string => {
+  if (!name) return '?'
+  const parts = name.trim().split(/\s+/).slice(0, 2)
+  return parts.map((p) => p[0]?.toUpperCase() || '').join('') || '?'
+}
+
+export const AdminNotesThread: React.FC<Props> = ({ plantId, actor, refreshVersion = 0, onChanged }) => {
+  const [notes, setNotes] = React.useState<PlantAdminNote[]>([])
+  const [loading, setLoading] = React.useState(false)
+  const [draft, setDraft] = React.useState('')
+  const [posting, setPosting] = React.useState(false)
+  const [editingId, setEditingId] = React.useState<string | null>(null)
+  const [editDraft, setEditDraft] = React.useState('')
+
+  const refresh = React.useCallback(async () => {
+    if (!plantId) { setNotes([]); return }
+    setLoading(true)
+    try {
+      setNotes(await fetchPlantAdminNotes(plantId))
+    } finally {
+      setLoading(false)
+    }
+  }, [plantId])
+
+  React.useEffect(() => { void refresh() }, [refresh, refreshVersion])
+
+  const handleSubmit = async () => {
+    if (!plantId || posting) return
+    const body = draft.trim()
+    if (!body) return
+    setPosting(true)
+    try {
+      const note = await createPlantAdminNote(plantId, body, { authorId: actor.id, authorName: actor.name })
+      if (note) {
+        setNotes((prev) => [...prev, note])
+        setDraft('')
+        onChanged?.()
+      }
+    } finally {
+      setPosting(false)
+    }
+  }
+
+  const beginEdit = (note: PlantAdminNote) => {
+    setEditingId(note.id)
+    setEditDraft(note.body)
+  }
+
+  const cancelEdit = () => {
+    setEditingId(null)
+    setEditDraft('')
+  }
+
+  const commitEdit = async (note: PlantAdminNote) => {
+    const next = editDraft.trim()
+    if (!next || next === note.body) { cancelEdit(); return }
+    const updated = await updatePlantAdminNote(note, next, { authorId: actor.id, authorName: actor.name })
+    if (updated) {
+      setNotes((prev) => prev.map((n) => (n.id === note.id ? updated : n)))
+      onChanged?.()
+    }
+    cancelEdit()
+  }
+
+  const remove = async (note: PlantAdminNote) => {
+    const ok = await deletePlantAdminNote(note, { authorId: actor.id, authorName: actor.name })
+    if (ok) {
+      setNotes((prev) => prev.filter((n) => n.id !== note.id))
+      onChanged?.()
+    }
+  }
+
+  if (!plantId) {
+    return (
+      <div className="rounded-2xl border border-dashed border-stone-300 dark:border-[#3e3e42] p-5 text-sm text-muted-foreground">
+        Save the plant first to enable admin notes.
+      </div>
+    )
+  }
+
+  return (
+    <div className="rounded-2xl border border-sky-200/70 dark:border-sky-800/40 bg-sky-50/40 dark:bg-sky-950/10 shadow-sm">
+      <div className="flex items-center gap-2 px-4 py-3 border-b border-sky-200/60 dark:border-sky-800/30">
+        <MessageSquare className="h-4 w-4 text-sky-700 dark:text-sky-300" />
+        <h3 className="text-sm font-semibold text-sky-900 dark:text-sky-100">Admin Notes</h3>
+        <span className="text-xs text-muted-foreground ml-auto">
+          {notes.length > 0 ? `${notes.length} ${notes.length === 1 ? 'note' : 'notes'}` : 'No notes yet'}
+        </span>
+      </div>
+
+      <div className="px-4 py-3 space-y-3 max-h-[420px] overflow-y-auto">
+        {loading && !notes.length && (
+          <div className="text-sm text-muted-foreground">Loading notes…</div>
+        )}
+        {!loading && !notes.length && (
+          <div className="text-sm text-muted-foreground italic">
+            No notes yet — start the conversation below.
+          </div>
+        )}
+        {notes.map((note) => {
+          const isEditing = editingId === note.id
+          const edited = note.updatedAt && note.updatedAt !== note.createdAt
+          return (
+            <div key={note.id} className="flex gap-3">
+              <div className="h-8 w-8 rounded-full bg-sky-600 text-white flex items-center justify-center text-xs font-semibold flex-shrink-0">
+                {initialsFor(note.authorName)}
+              </div>
+              <div className="flex-1 min-w-0">
+                <div className="flex items-baseline flex-wrap gap-2">
+                  <span className="text-sm font-medium text-sky-900 dark:text-sky-100">
+                    {note.authorName || 'Unknown'}
+                  </span>
+                  <span className="text-[11px] text-muted-foreground">
+                    {formatStamp(note.createdAt)}
+                    {edited ? ` · edited ${formatStamp(note.updatedAt)}` : ''}
+                  </span>
+                  {!isEditing && (
+                    <span className="ml-auto flex items-center gap-1">
+                      <button
+                        type="button"
+                        aria-label="Edit note"
+                        className="p-1 rounded hover:bg-sky-100 dark:hover:bg-sky-900/40 text-sky-700 dark:text-sky-300"
+                        onClick={() => beginEdit(note)}
+                      >
+                        <Pencil className="h-3.5 w-3.5" />
+                      </button>
+                      <button
+                        type="button"
+                        aria-label="Delete note"
+                        className="p-1 rounded hover:bg-red-100 dark:hover:bg-red-900/30 text-red-600 dark:text-red-400"
+                        onClick={() => remove(note)}
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </button>
+                    </span>
+                  )}
+                </div>
+                {isEditing ? (
+                  <div className="mt-1 space-y-2">
+                    <Textarea
+                      value={editDraft}
+                      onChange={(e) => setEditDraft(e.target.value)}
+                      rows={3}
+                      autoFocus
+                    />
+                    <div className="flex gap-2">
+                      <Button size="sm" type="button" onClick={() => void commitEdit(note)}>
+                        <Check className="h-3.5 w-3.5" /> Save
+                      </Button>
+                      <Button size="sm" type="button" variant="secondary" onClick={cancelEdit}>
+                        <X className="h-3.5 w-3.5" /> Cancel
+                      </Button>
+                    </div>
+                  </div>
+                ) : (
+                  <p className="mt-0.5 text-sm whitespace-pre-wrap text-stone-800 dark:text-stone-100 leading-snug">
+                    {note.body}
+                  </p>
+                )}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+
+      <div className="px-4 py-3 border-t border-sky-200/60 dark:border-sky-800/30 space-y-2">
+        <Textarea
+          placeholder="Write an internal note… (all note actions are recorded in History)"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          rows={2}
+          onKeyDown={(e) => {
+            if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+              e.preventDefault()
+              void handleSubmit()
+            }
+          }}
+        />
+        <div className="flex items-center justify-between">
+          <span className="text-[11px] text-muted-foreground">Ctrl/⌘ + Enter to post</span>
+          <Button type="button" size="sm" onClick={() => void handleSubmit()} disabled={posting || !draft.trim()}>
+            <Send className="h-3.5 w-3.5" /> Post note
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default AdminNotesThread

--- a/plant-swipe/src/components/plant/PlantContributorsPicker.tsx
+++ b/plant-swipe/src/components/plant/PlantContributorsPicker.tsx
@@ -1,0 +1,122 @@
+import React from 'react'
+import { User, X, Users } from 'lucide-react'
+import { SearchItem, type SearchItemOption } from '@/components/ui/search-item'
+import { supabase } from '@/lib/supabaseClient'
+import type { PlantContributor } from '@/types/plant'
+
+interface Props {
+  value: PlantContributor[]
+  onChange: (next: PlantContributor[]) => void
+}
+
+const optionForContributor = (c: PlantContributor): SearchItemOption => ({
+  id: c.id || `legacy:${(c.name || 'unknown').toLowerCase()}`,
+  label: c.name || 'Unknown',
+  description: c.id ? c.id : 'legacy contributor (no profile linked)',
+  icon: <User className="h-4 w-4 text-stone-400 dark:text-stone-500" />,
+})
+
+/**
+ * Multi-select user picker for plant contributors.
+ * - Saves profile ids (via onChange / PlantContributor.id).
+ * - Legacy rows (id=null, name=...) from before the id backfill are shown with
+ *   a neutral avatar and keyed by `legacy:<lowercased name>` so the SearchItem
+ *   can treat them as stable entries. Removing a legacy row strips it from the
+ *   list; adding a matched profile through search replaces any legacy entry
+ *   with the same display name because mergeContributors dedupes by id first.
+ */
+export const PlantContributorsPicker: React.FC<Props> = ({ value, onChange }) => {
+  const searchUsers = React.useCallback(async (query: string): Promise<SearchItemOption[]> => {
+    try {
+      let q = supabase.from('profiles').select('id, display_name, avatar_url, is_admin').limit(20)
+      if (query.trim()) q = q.ilike('display_name', `%${query.trim()}%`)
+      const { data, error } = await q
+      if (error) {
+        console.warn('[PlantContributorsPicker] search failed', error.message)
+        return []
+      }
+      return (data || []).map((u: any) => ({
+        id: String(u.id),
+        label: u.display_name || 'Unknown User',
+        description: u.is_admin ? 'Admin' : u.id,
+        icon: u.avatar_url
+          ? <img src={u.avatar_url} alt="" className="h-4 w-4 rounded-full object-cover" />
+          : <User className="h-4 w-4 text-stone-400 dark:text-stone-500" />,
+      }))
+    } catch (err) {
+      console.warn('[PlantContributorsPicker] search threw', err)
+      return []
+    }
+  }, [])
+
+  const currentOptions = React.useMemo(() => value.map(optionForContributor), [value])
+  const currentIds = React.useMemo(() => currentOptions.map((o) => o.id), [currentOptions])
+
+  const handleMultiSelect = (options: SearchItemOption[]) => {
+    const next: PlantContributor[] = options.map((opt) => {
+      if (opt.id.startsWith('legacy:')) {
+        return { id: null, name: opt.label || null }
+      }
+      return { id: opt.id, name: opt.label || null }
+    })
+    onChange(next)
+  }
+
+  const removeAt = (idx: number) => {
+    const next = value.slice()
+    next.splice(idx, 1)
+    onChange(next)
+  }
+
+  return (
+    <div className="space-y-2">
+      {value.length > 0 ? (
+        <div className="flex flex-wrap gap-2">
+          {value.map((c, idx) => (
+            <span
+              key={(c.id || c.name || 'anon') + ':' + idx}
+              className="inline-flex items-center gap-1.5 rounded-full border border-stone-200 dark:border-[#3e3e42] bg-white dark:bg-[#1e1e20] px-2.5 py-1 text-xs"
+              title={c.id ? `profile ${c.id}` : 'legacy entry (no profile linked)'}
+            >
+              <User className="h-3 w-3 text-stone-500" />
+              <span>{c.name || 'Unknown'}</span>
+              {!c.id && (
+                <span className="text-[10px] text-amber-600 dark:text-amber-400">legacy</span>
+              )}
+              <button
+                type="button"
+                aria-label={`Remove ${c.name || 'contributor'}`}
+                className="ml-0.5 text-stone-400 hover:text-red-600 dark:hover:text-red-400"
+                onClick={() => removeAt(idx)}
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </span>
+          ))}
+        </div>
+      ) : (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Users className="h-4 w-4" />
+          No contributors yet. Search and add users below.
+        </div>
+      )}
+      <SearchItem
+        multiSelect
+        value={null}
+        values={currentIds}
+        selectedOptions={currentOptions}
+        onSelect={() => {}}
+        onMultiSelect={handleMultiSelect}
+        onSearch={searchUsers}
+        placeholder="Add contributor"
+        title="Select contributors"
+        description="Search users by display name. Their profile id will be saved."
+        searchPlaceholder="Search users…"
+        emptyMessage="No users found."
+        confirmLabel="Confirm contributors"
+      />
+    </div>
+  )
+}
+
+export default PlantContributorsPicker

--- a/plant-swipe/src/components/plant/PlantContributorsPicker.tsx
+++ b/plant-swipe/src/components/plant/PlantContributorsPicker.tsx
@@ -10,20 +10,15 @@ interface Props {
 }
 
 const optionForContributor = (c: PlantContributor): SearchItemOption => ({
-  id: c.id || `legacy:${(c.name || 'unknown').toLowerCase()}`,
+  id: c.id,
   label: c.name || 'Unknown',
-  description: c.id ? c.id : 'legacy contributor (no profile linked)',
+  description: c.id,
   icon: <User className="h-4 w-4 text-stone-400 dark:text-stone-500" />,
 })
 
 /**
- * Multi-select user picker for plant contributors.
- * - Saves profile ids (via onChange / PlantContributor.id).
- * - Legacy rows (id=null, name=...) from before the id backfill are shown with
- *   a neutral avatar and keyed by `legacy:<lowercased name>` so the SearchItem
- *   can treat them as stable entries. Removing a legacy row strips it from the
- *   list; adding a matched profile through search replaces any legacy entry
- *   with the same display name because mergeContributors dedupes by id first.
+ * Multi-select user picker for plant contributors. Saves profile ids only —
+ * display names are resolved from `profiles` at read time.
  */
 export const PlantContributorsPicker: React.FC<Props> = ({ value, onChange }) => {
   const searchUsers = React.useCallback(async (query: string): Promise<SearchItemOption[]> => {
@@ -53,13 +48,7 @@ export const PlantContributorsPicker: React.FC<Props> = ({ value, onChange }) =>
   const currentIds = React.useMemo(() => currentOptions.map((o) => o.id), [currentOptions])
 
   const handleMultiSelect = (options: SearchItemOption[]) => {
-    const next: PlantContributor[] = options.map((opt) => {
-      if (opt.id.startsWith('legacy:')) {
-        return { id: null, name: opt.label || null }
-      }
-      return { id: opt.id, name: opt.label || null }
-    })
-    onChange(next)
+    onChange(options.map((opt) => ({ id: opt.id, name: opt.label || null })))
   }
 
   const removeAt = (idx: number) => {
@@ -74,15 +63,12 @@ export const PlantContributorsPicker: React.FC<Props> = ({ value, onChange }) =>
         <div className="flex flex-wrap gap-2">
           {value.map((c, idx) => (
             <span
-              key={(c.id || c.name || 'anon') + ':' + idx}
+              key={c.id + ':' + idx}
               className="inline-flex items-center gap-1.5 rounded-full border border-stone-200 dark:border-[#3e3e42] bg-white dark:bg-[#1e1e20] px-2.5 py-1 text-xs"
-              title={c.id ? `profile ${c.id}` : 'legacy entry (no profile linked)'}
+              title={`profile ${c.id}`}
             >
               <User className="h-3 w-3 text-stone-500" />
               <span>{c.name || 'Unknown'}</span>
-              {!c.id && (
-                <span className="text-[10px] text-amber-600 dark:text-amber-400">legacy</span>
-              )}
               <button
                 type="button"
                 aria-label={`Remove ${c.name || 'contributor'}`}

--- a/plant-swipe/src/components/plant/PlantHistoryPanel.tsx
+++ b/plant-swipe/src/components/plant/PlantHistoryPanel.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { ChevronDown, ChevronUp, History as HistoryIcon, Languages, Pencil, Plus, Sparkles, StickyNote, Trash2 } from 'lucide-react'
 import type { PlantHistoryEntry, PlantHistoryAction } from '@/types/plantHistory'
 import { fetchPlantHistory } from '@/lib/plantHistory'
+import { fetchDisplayNames } from '@/lib/displayNameLookup'
 
 interface Props {
   plantId: string | null | undefined
@@ -73,27 +74,25 @@ interface EntryGroup {
 }
 
 /**
- * Group consecutive entries with the same (author, calendar-hour).
- * Any change in either value starts a new group, preserving chronological order.
+ * Group consecutive entries with the same (author identity, calendar-hour).
+ * Author identity = author_id when available (stable across display-name changes);
+ * otherwise the snapshot author_name as fallback.
  */
 function groupEntries(entries: PlantHistoryEntry[]): EntryGroup[] {
   // Iterate oldest-first so groups read chronologically inside a day.
   const ascending = [...entries].sort((a, b) => a.createdAt.localeCompare(b.createdAt))
   const groups: EntryGroup[] = []
+  const identity = (e: PlantHistoryEntry) => e.authorId || `name:${e.authorName || 'anon'}`
   for (const e of ascending) {
     const bucket = hourBucket(e.createdAt)
     const last = groups[groups.length - 1]
-    if (
-      last
-      && last.hour === bucket
-      && last.authorName === (e.authorName || null)
-      && last.authorId === (e.authorId || null)
-    ) {
+    const lastIdentity = last ? (last.authorId || `name:${last.authorName || 'anon'}`) : null
+    if (last && last.hour === bucket && lastIdentity === identity(e)) {
       last.entries.push(e)
       last.endIso = e.createdAt
     } else {
       groups.push({
-        key: `${bucket}-${e.authorId || e.authorName || 'anon'}-${e.id}`,
+        key: `${bucket}-${identity(e)}-${e.id}`,
         authorName: e.authorName || null,
         authorId: e.authorId || null,
         hour: bucket,
@@ -117,18 +116,28 @@ export const PlantHistoryPanel: React.FC<Props> = ({ plantId, refreshVersion = 0
   const [entries, setEntries] = React.useState<PlantHistoryEntry[]>([])
   const [loading, setLoading] = React.useState(false)
   const [open, setOpen] = React.useState(defaultOpen)
+  const [nameById, setNameById] = React.useState<Map<string, string>>(new Map())
 
   const refresh = React.useCallback(async () => {
     if (!plantId) { setEntries([]); return }
     setLoading(true)
     try {
-      setEntries(await fetchPlantHistory(plantId, 300))
+      const rows = await fetchPlantHistory(plantId, 300)
+      setEntries(rows)
+      const ids = rows.map((r) => r.authorId).filter((x): x is string => Boolean(x))
+      setNameById(await fetchDisplayNames(ids))
     } finally {
       setLoading(false)
     }
   }, [plantId])
 
   React.useEffect(() => { void refresh() }, [refresh, refreshVersion])
+
+  const resolveName = React.useCallback(
+    (authorId: string | null, snapshotName: string | null): string =>
+      (authorId && nameById.get(authorId)) || snapshotName || 'Unknown',
+    [nameById],
+  )
 
   const groups = React.useMemo(() => groupEntries(entries), [entries])
 
@@ -149,15 +158,16 @@ export const PlantHistoryPanel: React.FC<Props> = ({ plantId, refreshVersion = 0
         )
         prevDate = dBucket
       }
+      const displayName = resolveName(g.authorId, g.authorName)
       out.push(
         <div key={g.key} className="flex gap-3 pt-2 pb-2 border-b border-stone-200/40 dark:border-[#3e3e42]/30 last:border-b-0">
           <div className="h-7 w-7 rounded-full bg-stone-300 dark:bg-stone-700 text-stone-800 dark:text-stone-100 flex items-center justify-center text-[10px] font-semibold flex-shrink-0">
-            {initialsFor(g.authorName)}
+            {initialsFor(displayName)}
           </div>
           <div className="flex-1 min-w-0">
             <div className="flex items-baseline gap-2 flex-wrap">
               <span className="text-xs font-semibold text-stone-800 dark:text-stone-100">
-                {g.authorName || 'Unknown'}
+                {displayName}
               </span>
               <span className="text-[11px] text-muted-foreground">
                 {formatTime(g.startIso)}{g.entries.length > 1 ? ` · ${g.entries.length} changes` : ''}
@@ -184,7 +194,7 @@ export const PlantHistoryPanel: React.FC<Props> = ({ plantId, refreshVersion = 0
       )
     }
     return out
-  }, [groups])
+  }, [groups, resolveName])
 
   return (
     <div className="rounded-2xl border border-stone-200 dark:border-[#3e3e42] bg-white/80 dark:bg-[#17171a]/80">

--- a/plant-swipe/src/components/plant/PlantHistoryPanel.tsx
+++ b/plant-swipe/src/components/plant/PlantHistoryPanel.tsx
@@ -65,7 +65,6 @@ const dateBucket = (iso: string): string => {
 
 interface EntryGroup {
   key: string
-  authorName: string | null
   authorId: string | null
   hour: string
   startIso: string
@@ -74,26 +73,24 @@ interface EntryGroup {
 }
 
 /**
- * Group consecutive entries with the same (author identity, calendar-hour).
- * Author identity = author_id when available (stable across display-name changes);
- * otherwise the snapshot author_name as fallback.
+ * Group consecutive entries with the same (author_id, calendar-hour).
+ * Unknown authors (no author_id — profile deleted) are grouped together as 'anon'.
  */
 function groupEntries(entries: PlantHistoryEntry[]): EntryGroup[] {
   // Iterate oldest-first so groups read chronologically inside a day.
   const ascending = [...entries].sort((a, b) => a.createdAt.localeCompare(b.createdAt))
   const groups: EntryGroup[] = []
-  const identity = (e: PlantHistoryEntry) => e.authorId || `name:${e.authorName || 'anon'}`
+  const identity = (e: PlantHistoryEntry) => e.authorId || 'anon'
   for (const e of ascending) {
     const bucket = hourBucket(e.createdAt)
     const last = groups[groups.length - 1]
-    const lastIdentity = last ? (last.authorId || `name:${last.authorName || 'anon'}`) : null
+    const lastIdentity = last ? (last.authorId || 'anon') : null
     if (last && last.hour === bucket && lastIdentity === identity(e)) {
       last.entries.push(e)
       last.endIso = e.createdAt
     } else {
       groups.push({
         key: `${bucket}-${identity(e)}-${e.id}`,
-        authorName: e.authorName || null,
         authorId: e.authorId || null,
         hour: bucket,
         startIso: e.createdAt,
@@ -134,8 +131,8 @@ export const PlantHistoryPanel: React.FC<Props> = ({ plantId, refreshVersion = 0
   React.useEffect(() => { void refresh() }, [refresh, refreshVersion])
 
   const resolveName = React.useCallback(
-    (authorId: string | null, snapshotName: string | null): string =>
-      (authorId && nameById.get(authorId)) || snapshotName || 'Unknown',
+    (authorId: string | null): string =>
+      (authorId && nameById.get(authorId)) || 'Unknown',
     [nameById],
   )
 
@@ -158,7 +155,7 @@ export const PlantHistoryPanel: React.FC<Props> = ({ plantId, refreshVersion = 0
         )
         prevDate = dBucket
       }
-      const displayName = resolveName(g.authorId, g.authorName)
+      const displayName = resolveName(g.authorId)
       out.push(
         <div key={g.key} className="flex gap-3 pt-2 pb-2 border-b border-stone-200/40 dark:border-[#3e3e42]/30 last:border-b-0">
           <div className="h-7 w-7 rounded-full bg-stone-300 dark:bg-stone-700 text-stone-800 dark:text-stone-100 flex items-center justify-center text-[10px] font-semibold flex-shrink-0">

--- a/plant-swipe/src/components/plant/PlantHistoryPanel.tsx
+++ b/plant-swipe/src/components/plant/PlantHistoryPanel.tsx
@@ -1,0 +1,222 @@
+import React from 'react'
+import { ChevronDown, ChevronUp, History as HistoryIcon, Languages, Pencil, Plus, Sparkles, StickyNote, Trash2 } from 'lucide-react'
+import type { PlantHistoryEntry, PlantHistoryAction } from '@/types/plantHistory'
+import { fetchPlantHistory } from '@/lib/plantHistory'
+
+interface Props {
+  plantId: string | null | undefined
+  refreshVersion?: number
+  /** Optional initial open state. */
+  defaultOpen?: boolean
+}
+
+const actionIcon = (action: PlantHistoryAction) => {
+  switch (action) {
+    case 'translate': return Languages
+    case 'ai_fill': return Sparkles
+    case 'note_add': return Plus
+    case 'note_edit': return Pencil
+    case 'note_delete': return Trash2
+    case 'create': return Plus
+    case 'status_change': return StickyNote
+    default: return Pencil
+  }
+}
+
+const actionColor = (action: PlantHistoryAction): string => {
+  switch (action) {
+    case 'translate': return 'text-indigo-600 dark:text-indigo-300'
+    case 'ai_fill': return 'text-amber-600 dark:text-amber-300'
+    case 'note_add': return 'text-emerald-600 dark:text-emerald-300'
+    case 'note_edit': return 'text-sky-600 dark:text-sky-300'
+    case 'note_delete': return 'text-red-600 dark:text-red-300'
+    case 'create': return 'text-emerald-600 dark:text-emerald-300'
+    case 'status_change': return 'text-purple-600 dark:text-purple-300'
+    default: return 'text-stone-600 dark:text-stone-300'
+  }
+}
+
+const formatTime = (iso: string): string => {
+  const d = new Date(iso)
+  return d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })
+}
+
+const formatDateHeading = (iso: string): string => {
+  const d = new Date(iso)
+  const today = new Date()
+  const same = d.getFullYear() === today.getFullYear() && d.getMonth() === today.getMonth() && d.getDate() === today.getDate()
+  const yday = new Date(today); yday.setDate(today.getDate() - 1)
+  const isYday = d.getFullYear() === yday.getFullYear() && d.getMonth() === yday.getMonth() && d.getDate() === yday.getDate()
+  if (same) return 'Today'
+  if (isYday) return 'Yesterday'
+  return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
+}
+
+const hourBucket = (iso: string): string => {
+  const d = new Date(iso)
+  return `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}-${d.getHours()}`
+}
+
+const dateBucket = (iso: string): string => {
+  const d = new Date(iso)
+  return `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`
+}
+
+interface EntryGroup {
+  key: string
+  authorName: string | null
+  authorId: string | null
+  hour: string
+  startIso: string
+  endIso: string
+  entries: PlantHistoryEntry[]
+}
+
+/**
+ * Group consecutive entries with the same (author, calendar-hour).
+ * Any change in either value starts a new group, preserving chronological order.
+ */
+function groupEntries(entries: PlantHistoryEntry[]): EntryGroup[] {
+  // Iterate oldest-first so groups read chronologically inside a day.
+  const ascending = [...entries].sort((a, b) => a.createdAt.localeCompare(b.createdAt))
+  const groups: EntryGroup[] = []
+  for (const e of ascending) {
+    const bucket = hourBucket(e.createdAt)
+    const last = groups[groups.length - 1]
+    if (
+      last
+      && last.hour === bucket
+      && last.authorName === (e.authorName || null)
+      && last.authorId === (e.authorId || null)
+    ) {
+      last.entries.push(e)
+      last.endIso = e.createdAt
+    } else {
+      groups.push({
+        key: `${bucket}-${e.authorId || e.authorName || 'anon'}-${e.id}`,
+        authorName: e.authorName || null,
+        authorId: e.authorId || null,
+        hour: bucket,
+        startIso: e.createdAt,
+        endIso: e.createdAt,
+        entries: [e],
+      })
+    }
+  }
+  // Return newest-first for display.
+  return groups.reverse()
+}
+
+const initialsFor = (name: string | null): string => {
+  if (!name) return '?'
+  const parts = name.trim().split(/\s+/).slice(0, 2)
+  return parts.map((p) => p[0]?.toUpperCase() || '').join('') || '?'
+}
+
+export const PlantHistoryPanel: React.FC<Props> = ({ plantId, refreshVersion = 0, defaultOpen = false }) => {
+  const [entries, setEntries] = React.useState<PlantHistoryEntry[]>([])
+  const [loading, setLoading] = React.useState(false)
+  const [open, setOpen] = React.useState(defaultOpen)
+
+  const refresh = React.useCallback(async () => {
+    if (!plantId) { setEntries([]); return }
+    setLoading(true)
+    try {
+      setEntries(await fetchPlantHistory(plantId, 300))
+    } finally {
+      setLoading(false)
+    }
+  }, [plantId])
+
+  React.useEffect(() => { void refresh() }, [refresh, refreshVersion])
+
+  const groups = React.useMemo(() => groupEntries(entries), [entries])
+
+  // Render with day headings inserted whenever the calendar day changes.
+  const rendered = React.useMemo(() => {
+    const out: React.ReactNode[] = []
+    let prevDate: string | null = null
+    for (const g of groups) {
+      const dBucket = dateBucket(g.startIso)
+      if (dBucket !== prevDate) {
+        out.push(
+          <div
+            key={`heading-${dBucket}`}
+            className="sticky top-0 z-10 -mx-4 px-4 py-1 bg-stone-100/90 dark:bg-[#1b1b1d]/90 backdrop-blur border-y border-stone-200/70 dark:border-[#3e3e42]/60 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground"
+          >
+            {formatDateHeading(g.startIso)}
+          </div>,
+        )
+        prevDate = dBucket
+      }
+      out.push(
+        <div key={g.key} className="flex gap-3 pt-2 pb-2 border-b border-stone-200/40 dark:border-[#3e3e42]/30 last:border-b-0">
+          <div className="h-7 w-7 rounded-full bg-stone-300 dark:bg-stone-700 text-stone-800 dark:text-stone-100 flex items-center justify-center text-[10px] font-semibold flex-shrink-0">
+            {initialsFor(g.authorName)}
+          </div>
+          <div className="flex-1 min-w-0">
+            <div className="flex items-baseline gap-2 flex-wrap">
+              <span className="text-xs font-semibold text-stone-800 dark:text-stone-100">
+                {g.authorName || 'Unknown'}
+              </span>
+              <span className="text-[11px] text-muted-foreground">
+                {formatTime(g.startIso)}{g.entries.length > 1 ? ` · ${g.entries.length} changes` : ''}
+              </span>
+            </div>
+            <ul className="mt-1 space-y-0.5">
+              {g.entries.map((e) => {
+                const Icon = actionIcon(e.action)
+                return (
+                  <li key={e.id} className="flex items-center gap-2 text-[12px] leading-snug">
+                    <Icon className={`h-3 w-3 flex-shrink-0 ${actionColor(e.action)}`} />
+                    <span className="text-muted-foreground tabular-nums text-[10px] w-10">
+                      {formatTime(e.createdAt)}
+                    </span>
+                    <span className="truncate text-stone-700 dark:text-stone-200" title={e.summary || undefined}>
+                      {e.summary || e.field || e.action}
+                    </span>
+                  </li>
+                )
+              })}
+            </ul>
+          </div>
+        </div>,
+      )
+    }
+    return out
+  }, [groups])
+
+  return (
+    <div className="rounded-2xl border border-stone-200 dark:border-[#3e3e42] bg-white/80 dark:bg-[#17171a]/80">
+      <button
+        type="button"
+        className="w-full flex items-center gap-2 px-4 py-3 text-left hover:bg-stone-50 dark:hover:bg-[#1f1f22] rounded-2xl transition-colors"
+        onClick={() => setOpen((v) => !v)}
+      >
+        <HistoryIcon className="h-4 w-4 text-stone-600 dark:text-stone-300" />
+        <h3 className="text-sm font-semibold text-stone-800 dark:text-stone-100">Change History</h3>
+        <span className="text-xs text-muted-foreground ml-2">
+          {loading ? 'loading…' : entries.length > 0 ? `${entries.length} ${entries.length === 1 ? 'entry' : 'entries'}` : 'No history yet'}
+        </span>
+        <span className="ml-auto text-muted-foreground">
+          {open ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+        </span>
+      </button>
+      {open && (
+        <div className="px-4 pb-4 max-h-[420px] overflow-y-auto">
+          {!plantId ? (
+            <p className="text-sm text-muted-foreground">Save the plant to start tracking history.</p>
+          ) : !entries.length && !loading ? (
+            <p className="text-sm text-muted-foreground italic">No changes recorded yet.</p>
+          ) : (
+            <div className="divide-y divide-stone-200/30 dark:divide-[#3e3e42]/20">
+              {rendered}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default PlantHistoryPanel

--- a/plant-swipe/src/components/plant/PlantProfileForm.tsx
+++ b/plant-swipe/src/components/plant/PlantProfileForm.tsx
@@ -1270,8 +1270,8 @@ const metaFields: FieldConfig[] = [
     { label: "Review", value: "review" },
     { label: "In Progress", value: "in_progress" },
   ] },
-  { key: "adminCommentary", label: "Admin Notes", description: "Internal notes for editors", type: "textarea" },
-  { key: "contributors", label: "Contributors", description: "People who contributed to this plant entry", type: "tags", tagConfig: { unique: true, caseInsensitive: true } },
+  // adminCommentary removed — replaced by the plant_admin_notes thread slot.
+  // contributors removed — replaced by the SearchItem-backed contributorsSlot.
 ]
 
 function renderField(plant: Plant, onChange: (path: string, value: any) => void, field: FieldConfig, t: TFunction<'plantAdmin'>) {
@@ -3124,12 +3124,9 @@ export function PlantProfileForm({ value, onChange, colorSuggestions, companionS
   )
 
   const renderMeta = () => {
-    const skipKeys = new Set<string>()
-    if (adminNotesSlot) skipKeys.add('adminCommentary')
-    if (contributorsSlot) skipKeys.add('contributors')
     return (
     <div className="space-y-5">
-      {renderFieldGroup(metaFields, skipKeys.size ? { skipKeys } : undefined)}
+      {renderFieldGroup(metaFields)}
       {adminNotesSlot}
       {contributorsSlot ? (
         <div>

--- a/plant-swipe/src/components/plant/PlantProfileForm.tsx
+++ b/plant-swipe/src/components/plant/PlantProfileForm.tsx
@@ -54,6 +54,8 @@ export type PlantProfileFormProps = {
   adminNotesSlot?: React.ReactNode
   /** Slot rendered at the bottom of the Meta section (plant change history). */
   historySlot?: React.ReactNode
+  /** Replaces the Contributors tags field with a user-search multi-select. */
+  contributorsSlot?: React.ReactNode
 }
 
 const glassCardClass =
@@ -2605,7 +2607,7 @@ function ColorPicker({ colors, onChange }: { colors: PlantColor[]; onChange: (v:
   )
 }
 
-export function PlantProfileForm({ value, onChange, colorSuggestions, companionSuggestions, biotopeSuggestions, beneficialSuggestions, harmfulSuggestions, categoryProgress, language = 'en', onImageRemove, onUploadImages, plantReports, plantVarieties, adminNotesSlot, historySlot }: PlantProfileFormProps) {
+export function PlantProfileForm({ value, onChange, colorSuggestions, companionSuggestions, biotopeSuggestions, beneficialSuggestions, harmfulSuggestions, categoryProgress, language = 'en', onImageRemove, onUploadImages, plantReports, plantVarieties, adminNotesSlot, historySlot, contributorsSlot }: PlantProfileFormProps) {
   const { t } = useTranslation('plantAdmin')
   const [selectedCategory, setSelectedCategory] = React.useState<string>('base')
   const [showColorRecommendations, setShowColorRecommendations] = React.useState(false)
@@ -3121,10 +3123,25 @@ export function PlantProfileForm({ value, onChange, colorSuggestions, companionS
     </div>
   )
 
-  const renderMeta = () => (
+  const renderMeta = () => {
+    const skipKeys = new Set<string>()
+    if (adminNotesSlot) skipKeys.add('adminCommentary')
+    if (contributorsSlot) skipKeys.add('contributors')
+    return (
     <div className="space-y-5">
-      {renderFieldGroup(metaFields, adminNotesSlot ? { skipKeys: new Set(['adminCommentary']) } : undefined)}
+      {renderFieldGroup(metaFields, skipKeys.size ? { skipKeys } : undefined)}
       {adminNotesSlot}
+      {contributorsSlot ? (
+        <div>
+          <label className="block text-sm font-medium mb-1.5">
+            {t('plantAdmin.fields.contributors.label', { defaultValue: 'Contributors' })}
+          </label>
+          <p className="text-xs text-muted-foreground mb-2">
+            {t('plantAdmin.fields.contributors.description', { defaultValue: 'People who contributed to this plant entry' })}
+          </p>
+          {contributorsSlot}
+        </div>
+      ) : null}
       {historySlot}
       {plantReports && plantReports.length > 0 && (
         <>
@@ -3151,7 +3168,8 @@ export function PlantProfileForm({ value, onChange, colorSuggestions, companionS
         </>
       )}
     </div>
-  )
+    )
+  }
 
   const sectionRenderers: Record<string, () => React.ReactNode> = {
     base: renderBase,

--- a/plant-swipe/src/components/plant/PlantProfileForm.tsx
+++ b/plant-swipe/src/components/plant/PlantProfileForm.tsx
@@ -50,6 +50,10 @@ export type PlantProfileFormProps = {
   plantReports?: PlantReport[]
   /** Auto-detected varieties (same species, different variety) */
   plantVarieties?: PlantVariety[]
+  /** Replaces the Admin Notes textarea with a chat-style thread. */
+  adminNotesSlot?: React.ReactNode
+  /** Slot rendered at the bottom of the Meta section (plant change history). */
+  historySlot?: React.ReactNode
 }
 
 const glassCardClass =
@@ -2601,7 +2605,7 @@ function ColorPicker({ colors, onChange }: { colors: PlantColor[]; onChange: (v:
   )
 }
 
-export function PlantProfileForm({ value, onChange, colorSuggestions, companionSuggestions, biotopeSuggestions, beneficialSuggestions, harmfulSuggestions, categoryProgress, language = 'en', onImageRemove, onUploadImages, plantReports, plantVarieties }: PlantProfileFormProps) {
+export function PlantProfileForm({ value, onChange, colorSuggestions, companionSuggestions, biotopeSuggestions, beneficialSuggestions, harmfulSuggestions, categoryProgress, language = 'en', onImageRemove, onUploadImages, plantReports, plantVarieties, adminNotesSlot, historySlot }: PlantProfileFormProps) {
   const { t } = useTranslation('plantAdmin')
   const [selectedCategory, setSelectedCategory] = React.useState<string>('base')
   const [showColorRecommendations, setShowColorRecommendations] = React.useState(false)
@@ -3119,7 +3123,9 @@ export function PlantProfileForm({ value, onChange, colorSuggestions, companionS
 
   const renderMeta = () => (
     <div className="space-y-5">
-      {renderFieldGroup(metaFields)}
+      {renderFieldGroup(metaFields, adminNotesSlot ? { skipKeys: new Set(['adminCommentary']) } : undefined)}
+      {adminNotesSlot}
+      {historySlot}
       {plantReports && plantReports.length > 0 && (
         <>
           <SectionDivider title={`${t('plantAdmin.userReports', 'User Reports')} (${plantReports.length})`} />

--- a/plant-swipe/src/lib/aiPrefillService.ts
+++ b/plant-swipe/src/lib/aiPrefillService.ts
@@ -45,7 +45,7 @@ import { BOOLEAN_GATE_DEPS, UTILITY_GATE_DEPS } from "@/lib/plantFormCategories"
 const AI_EXCLUDED_FIELDS = new Set([
   'name', 'variety', 'image', 'imageurl', 'image_url', 'imageURL', 'images',
   // Meta fields — admin-only
-  'meta', 'adminCommentary', 'contributors', 'status',
+  'meta', 'contributors', 'status',
   // Featured months — curated by admin
   'featuredMonth',
   // Plant link fields — AI is unaware of plants in our DB
@@ -162,37 +162,22 @@ const normalizeTimePeriodSlug = (value?: string | null): string | null => {
   return slug || null
 }
 
-type AiContributor = { id: string | null; name: string | null }
+type AiContributor = { id: string }
 
 const mergeContributors = (
-  existing: Array<AiContributor | string | null | undefined>,
-  extras: Array<AiContributor | string | null | undefined>,
+  existing: Array<AiContributor | { id?: unknown } | null | undefined>,
+  extras: Array<AiContributor | { id?: unknown } | null | undefined>,
 ): AiContributor[] => {
-  const combined = [...existing, ...extras]
-  const seenIds = new Set<string>()
-  const seenNames = new Set<string>()
+  const seen = new Set<string>()
   const out: AiContributor[] = []
-  for (const entry of combined) {
-    if (entry == null) continue
-    let id: string | null = null
-    let name: string | null = null
-    if (typeof entry === 'string') {
-      name = entry.trim() || null
-    } else if (typeof entry === 'object') {
-      const raw = entry as { id?: unknown; name?: unknown }
-      if (typeof raw.id === 'string' && raw.id.trim()) id = raw.id.trim()
-      if (typeof raw.name === 'string' && raw.name.trim()) name = raw.name.trim()
-    }
-    if (!id && !name) continue
-    if (id) {
-      if (seenIds.has(id)) continue
-      seenIds.add(id)
-    } else if (name) {
-      const k = name.toLowerCase()
-      if (seenNames.has(k)) continue
-      seenNames.add(k)
-    }
-    out.push({ id, name })
+  for (const entry of [...existing, ...extras]) {
+    if (!entry || typeof entry !== 'object') continue
+    const id = (entry as { id?: unknown }).id
+    if (typeof id !== 'string' || !id.trim()) continue
+    const trimmed = id.trim()
+    if (seen.has(trimmed)) continue
+    seen.add(trimmed)
+    out.push({ id: trimmed })
   }
   return out
 }
@@ -220,15 +205,14 @@ async function fetchRequestContributors(requestId: string): Promise<AiContributo
     if (userIds.size === 0) return []
     const { data: profilesData, error: profilesError } = await supabase
       .from('profiles')
-      .select('id, display_name')
+      .select('id')
       .in('id', Array.from(userIds))
     if (profilesError) throw new Error(profilesError.message)
     const contributors: AiContributor[] = (profilesData || [])
-      .map((profile: any) => ({
-        id: typeof profile?.id === 'string' ? profile.id : null,
-        name: typeof profile?.display_name === 'string' ? profile.display_name.trim() || null : null,
-      }))
-      .filter((c) => c.id || c.name)
+      .map((profile: any): AiContributor | null =>
+        typeof profile?.id === 'string' && profile.id ? { id: profile.id } : null,
+      )
+      .filter((c): c is AiContributor => Boolean(c))
     return mergeContributors(contributors, [])
   } catch (err) {
     console.warn('[aiPrefillService] Failed to load request contributors', err)
@@ -376,13 +360,8 @@ async function upsertContributors(plantId: string, contributors: AiContributor[]
   await supabase.from('plant_contributors').delete().eq('plant_id', plantId)
   if (!contributors.length) return
   const rows = contributors
-    .map((c) => {
-      const id = c.id && c.id.trim() ? c.id.trim() : null
-      const name = c.name && c.name.trim() ? c.name.trim() : null
-      if (!id && !name) return null
-      return { plant_id: plantId, contributor_id: id, contributor_name: name }
-    })
-    .filter((r): r is { plant_id: string; contributor_id: string | null; contributor_name: string | null } => Boolean(r))
+    .map((c) => (c.id && c.id.trim() ? { plant_id: plantId, contributor_id: c.id.trim() } : null))
+    .filter((r): r is { plant_id: string; contributor_id: string } => Boolean(r))
   if (!rows.length) return
   const { error } = await supabase.from('plant_contributors').insert(rows)
   if (error) throw new Error(error.message)
@@ -711,9 +690,13 @@ export async function processPlantRequest(
     const normalizedStatus = String(plant.status || 'in_progress').toLowerCase()
     const createdTimeValue = new Date().toISOString()
     const requestContributors = await fetchRequestContributors(requestId)
-    const contributors = mergeContributors(requestContributors, [
-      { id: null, name: createdBy ?? null },
-    ])
+    // Seed in the admin who launched the run (by profile id). `createdBy` is
+    // kept only for the plants.created_by display string; contributors are
+    // id-only.
+    const contributors = mergeContributors(
+      requestContributors,
+      authorId ? [{ id: authorId }] : [],
+    )
     
     // Pre-save cleanup: clear fields that are gated off by boolean toggles or missing utility values
     // This prevents AI-filled data from being saved when its gate is disabled
@@ -820,7 +803,6 @@ export async function processPlantRequest(
       harmful_plants: filterValidUuids(plant.harmfulPlants),
       // Section 9: Meta
       status: normalizedStatus,
-      admin_commentary: plant.adminCommentary || null,
       created_by: createdBy || null,
       created_time: createdTimeValue,
       updated_by: createdBy || null,

--- a/plant-swipe/src/lib/aiPrefillService.ts
+++ b/plant-swipe/src/lib/aiPrefillService.ts
@@ -9,6 +9,7 @@ import { supabase } from "@/lib/supabaseClient"
 import { fetchAiPlantFill, getEnglishPlantName } from "@/lib/aiPlantFill"
 import { fetchExternalPlantImages, uploadPlantImageFromUrl, type SourceResult, type ExternalImageSource } from "@/lib/externalImages"
 import { translateBatch } from "@/lib/deepl"
+import { logPlantHistory } from "@/lib/plantHistory"
 import { SUPPORTED_LANGUAGES, type SupportedLanguage } from "@/lib/i18n"
 import { applyAiFieldToPlant } from "@/lib/applyAiField"
 import { plantSchema } from "@/lib/plantSchema"
@@ -455,7 +456,8 @@ export async function processPlantRequest(
   plantName: string,
   requestId: string,
   createdBy: string | undefined,
-  callbacks?: AiPrefillCallbacks
+  callbacks?: AiPrefillCallbacks,
+  authorId?: string | null,
 ): Promise<{ success: boolean; plantId?: string; error?: string; cancelled?: boolean }> {
   const { onProgress, onFieldComplete, onFieldStart, onImageSourceStart, onImageSourceDone, onImageUploadProgress, onError, signal } = callbacks || {}
   
@@ -1215,9 +1217,17 @@ export async function processPlantRequest(
       console.error('Failed to delete plant request:', deleteError)
       // Don't fail - the plant was created successfully
     }
-    
+
+    // Plant-history entry: creation via AI Plant Request.
+    await logPlantHistory({
+      plantId,
+      authorId: authorId ?? null,
+      action: 'create',
+      summary: `Created plant via AI Plant Request ("${plantName}")`,
+    })
+
     return { success: true, plantId }
-    
+
   } catch (error) {
     // Don't report cancellation errors as failures - they're intentional
     if (isCancellationError(error)) {
@@ -1239,7 +1249,8 @@ export async function processAllPlantRequests(
   callbacks?: AiPrefillCallbacks & {
     onPlantProgress?: (info: { current: number; total: number; plantName: string }) => void
     onPlantComplete?: (info: { plantName: string; requestId: string; success: boolean; error?: string }) => void
-  }
+  },
+  authorId?: string | null,
 ): Promise<{ processed: number; failed: number; cancelled: boolean }> {
   const { onPlantProgress, onPlantComplete, signal } = callbacks || {}
   
@@ -1259,7 +1270,8 @@ export async function processAllPlantRequests(
       request.plant_name,
       request.id,
       createdBy,
-      callbacks
+      callbacks,
+      authorId,
     )
     
     // If the operation was cancelled, stop processing and don't count as failure

--- a/plant-swipe/src/lib/aiPrefillService.ts
+++ b/plant-swipe/src/lib/aiPrefillService.ts
@@ -162,26 +162,42 @@ const normalizeTimePeriodSlug = (value?: string | null): string | null => {
   return slug || null
 }
 
-const mergeContributorNames = (
-  existing: Array<string | null | undefined>,
-  extras: Array<string | null | undefined>,
-): string[] => {
+type AiContributor = { id: string | null; name: string | null }
+
+const mergeContributors = (
+  existing: Array<AiContributor | string | null | undefined>,
+  extras: Array<AiContributor | string | null | undefined>,
+): AiContributor[] => {
   const combined = [...existing, ...extras]
-  const seen = new Set<string>()
-  const result: string[] = []
+  const seenIds = new Set<string>()
+  const seenNames = new Set<string>()
+  const out: AiContributor[] = []
   for (const entry of combined) {
-    if (typeof entry !== 'string') continue
-    const trimmed = entry.trim()
-    if (!trimmed) continue
-    const key = trimmed.toLowerCase()
-    if (seen.has(key)) continue
-    seen.add(key)
-    result.push(trimmed)
+    if (entry == null) continue
+    let id: string | null = null
+    let name: string | null = null
+    if (typeof entry === 'string') {
+      name = entry.trim() || null
+    } else if (typeof entry === 'object') {
+      const raw = entry as { id?: unknown; name?: unknown }
+      if (typeof raw.id === 'string' && raw.id.trim()) id = raw.id.trim()
+      if (typeof raw.name === 'string' && raw.name.trim()) name = raw.name.trim()
+    }
+    if (!id && !name) continue
+    if (id) {
+      if (seenIds.has(id)) continue
+      seenIds.add(id)
+    } else if (name) {
+      const k = name.toLowerCase()
+      if (seenNames.has(k)) continue
+      seenNames.add(k)
+    }
+    out.push({ id, name })
   }
-  return result
+  return out
 }
 
-async function fetchRequestContributors(requestId: string): Promise<string[]> {
+async function fetchRequestContributors(requestId: string): Promise<AiContributor[]> {
   if (!requestId) return []
   try {
     const { data: requestUsersData, error: usersError } = await supabase
@@ -207,11 +223,13 @@ async function fetchRequestContributors(requestId: string): Promise<string[]> {
       .select('id, display_name')
       .in('id', Array.from(userIds))
     if (profilesError) throw new Error(profilesError.message)
-    const names = (profilesData || [])
-      .map((profile: any) => profile?.display_name)
-      .filter((name: any) => typeof name === 'string' && name.trim())
-      .map((name: string) => name.trim())
-    return mergeContributorNames(names, [])
+    const contributors: AiContributor[] = (profilesData || [])
+      .map((profile: any) => ({
+        id: typeof profile?.id === 'string' ? profile.id : null,
+        name: typeof profile?.display_name === 'string' ? profile.display_name.trim() || null : null,
+      }))
+      .filter((c) => c.id || c.name)
+    return mergeContributors(contributors, [])
   } catch (err) {
     console.warn('[aiPrefillService] Failed to load request contributors', err)
     return []
@@ -354,15 +372,17 @@ async function upsertSources(plantId: string, sources?: PlantSource[]) {
   if (error) throw new Error(error.message)
 }
 
-async function upsertContributors(plantId: string, contributors: string[]) {
+async function upsertContributors(plantId: string, contributors: AiContributor[]) {
   await supabase.from('plant_contributors').delete().eq('plant_id', plantId)
   if (!contributors.length) return
   const rows = contributors
-    .filter((name) => typeof name === 'string' && name.trim())
-    .map((name) => ({
-      plant_id: plantId,
-      contributor_name: name.trim(),
-    }))
+    .map((c) => {
+      const id = c.id && c.id.trim() ? c.id.trim() : null
+      const name = c.name && c.name.trim() ? c.name.trim() : null
+      if (!id && !name) return null
+      return { plant_id: plantId, contributor_id: id, contributor_name: name }
+    })
+    .filter((r): r is { plant_id: string; contributor_id: string | null; contributor_name: string | null } => Boolean(r))
   if (!rows.length) return
   const { error } = await supabase.from('plant_contributors').insert(rows)
   if (error) throw new Error(error.message)
@@ -691,7 +711,9 @@ export async function processPlantRequest(
     const normalizedStatus = String(plant.status || 'in_progress').toLowerCase()
     const createdTimeValue = new Date().toISOString()
     const requestContributors = await fetchRequestContributors(requestId)
-    const contributors = mergeContributorNames(requestContributors, [createdBy])
+    const contributors = mergeContributors(requestContributors, [
+      { id: null, name: createdBy ?? null },
+    ])
     
     // Pre-save cleanup: clear fields that are gated off by boolean toggles or missing utility values
     // This prevents AI-filled data from being saved when its gate is disabled

--- a/plant-swipe/src/lib/applyAiField.ts
+++ b/plant-swipe/src/lib/applyAiField.ts
@@ -193,7 +193,7 @@ const TEXT_FIELDS = new Set([
   'nutritionalValue', 'infusionBenefits', 'infusionRecipeIdeas',
   'medicinalBenefits', 'medicinalUsage', 'medicinalWarning', 'medicinalHistory',
   'aromatherapyBenefits', 'essentialOilBlends',
-  'symbiosisNotes', 'adminCommentary',
+  'symbiosisNotes',
 ])
 
 // String array (tag) fields

--- a/plant-swipe/src/lib/displayNameLookup.ts
+++ b/plant-swipe/src/lib/displayNameLookup.ts
@@ -1,0 +1,24 @@
+import { supabase } from '@/lib/supabaseClient'
+
+/**
+ * Fetch current display_name for a set of profile ids.
+ * Returns a map keyed by profile id. Missing/failed lookups are omitted
+ * so callers can fall back to their snapshot copy of the name.
+ */
+export async function fetchDisplayNames(ids: Iterable<string>): Promise<Map<string, string>> {
+  const unique = Array.from(new Set(Array.from(ids).filter((x): x is string => Boolean(x))))
+  const out = new Map<string, string>()
+  if (!unique.length) return out
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('id, display_name')
+    .in('id', unique)
+  if (error) {
+    console.warn('[displayNameLookup] fetch failed', error.message)
+    return out
+  }
+  for (const row of data || []) {
+    if (row?.id && row?.display_name) out.set(row.id as string, row.display_name as string)
+  }
+  return out
+}

--- a/plant-swipe/src/lib/plantAdminNotes.ts
+++ b/plant-swipe/src/lib/plantAdminNotes.ts
@@ -1,0 +1,122 @@
+import { supabase } from '@/lib/supabaseClient'
+import type { PlantAdminNote } from '@/types/plantHistory'
+import { logPlantHistory } from '@/lib/plantHistory'
+
+/* eslint-disable @typescript-eslint/no-explicit-any -- dynamic supabase rows */
+
+const rowToNote = (row: any): PlantAdminNote => ({
+  id: row.id,
+  plantId: row.plant_id,
+  authorId: row.author_id ?? null,
+  authorName: row.author_name ?? null,
+  body: row.body,
+  createdAt: row.created_at,
+  updatedAt: row.updated_at,
+})
+
+export async function fetchPlantAdminNotes(plantId: string): Promise<PlantAdminNote[]> {
+  if (!plantId) return []
+  const { data, error } = await supabase
+    .from('plant_admin_notes')
+    .select('*')
+    .eq('plant_id', plantId)
+    .order('created_at', { ascending: true })
+  if (error) {
+    console.warn('[plantAdminNotes] fetch failed', error.message)
+    return []
+  }
+  return (data || []).map(rowToNote)
+}
+
+interface Actor {
+  authorId?: string | null
+  authorName?: string | null
+}
+
+export async function createPlantAdminNote(
+  plantId: string,
+  body: string,
+  actor: Actor,
+): Promise<PlantAdminNote | null> {
+  const trimmed = body.trim()
+  if (!plantId || !trimmed) return null
+  const { data, error } = await supabase
+    .from('plant_admin_notes')
+    .insert({
+      plant_id: plantId,
+      author_id: actor.authorId ?? null,
+      author_name: actor.authorName ?? null,
+      body: trimmed,
+    })
+    .select('*')
+    .maybeSingle()
+  if (error || !data) {
+    console.warn('[plantAdminNotes] create failed', error?.message)
+    return null
+  }
+  await logPlantHistory({
+    plantId,
+    authorId: actor.authorId,
+    authorName: actor.authorName,
+    action: 'note_add',
+    summary: 'Added note',
+    newValue: trimmed,
+  })
+  return rowToNote(data)
+}
+
+export async function updatePlantAdminNote(
+  note: PlantAdminNote,
+  nextBody: string,
+  actor: Actor,
+): Promise<PlantAdminNote | null> {
+  const trimmed = nextBody.trim()
+  if (!trimmed || trimmed === note.body) return note
+  const { data, error } = await supabase
+    .from('plant_admin_notes')
+    .update({ body: trimmed, updated_at: new Date().toISOString() })
+    .eq('id', note.id)
+    .select('*')
+    .maybeSingle()
+  if (error || !data) {
+    console.warn('[plantAdminNotes] update failed', error?.message)
+    return null
+  }
+  await logPlantHistory({
+    plantId: note.plantId,
+    authorId: actor.authorId,
+    authorName: actor.authorName,
+    action: 'note_edit',
+    summary: note.authorName && note.authorName !== actor.authorName
+      ? `Edited note by ${note.authorName}`
+      : 'Edited note',
+    oldValue: note.body,
+    newValue: trimmed,
+  })
+  return rowToNote(data)
+}
+
+export async function deletePlantAdminNote(
+  note: PlantAdminNote,
+  actor: Actor,
+): Promise<boolean> {
+  const { error } = await supabase
+    .from('plant_admin_notes')
+    .delete()
+    .eq('id', note.id)
+  if (error) {
+    console.warn('[plantAdminNotes] delete failed', error.message)
+    return false
+  }
+  await logPlantHistory({
+    plantId: note.plantId,
+    authorId: actor.authorId,
+    authorName: actor.authorName,
+    action: 'note_delete',
+    summary: note.authorName && note.authorName !== actor.authorName
+      ? `Deleted note by ${note.authorName}`
+      : 'Deleted own note',
+    oldValue: note.body,
+  })
+  return true
+}

--- a/plant-swipe/src/lib/plantAdminNotes.ts
+++ b/plant-swipe/src/lib/plantAdminNotes.ts
@@ -56,7 +56,6 @@ export async function createPlantAdminNote(
     authorId: actor.authorId,
     action: 'note_add',
     summary: 'Added note',
-    newValue: trimmed,
   })
   return rowToNote(data)
 }
@@ -84,8 +83,6 @@ export async function updatePlantAdminNote(
     authorId: actor.authorId,
     action: 'note_edit',
     summary: ownEdit ? 'Edited own note' : 'Edited another admin’s note',
-    oldValue: note.body,
-    newValue: trimmed,
   })
   return rowToNote(data)
 }
@@ -108,7 +105,6 @@ export async function deletePlantAdminNote(
     authorId: actor.authorId,
     action: 'note_delete',
     summary: ownDelete ? 'Deleted own note' : 'Deleted another admin’s note',
-    oldValue: note.body,
   })
   return true
 }

--- a/plant-swipe/src/lib/plantAdminNotes.ts
+++ b/plant-swipe/src/lib/plantAdminNotes.ts
@@ -8,7 +8,6 @@ const rowToNote = (row: any): PlantAdminNote => ({
   id: row.id,
   plantId: row.plant_id,
   authorId: row.author_id ?? null,
-  authorName: row.author_name ?? null,
   body: row.body,
   createdAt: row.created_at,
   updatedAt: row.updated_at,
@@ -30,7 +29,6 @@ export async function fetchPlantAdminNotes(plantId: string): Promise<PlantAdminN
 
 interface Actor {
   authorId?: string | null
-  authorName?: string | null
 }
 
 export async function createPlantAdminNote(
@@ -45,7 +43,6 @@ export async function createPlantAdminNote(
     .insert({
       plant_id: plantId,
       author_id: actor.authorId ?? null,
-      author_name: actor.authorName ?? null,
       body: trimmed,
     })
     .select('*')
@@ -57,7 +54,6 @@ export async function createPlantAdminNote(
   await logPlantHistory({
     plantId,
     authorId: actor.authorId,
-    authorName: actor.authorName,
     action: 'note_add',
     summary: 'Added note',
     newValue: trimmed,
@@ -82,14 +78,12 @@ export async function updatePlantAdminNote(
     console.warn('[plantAdminNotes] update failed', error?.message)
     return null
   }
+  const ownEdit = note.authorId && actor.authorId && note.authorId === actor.authorId
   await logPlantHistory({
     plantId: note.plantId,
     authorId: actor.authorId,
-    authorName: actor.authorName,
     action: 'note_edit',
-    summary: note.authorName && note.authorName !== actor.authorName
-      ? `Edited note by ${note.authorName}`
-      : 'Edited note',
+    summary: ownEdit ? 'Edited own note' : 'Edited another admin’s note',
     oldValue: note.body,
     newValue: trimmed,
   })
@@ -108,14 +102,12 @@ export async function deletePlantAdminNote(
     console.warn('[plantAdminNotes] delete failed', error.message)
     return false
   }
+  const ownDelete = note.authorId && actor.authorId && note.authorId === actor.authorId
   await logPlantHistory({
     plantId: note.plantId,
     authorId: actor.authorId,
-    authorName: actor.authorName,
     action: 'note_delete',
-    summary: note.authorName && note.authorName !== actor.authorName
-      ? `Deleted note by ${note.authorName}`
-      : 'Deleted own note',
+    summary: ownDelete ? 'Deleted own note' : 'Deleted another admin’s note',
     oldValue: note.body,
   })
   return true

--- a/plant-swipe/src/lib/plantFormCategories.ts
+++ b/plant-swipe/src/lib/plantFormCategories.ts
@@ -154,7 +154,6 @@ const fieldCategoryMap: Record<string, PlantFormCategory> = {
 
   // Section 9: Meta
   status: 'meta',
-  adminCommentary: 'meta',
   contributors: 'meta',
 
   // Legacy aliases (map old names to new categories)

--- a/plant-swipe/src/lib/plantHistory.ts
+++ b/plant-swipe/src/lib/plantHistory.ts
@@ -15,7 +15,6 @@ const rowToEntry = (row: any): PlantHistoryEntry => ({
   id: row.id,
   plantId: row.plant_id,
   authorId: row.author_id ?? null,
-  authorName: row.author_name ?? null,
   action: row.action as PlantHistoryAction,
   field: row.field ?? null,
   summary: row.summary ?? null,
@@ -27,7 +26,6 @@ const rowToEntry = (row: any): PlantHistoryEntry => ({
 export interface LogPlantHistoryInput {
   plantId: string
   authorId?: string | null
-  authorName?: string | null
   action: PlantHistoryAction
   field?: string | null
   summary?: string | null
@@ -40,7 +38,6 @@ export async function logPlantHistory(input: LogPlantHistoryInput): Promise<void
   const payload = {
     plant_id: input.plantId,
     author_id: input.authorId ?? null,
-    author_name: input.authorName ?? null,
     action: input.action,
     field: input.field ?? null,
     summary: clip(input.summary),
@@ -59,7 +56,6 @@ export async function logPlantHistoryBatch(entries: LogPlantHistoryInput[]): Pro
   const payload = entries.map((e) => ({
     plant_id: e.plantId,
     author_id: e.authorId ?? null,
-    author_name: e.authorName ?? null,
     action: e.action,
     field: e.field ?? null,
     summary: clip(e.summary),

--- a/plant-swipe/src/lib/plantHistory.ts
+++ b/plant-swipe/src/lib/plantHistory.ts
@@ -1,0 +1,88 @@
+import { supabase } from '@/lib/supabaseClient'
+import type { PlantHistoryAction, PlantHistoryEntry } from '@/types/plantHistory'
+
+/* eslint-disable @typescript-eslint/no-explicit-any -- dynamic supabase rows */
+
+const MAX_SNIPPET_LEN = 240
+
+const clip = (s: string | null | undefined): string | null => {
+  if (s == null) return null
+  if (s.length <= MAX_SNIPPET_LEN) return s
+  return s.slice(0, MAX_SNIPPET_LEN - 1) + '…'
+}
+
+const rowToEntry = (row: any): PlantHistoryEntry => ({
+  id: row.id,
+  plantId: row.plant_id,
+  authorId: row.author_id ?? null,
+  authorName: row.author_name ?? null,
+  action: row.action as PlantHistoryAction,
+  field: row.field ?? null,
+  summary: row.summary ?? null,
+  oldValue: row.old_value ?? null,
+  newValue: row.new_value ?? null,
+  createdAt: row.created_at,
+})
+
+export interface LogPlantHistoryInput {
+  plantId: string
+  authorId?: string | null
+  authorName?: string | null
+  action: PlantHistoryAction
+  field?: string | null
+  summary?: string | null
+  oldValue?: string | null
+  newValue?: string | null
+}
+
+export async function logPlantHistory(input: LogPlantHistoryInput): Promise<void> {
+  if (!input.plantId) return
+  const payload = {
+    plant_id: input.plantId,
+    author_id: input.authorId ?? null,
+    author_name: input.authorName ?? null,
+    action: input.action,
+    field: input.field ?? null,
+    summary: clip(input.summary),
+    old_value: clip(input.oldValue),
+    new_value: clip(input.newValue),
+  }
+  const { error } = await supabase.from('plant_history').insert(payload)
+  if (error) {
+    // History is best-effort; log but never block the main action.
+    console.warn('[plantHistory] insert failed', error.message)
+  }
+}
+
+export async function logPlantHistoryBatch(entries: LogPlantHistoryInput[]): Promise<void> {
+  if (!entries.length) return
+  const payload = entries.map((e) => ({
+    plant_id: e.plantId,
+    author_id: e.authorId ?? null,
+    author_name: e.authorName ?? null,
+    action: e.action,
+    field: e.field ?? null,
+    summary: clip(e.summary),
+    old_value: clip(e.oldValue),
+    new_value: clip(e.newValue),
+  }))
+  const { error } = await supabase.from('plant_history').insert(payload)
+  if (error) {
+    console.warn('[plantHistory] batch insert failed', error.message)
+  }
+}
+
+export async function fetchPlantHistory(plantId: string, limit = 200): Promise<PlantHistoryEntry[]> {
+  if (!plantId) return []
+  const { data, error } = await supabase
+    .from('plant_history')
+    .select('*')
+    .eq('plant_id', plantId)
+    .order('created_at', { ascending: false })
+    .limit(limit)
+  if (error) {
+    console.warn('[plantHistory] fetch failed', error.message)
+    return []
+  }
+  return (data || []).map(rowToEntry)
+}

--- a/plant-swipe/src/lib/plantHistory.ts
+++ b/plant-swipe/src/lib/plantHistory.ts
@@ -3,14 +3,6 @@ import type { PlantHistoryAction, PlantHistoryEntry } from '@/types/plantHistory
 
 /* eslint-disable @typescript-eslint/no-explicit-any -- dynamic supabase rows */
 
-const MAX_SNIPPET_LEN = 240
-
-const clip = (s: string | null | undefined): string | null => {
-  if (s == null) return null
-  if (s.length <= MAX_SNIPPET_LEN) return s
-  return s.slice(0, MAX_SNIPPET_LEN - 1) + '…'
-}
-
 const rowToEntry = (row: any): PlantHistoryEntry => ({
   id: row.id,
   plantId: row.plant_id,
@@ -18,8 +10,6 @@ const rowToEntry = (row: any): PlantHistoryEntry => ({
   action: row.action as PlantHistoryAction,
   field: row.field ?? null,
   summary: row.summary ?? null,
-  oldValue: row.old_value ?? null,
-  newValue: row.new_value ?? null,
   createdAt: row.created_at,
 })
 
@@ -29,8 +19,6 @@ export interface LogPlantHistoryInput {
   action: PlantHistoryAction
   field?: string | null
   summary?: string | null
-  oldValue?: string | null
-  newValue?: string | null
 }
 
 export async function logPlantHistory(input: LogPlantHistoryInput): Promise<void> {
@@ -40,9 +28,7 @@ export async function logPlantHistory(input: LogPlantHistoryInput): Promise<void
     author_id: input.authorId ?? null,
     action: input.action,
     field: input.field ?? null,
-    summary: clip(input.summary),
-    old_value: clip(input.oldValue),
-    new_value: clip(input.newValue),
+    summary: input.summary ?? null,
   }
   const { error } = await supabase.from('plant_history').insert(payload)
   if (error) {
@@ -58,9 +44,7 @@ export async function logPlantHistoryBatch(entries: LogPlantHistoryInput[]): Pro
     author_id: e.authorId ?? null,
     action: e.action,
     field: e.field ?? null,
-    summary: clip(e.summary),
-    old_value: clip(e.oldValue),
-    new_value: clip(e.newValue),
+    summary: e.summary ?? null,
   }))
   const { error } = await supabase.from('plant_history').insert(payload)
   if (error) {

--- a/plant-swipe/src/lib/plantHistoryDiff.ts
+++ b/plant-swipe/src/lib/plantHistoryDiff.ts
@@ -12,7 +12,6 @@ const IGNORED_FIELDS = new Set<string>([
   'createdAt',
   'createdTime',
   'meta',
-  'adminCommentary', // replaced by plant_admin_notes
   // Nested aggregates already represented by flat fields:
   'identity',
   'plantCare',

--- a/plant-swipe/src/lib/plantHistoryDiff.ts
+++ b/plant-swipe/src/lib/plantHistoryDiff.ts
@@ -187,7 +187,6 @@ const shortRepr = (v: any): string | null => {
 
 export interface DiffActor {
   authorId?: string | null
-  authorName?: string | null
 }
 
 /**
@@ -217,7 +216,6 @@ export function buildPlantFieldDiff(
     result.push({
       plantId,
       authorId: actor.authorId ?? null,
-      authorName: actor.authorName ?? null,
       action,
       field: key,
       summary: `Changed ${label}`,

--- a/plant-swipe/src/lib/plantHistoryDiff.ts
+++ b/plant-swipe/src/lib/plantHistoryDiff.ts
@@ -170,21 +170,6 @@ const equal = (a: any, b: any): boolean => {
   return false
 }
 
-const MAX_SNIPPET = 180
-
-const shortRepr = (v: any): string | null => {
-  const n = normalize(v)
-  if (n == null) return null
-  let s: string
-  if (typeof n === 'string') s = n
-  else if (Array.isArray(n)) s = n.map((x) => (typeof x === 'string' ? x : JSON.stringify(x))).join(', ')
-  else if (typeof n === 'object') {
-    try { s = JSON.stringify(n) } catch { s = String(n) }
-  } else s = String(n)
-  if (s.length > MAX_SNIPPET) return s.slice(0, MAX_SNIPPET - 1) + '…'
-  return s
-}
-
 export interface DiffActor {
   authorId?: string | null
 }
@@ -219,8 +204,6 @@ export function buildPlantFieldDiff(
       action,
       field: key,
       summary: `Changed ${label}`,
-      oldValue: shortRepr(before),
-      newValue: shortRepr(after),
     })
   }
   return result

--- a/plant-swipe/src/lib/plantHistoryDiff.ts
+++ b/plant-swipe/src/lib/plantHistoryDiff.ts
@@ -1,0 +1,229 @@
+import type { Plant } from '@/types/plant'
+import type { LogPlantHistoryInput } from '@/lib/plantHistory'
+
+/* eslint-disable @typescript-eslint/no-explicit-any -- dynamic plant field reads */
+
+// Fields we never report in history (noise, or tracked by their own action types).
+const IGNORED_FIELDS = new Set<string>([
+  'id',
+  'updatedBy',
+  'updatedTime',
+  'createdBy',
+  'createdAt',
+  'createdTime',
+  'meta',
+  'adminCommentary', // replaced by plant_admin_notes
+  // Nested aggregates already represented by flat fields:
+  'identity',
+  'plantCare',
+  'growth',
+  'danger',
+  'ecology',
+  'usage',
+  'miscellaneous',
+])
+
+// Human label for field keys. Falls back to a titlecased version of the key.
+const FIELD_LABELS: Record<string, string> = {
+  name: 'Name',
+  scientificNameSpecies: 'Scientific name',
+  family: 'Family',
+  variety: 'Variety',
+  commonNames: 'Common names',
+  presentation: 'Presentation',
+  featuredMonth: 'Featured months',
+  plantType: 'Plant type',
+  plantPart: 'Plant part',
+  habitat: 'Habitat',
+  climate: 'Climate',
+  season: 'Season',
+  utility: 'Utility',
+  vegetable: 'Vegetable',
+  ediblePart: 'Edible part',
+  thorny: 'Thorny',
+  toxicityHuman: 'Toxicity (human)',
+  toxicityPets: 'Toxicity (pets)',
+  lifeCycle: 'Life cycle',
+  averageLifespan: 'Average lifespan',
+  foliagePersistence: 'Foliage persistence',
+  livingSpace: 'Living space',
+  landscaping: 'Landscaping',
+  plantHabit: 'Plant habit',
+  multicolor: 'Multicolor',
+  bicolor: 'Bicolor',
+  careLevel: 'Care level',
+  sunlight: 'Sunlight',
+  temperatureMax: 'Temperature max',
+  temperatureMin: 'Temperature min',
+  temperatureIdeal: 'Temperature ideal',
+  wateringType: 'Watering type',
+  hygrometry: 'Hygrometry',
+  specialNeeds: 'Special needs',
+  substrate: 'Substrate',
+  substrateMix: 'Substrate mix',
+  mulchingNeeded: 'Mulching needed',
+  mulchType: 'Mulch type',
+  nutritionNeed: 'Nutrition need',
+  fertilizer: 'Fertilizer',
+  sowingMonth: 'Sowing months',
+  floweringMonth: 'Flowering months',
+  fruitingMonth: 'Fruiting months',
+  harvestingMonth: 'Harvesting months',
+  heightCm: 'Height (cm)',
+  wingspanCm: 'Wingspan (cm)',
+  separationCm: 'Separation (cm)',
+  staking: 'Staking',
+  division: 'Division',
+  cultivationMode: 'Cultivation mode',
+  sowingMethod: 'Sowing method',
+  transplanting: 'Transplanting',
+  pruning: 'Pruning',
+  pruningMonth: 'Pruning months',
+  conservationStatus: 'Conservation status',
+  ecologicalStatus: 'Ecological status',
+  biotopes: 'Biotopes',
+  urbanBiotopes: 'Urban biotopes',
+  ecologicalTolerance: 'Ecological tolerance',
+  biodiversityRole: 'Biodiversity role',
+  pollinatorsAttracted: 'Pollinators attracted',
+  birdsAttracted: 'Birds attracted',
+  mammalsAttracted: 'Mammals attracted',
+  ecologicalManagement: 'Ecological management',
+  ecologicalImpact: 'Ecological impact',
+  infusionParts: 'Infusion parts',
+  edibleOil: 'Edible oil',
+  companionPlants: 'Companion plants',
+  biotopePlants: 'Biotope plants',
+  beneficialPlants: 'Beneficial plants',
+  harmfulPlants: 'Harmful plants',
+  plantTags: 'Plant tags',
+  biodiversityTags: 'Biodiversity tags',
+  sources: 'Sources',
+  contributors: 'Contributors',
+  status: 'Status',
+  images: 'Images',
+  colors: 'Colors',
+  wateringSchedules: 'Watering schedules',
+  recipes: 'Recipes',
+  infusionMixes: 'Infusion mixes',
+  origin: 'Origin',
+  allergens: 'Allergens',
+  poisoningSymptoms: 'Poisoning symptoms',
+  soilAdvice: 'Soil advice',
+  mulchAdvice: 'Mulch advice',
+  fertilizerAdvice: 'Fertilizer advice',
+  stakingAdvice: 'Staking advice',
+  sowingAdvice: 'Sowing advice',
+  transplantingTime: 'Transplanting time',
+  outdoorPlantingTime: 'Outdoor planting time',
+  pruningAdvice: 'Pruning advice',
+  pests: 'Pests',
+  diseases: 'Diseases',
+  nutritionalValue: 'Nutritional value',
+  recipesIdeas: 'Recipes ideas',
+  infusionBenefits: 'Infusion benefits',
+}
+
+const titleCase = (key: string): string =>
+  key
+    .replace(/([A-Z])/g, ' $1')
+    .replace(/^./, (c) => c.toUpperCase())
+    .trim()
+
+export const labelForField = (key: string): string => FIELD_LABELS[key] ?? titleCase(key)
+
+const normalize = (v: any): any => {
+  if (v == null) return null
+  if (typeof v === 'string') {
+    const t = v.trim()
+    return t.length ? t : null
+  }
+  if (Array.isArray(v)) {
+    return v.length ? v.map(normalize) : null
+  }
+  if (typeof v === 'object') {
+    const keys = Object.keys(v).sort()
+    if (!keys.length) return null
+    const obj: any = {}
+    for (const k of keys) {
+      const nv = normalize((v as any)[k])
+      if (nv !== null && nv !== undefined) obj[k] = nv
+    }
+    return Object.keys(obj).length ? obj : null
+  }
+  return v
+}
+
+const equal = (a: any, b: any): boolean => {
+  const na = normalize(a)
+  const nb = normalize(b)
+  if (na === nb) return true
+  if (na == null || nb == null) return na == null && nb == null
+  if (typeof na !== typeof nb) return false
+  if (typeof na === 'object') {
+    try {
+      return JSON.stringify(na) === JSON.stringify(nb)
+    } catch {
+      return false
+    }
+  }
+  return false
+}
+
+const MAX_SNIPPET = 180
+
+const shortRepr = (v: any): string | null => {
+  const n = normalize(v)
+  if (n == null) return null
+  let s: string
+  if (typeof n === 'string') s = n
+  else if (Array.isArray(n)) s = n.map((x) => (typeof x === 'string' ? x : JSON.stringify(x))).join(', ')
+  else if (typeof n === 'object') {
+    try { s = JSON.stringify(n) } catch { s = String(n) }
+  } else s = String(n)
+  if (s.length > MAX_SNIPPET) return s.slice(0, MAX_SNIPPET - 1) + '…'
+  return s
+}
+
+export interface DiffActor {
+  authorId?: string | null
+  authorName?: string | null
+}
+
+/**
+ * Build history entries for every field that changed between oldPlant and newPlant.
+ * Entries are NOT written to the DB here — caller should pass them to logPlantHistoryBatch.
+ */
+export function buildPlantFieldDiff(
+  plantId: string,
+  oldPlant: Plant | null | undefined,
+  newPlant: Plant,
+  actor: DiffActor,
+  extraIgnored: Iterable<string> = [],
+): LogPlantHistoryInput[] {
+  const ignored = new Set([...IGNORED_FIELDS, ...extraIgnored])
+  const result: LogPlantHistoryInput[] = []
+  const keys = new Set<string>([
+    ...Object.keys(oldPlant || {}),
+    ...Object.keys(newPlant || {}),
+  ])
+  for (const key of keys) {
+    if (ignored.has(key)) continue
+    const before = (oldPlant as any)?.[key]
+    const after = (newPlant as any)?.[key]
+    if (equal(before, after)) continue
+    const label = labelForField(key)
+    const action = key === 'status' ? 'status_change' : 'field_change'
+    result.push({
+      plantId,
+      authorId: actor.authorId ?? null,
+      authorName: actor.authorName ?? null,
+      action,
+      field: key,
+      summary: `Changed ${label}`,
+      oldValue: shortRepr(before),
+      newValue: shortRepr(after),
+    })
+  }
+  return result
+}

--- a/plant-swipe/src/lib/plantSchema.ts
+++ b/plant-swipe/src/lib/plantSchema.ts
@@ -336,7 +336,7 @@ export const plantSchema = {
   },
 
   // -- Section 9: Meta --------------------------------------------------------
-  adminCommentary: { type: 'longtext', description: 'Internal notes for editors' },
+  // (admin_commentary removed — replaced by the plant_admin_notes thread.)
 } as const
 
 export type PlantSchema = typeof plantSchema

--- a/plant-swipe/src/lib/plantTranslationLoader.ts
+++ b/plant-swipe/src/lib/plantTranslationLoader.ts
@@ -256,7 +256,6 @@ function mapDbRowToPlant(
 
     // Section 9: Meta
     status: (basePlant.status as Plant['status']) || undefined,
-    adminCommentary: (basePlant.admin_commentary as string) || undefined,
     createdBy: (basePlant.created_by as string) || undefined,
     createdTime: (basePlant.created_time as string) || undefined,
     updatedBy: (basePlant.updated_by as string) || undefined,

--- a/plant-swipe/src/pages/AdminPage.tsx
+++ b/plant-swipe/src/pages/AdminPage.tsx
@@ -5609,7 +5609,6 @@ export const AdminPage: React.FC = () => {
       uploadedAt: string | null;
       gardenPlantId: string | null;
       plantName: string | null;
-      adminCommentary: string | null;
     }>;
     scansTotal?: number;
     scansThisMonth?: number;
@@ -6136,7 +6135,6 @@ export const AdminPage: React.FC = () => {
                 uploadedAt: f?.uploadedAt || f?.uploaded_at || null,
                 gardenPlantId: f?.gardenPlantId || f?.garden_plant_id || null,
                 plantName: f?.plantName || f?.plant_name || null,
-                adminCommentary: f?.adminCommentary || f?.admin_commentary || null,
               };
               })
             : [],

--- a/plant-swipe/src/pages/AdminPage.tsx
+++ b/plant-swipe/src/pages/AdminPage.tsx
@@ -129,6 +129,8 @@ import {
   type BroadcastRecord,
 } from "@/lib/broadcastStorage";
 import { processAllPlantRequests, aiFieldOrder as aiPrefillFieldOrder } from "@/lib/aiPrefillService";
+import { logPlantHistory, logPlantHistoryBatch } from "@/lib/plantHistory";
+import { labelForField } from "@/lib/plantHistoryDiff";
 import { IMAGE_SOURCES, type SourceResult, type ExternalImageSource } from "@/lib/externalImages";
 import { getEnglishPlantName } from "@/lib/aiPlantFill";
 import { Languages, Settings, GraduationCap, ListChecks } from "lucide-react";
@@ -3900,6 +3902,16 @@ export const AdminPage: React.FC = () => {
             p.id === plantId ? { ...p, [localKey]: newValue } : p,
           ),
         );
+        // History: single field_change entry per plant.
+        const fieldKey = String(localKey);
+        const label = labelForField(fieldKey);
+        await logPlantHistory({
+          plantId,
+          authorId: profile?.id ?? null,
+          action: fieldKey === "status" ? "status_change" : "field_change",
+          field: fieldKey,
+          summary: `Quick-edit: changed ${label}`,
+        });
       } catch (err) {
         console.error("Quick plant update error:", err);
         setPlantDashboardError(
@@ -3907,7 +3919,7 @@ export const AdminPage: React.FC = () => {
         );
       }
     },
-    [plantDashboardRows],
+    [plantDashboardRows, profile?.id],
   );
 
   // Bulk quick-action: update a field for all selected plants
@@ -3920,6 +3932,11 @@ export const AdminPage: React.FC = () => {
     ) => {
       if (selectedPlantIds.size === 0) return;
       setBulkActionLoading(true);
+      const fieldKey = String(localKey);
+      const label = labelForField(fieldKey);
+      const action: "status_change" | "field_change" =
+        fieldKey === "status" ? "status_change" : "field_change";
+      const touchedIds: string[] = [];
       try {
         const ids = Array.from(selectedPlantIds);
         if (mode === "set") {
@@ -3932,6 +3949,7 @@ export const AdminPage: React.FC = () => {
               .update({ [dbColumn]: value })
               .in("id", batch);
             if (error) throw new Error(error.message);
+            touchedIds.push(...batch);
           }
           setPlantDashboardRows((prev) =>
             prev.map((p) =>
@@ -3958,12 +3976,25 @@ export const AdminPage: React.FC = () => {
               .update({ [dbColumn]: newValue })
               .eq("id", id);
             if (error) throw new Error(error.message);
+            touchedIds.push(id);
           }
           setPlantDashboardRows((prev) =>
             prev.map((p) => {
               const upd = updates.find((u) => u.id === p.id);
               return upd ? { ...p, [localKey]: upd.newValue } : p;
             }),
+          );
+        }
+        // History: one field_change entry per touched plant.
+        if (touchedIds.length) {
+          await logPlantHistoryBatch(
+            touchedIds.map((plantId) => ({
+              plantId,
+              authorId: profile?.id ?? null,
+              action,
+              field: fieldKey,
+              summary: `Bulk quick-edit: changed ${label}`,
+            })),
           );
         }
       } catch (err) {
@@ -3975,7 +4006,7 @@ export const AdminPage: React.FC = () => {
         setBulkActionLoading(false);
       }
     },
-    [selectedPlantIds, plantDashboardRows],
+    [selectedPlantIds, plantDashboardRows, profile?.id],
   );
 
   const plantStatusCounts = React.useMemo(() => {
@@ -4279,7 +4310,8 @@ export const AdminPage: React.FC = () => {
               setAiPrefillError(error);
             }
           },
-        }
+        },
+        profile?.id ?? null,
       );
       
       // Refresh the requests list after completion
@@ -4301,7 +4333,7 @@ export const AdminPage: React.FC = () => {
       setAiPrefillFieldProgress({ completed: 0, total: 0 });
       setAiPrefillStartTime(null);
     }
-  }, [aiPrefillRunning, filteredPlantRequests, profile?.display_name, loadPlantRequests, initAiPrefillCategoryProgress, markAiPrefillFieldComplete]);
+  }, [aiPrefillRunning, filteredPlantRequests, profile?.display_name, profile?.id, loadPlantRequests, initAiPrefillCategoryProgress, markAiPrefillFieldComplete]);
 
   const stopAiPrefill = React.useCallback(() => {
     if (aiPrefillAbortController) {

--- a/plant-swipe/src/pages/CreatePlantPage.tsx
+++ b/plant-swipe/src/pages/CreatePlantPage.tsx
@@ -7,9 +7,10 @@ import { supabase } from "@/lib/supabaseClient"
 import { PlantProfileForm, type PlantReport, type PlantVariety } from "@/components/plant/PlantProfileForm"
 import { AdminNotesThread } from "@/components/plant/AdminNotesThread"
 import { PlantHistoryPanel } from "@/components/plant/PlantHistoryPanel"
+import { PlantContributorsPicker } from "@/components/plant/PlantContributorsPicker"
 import { fetchAiPlantFill, fetchAiPlantFillField } from "@/lib/aiPlantFill"
 import { fetchExternalPlantImages, uploadPlantImageFromUrl, uploadPlantImageFile, deletePlantImage, isManagedPlantImageUrl, IMAGE_SOURCES, type SourceResult, type ExternalImageSource } from "@/lib/externalImages"
-import type { Plant, PlantColor, PlantImage, PlantMeta, PlantRecipe, PlantSource, PlantWateringSchedule, MonthSlug } from "@/types/plant"
+import type { Plant, PlantColor, PlantContributor, PlantImage, PlantMeta, PlantRecipe, PlantSource, PlantWateringSchedule, MonthSlug } from "@/types/plant"
 import { useAuth } from "@/context/AuthContext"
 import { useTranslation } from "react-i18next"
 import { SUPPORTED_LANGUAGES, type SupportedLanguage } from "@/lib/i18n"
@@ -383,22 +384,43 @@ function normalizeSchedules(entries?: PlantWateringSchedule[]): PlantWateringSch
     .filter((entry) => entry.season || entry.quantity !== undefined || entry.timePeriod)
 }
 
+type ContributorInput = PlantContributor | { id?: string | null; name?: string | null } | string | null | undefined
+
+/**
+ * Merge any mix of legacy strings, {id,name} shapes, or profile ids into a
+ * deduplicated list of PlantContributor rows. IDs dedupe first; nameless
+ * strings dedupe case-insensitively on the trimmed name.
+ */
 const mergeContributors = (
   existing: unknown,
-  extras: Array<string | null | undefined> = [],
-): string[] => {
-  const base = Array.isArray(existing) ? existing : []
+  extras: ContributorInput[] = [],
+): PlantContributor[] => {
+  const base = Array.isArray(existing) ? (existing as ContributorInput[]) : []
   const combined = [...base, ...extras]
-  const seen = new Set<string>()
-  const result: string[] = []
+  const seenIds = new Set<string>()
+  const seenNames = new Set<string>()
+  const result: PlantContributor[] = []
   for (const entry of combined) {
-    if (typeof entry !== "string") continue
-    const trimmed = entry.trim()
-    if (!trimmed) continue
-    const key = trimmed.toLowerCase()
-    if (seen.has(key)) continue
-    seen.add(key)
-    result.push(trimmed)
+    if (entry == null) continue
+    let id: string | null = null
+    let name: string | null = null
+    if (typeof entry === "string") {
+      name = entry.trim() || null
+    } else if (typeof entry === "object") {
+      const raw = entry as { id?: unknown; name?: unknown }
+      if (typeof raw.id === "string" && raw.id.trim()) id = raw.id.trim()
+      if (typeof raw.name === "string" && raw.name.trim()) name = raw.name.trim()
+    }
+    if (!id && !name) continue
+    if (id) {
+      if (seenIds.has(id)) continue
+      seenIds.add(id)
+    } else if (name) {
+      const nameKey = name.toLowerCase()
+      if (seenNames.has(nameKey)) continue
+      seenNames.add(nameKey)
+    }
+    result.push({ id, name })
   }
   return result
 }
@@ -626,18 +648,43 @@ async function upsertSources(plantId: string, sources?: PlantSource[]) {
   if (error) throw new Error(error.message)
 }
 
-async function upsertContributors(plantId: string, contributors: string[]) {
+async function upsertContributors(plantId: string, contributors: PlantContributor[]) {
   await supabase.from('plant_contributors').delete().eq('plant_id', plantId)
   if (!contributors.length) return
+  // Each row must carry an id OR a non-empty name (DB check constraint).
+  // For id rows we still persist the snapshot name so legacy listeners that
+  // only read contributor_name keep working until they're migrated.
   const rows = contributors
-    .filter((name) => typeof name === 'string' && name.trim())
-    .map((name) => ({
-      plant_id: plantId,
-      contributor_name: name.trim(),
-    }))
+    .map((c) => {
+      const id = c.id && c.id.trim() ? c.id.trim() : null
+      const name = c.name && c.name.trim() ? c.name.trim() : null
+      if (!id && !name) return null
+      return { plant_id: plantId, contributor_id: id, contributor_name: name }
+    })
+    .filter((r): r is { plant_id: string; contributor_id: string | null; contributor_name: string | null } => Boolean(r))
   if (!rows.length) return
   const { error } = await supabase.from('plant_contributors').insert(rows)
   if (error) throw new Error(error.message)
+}
+
+/**
+ * Convert rows fetched via `select('contributor_id, contributor_name, profile:contributor_id(...)')`
+ * into the PlantContributor shape used across the app. Prefers the live
+ * display_name from the joined profile; falls back to the stored legacy name.
+ */
+function contributorRowsToList(rows: unknown): PlantContributor[] {
+  if (!Array.isArray(rows)) return []
+  const out: PlantContributor[] = []
+  for (const row of rows as Array<Record<string, any>>) {
+    const id = typeof row?.contributor_id === 'string' ? row.contributor_id : null
+    const profile = Array.isArray(row?.profile) ? row.profile[0] : row?.profile
+    const liveName = profile && typeof profile.display_name === 'string' ? profile.display_name.trim() || null : null
+    const snapshotName = typeof row?.contributor_name === 'string' ? row.contributor_name.trim() || null : null
+    const name = liveName || snapshotName
+    if (!id && !name) continue
+    out.push({ id, name })
+  }
+  return out
 }
 
 function mapInfusionMixRows(rows?: Array<{ mix_name?: string | null; benefit?: string | null }> | null) {
@@ -833,7 +880,7 @@ async function loadPlant(id: string, language?: string): Promise<Plant | null> {
   const { data: sources } = await supabase.from('plant_sources').select('id,name,url').eq('plant_id', id)
   const { data: contributorRows } = await supabase
     .from('plant_contributors')
-    .select('contributor_name')
+    .select('contributor_id, contributor_name, profile:contributor_id(id, display_name)')
     .eq('plant_id', id)
   const { data: recipeRows } = await supabase
     .from('plant_recipes')
@@ -994,9 +1041,7 @@ async function loadPlant(id: string, language?: string): Promise<Plant | null> {
     meta: {
       status: formatStatusForUi(data.status),
       adminCommentary: data.admin_commentary || undefined,
-      contributors: (contributorRows || [])
-        .map((row: any) => row?.contributor_name)
-        .filter((name: any) => typeof name === 'string' && name.trim()),
+      contributors: contributorRowsToList(contributorRows),
       createdBy: data.created_by || undefined,
       createdAt: data.created_time || undefined,
       updatedBy: data.updated_by || undefined,
@@ -1158,9 +1203,7 @@ async function loadPlant(id: string, language?: string): Promise<Plant | null> {
   // Section 9: Meta
   flat.status = formatStatusForUi(data.status)
   flat.adminCommentary = data.admin_commentary || plant.meta?.adminCommentary || undefined
-  flat.contributors = (contributorRows || [])
-    .map((row: any) => row?.contributor_name)
-    .filter((name: any) => typeof name === 'string' && name.trim())
+  flat.contributors = contributorRowsToList(contributorRows)
 
   return plant
 }
@@ -1283,16 +1326,18 @@ export const CreatePlantPage: React.FC<{ onCancel: () => void; onSaved?: (id: st
             .select('id, display_name')
             .in('id', userIds)
           if (profilesError) throw new Error(profilesError.message)
-          const names = (profilesData || [])
-            .map((profile: any) => profile?.display_name)
-            .filter((name: any) => typeof name === 'string' && name.trim())
-            .map((name: string) => name.trim())
-          if (!names.length || cancelled) return
+          const contributors: PlantContributor[] = (profilesData || [])
+            .map((profile: any) => ({
+              id: typeof profile?.id === 'string' ? profile.id : null,
+              name: typeof profile?.display_name === 'string' ? profile.display_name.trim() || null : null,
+            }))
+            .filter((c) => c.id || c.name)
+          if (!contributors.length || cancelled) return
           setPlant((prev) => ({
             ...prev,
             meta: {
               ...(prev.meta || {}),
-              contributors: mergeContributors(prev.meta?.contributors, names),
+              contributors: mergeContributors(prev.meta?.contributors, contributors),
             },
           }))
         } catch (err) {
@@ -1693,7 +1738,15 @@ export const CreatePlantPage: React.FC<{ onCancel: () => void; onSaved?: (id: st
           ? (plantToSave.meta?.createdAt || null)
           : (plantToSave.meta?.createdAt || new Date().toISOString())
         const updatedByValue = profile?.display_name || plantToSave.meta?.updatedBy || null
-        const contributorList = mergeContributors(plantToSave.meta?.contributors || plantToSave.contributors, [profile?.display_name])
+        // Always seed in the current admin so editors are tracked by profile id.
+        const currentContributor: PlantContributor = {
+          id: profile?.id || null,
+          name: profile?.display_name || null,
+        }
+        const contributorList = mergeContributors(
+          plantToSave.meta?.contributors || plantToSave.contributors,
+          [currentContributor],
+        )
         const normalizedSchedules = normalizeSchedules(plantToSave.wateringSchedules || plantToSave.plantCare?.watering?.schedules)
         const sources = plantToSave.sources || plantToSave.miscellaneous?.sources || []
         const primarySource = sources[0]
@@ -3128,6 +3181,16 @@ export const CreatePlantPage: React.FC<{ onCancel: () => void; onSaved?: (id: st
               <PlantHistoryPanel
                 plantId={plant.id || id || null}
                 refreshVersion={historyVersion}
+              />
+            }
+            contributorsSlot={
+              <PlantContributorsPicker
+                value={Array.isArray(plant.contributors) ? (plant.contributors as PlantContributor[]) : []}
+                onChange={(next) => setPlant((prev) => ({
+                  ...prev,
+                  contributors: next,
+                  meta: { ...(prev.meta || {}), contributors: next },
+                }))}
               />
             }
           />

--- a/plant-swipe/src/pages/CreatePlantPage.tsx
+++ b/plant-swipe/src/pages/CreatePlantPage.tsx
@@ -2063,12 +2063,11 @@ export const CreatePlantPage: React.FC<{ onCancel: () => void; onSaved?: (id: st
         // Plant history: log create or per-field diff (English saves only — other
         // languages just update translations and are noisy to diff against the EN baseline).
         try {
-          const historyActor = { authorId: profile?.id || null, authorName: profile?.display_name || null }
+          const historyActor = { authorId: profile?.id || null }
           if (wasCreate) {
             await logPlantHistory({
               plantId: savedId,
               authorId: historyActor.authorId,
-              authorName: historyActor.authorName,
               action: 'create',
               summary: `Created plant "${trimmedName}"`,
               newValue: trimmedName,
@@ -2083,7 +2082,6 @@ export const CreatePlantPage: React.FC<{ onCancel: () => void; onSaved?: (id: st
             await logPlantHistory({
               plantId: savedId,
               authorId: historyActor.authorId,
-              authorName: historyActor.authorName,
               action: 'field_change',
               field: `translation:${saveLanguage}`,
               summary: `Updated ${saveLanguage.toUpperCase()} translation`,
@@ -2506,7 +2504,6 @@ export const CreatePlantPage: React.FC<{ onCancel: () => void; onSaved?: (id: st
         await logPlantHistory({
           plantId: targetPlant.id,
           authorId: profile?.id || null,
-          authorName: profile?.display_name || null,
           action: 'ai_fill',
           summary: 'Launched AI Fill (all fields)',
         })
@@ -2653,7 +2650,6 @@ export const CreatePlantPage: React.FC<{ onCancel: () => void; onSaved?: (id: st
         await logPlantHistory({
           plantId: plant.id,
           authorId: profile?.id || null,
-          authorName: profile?.display_name || null,
           action: 'translate',
           summary: `Launched DeepL translation (${targets.length} ${targets.length === 1 ? 'language' : 'languages'})`,
           newValue: targets.join(', '),
@@ -3125,7 +3121,7 @@ export const CreatePlantPage: React.FC<{ onCancel: () => void; onSaved?: (id: st
             adminNotesSlot={
               <AdminNotesThread
                 plantId={plant.id || id || null}
-                actor={{ id: profile?.id || null, name: profile?.display_name || null }}
+                actor={{ id: profile?.id || null }}
                 refreshVersion={historyVersion}
                 onChanged={bumpHistoryVersion}
               />

--- a/plant-swipe/src/pages/CreatePlantPage.tsx
+++ b/plant-swipe/src/pages/CreatePlantPage.tsx
@@ -98,7 +98,7 @@ const ALLOWED_ECOLOGICAL_MANAGEMENT = new Set(['let_seed','no_winter_pruning','k
 const AI_EXCLUDED_FIELDS = new Set([
   'name', 'image', 'imageurl', 'image_url', 'imageURL', 'images',
   // Meta fields — admin-only
-  'meta', 'adminCommentary', 'contributors', 'status',
+  'meta', 'contributors', 'status',
   // Featured months — curated by admin
   'featuredMonth',
   // Plant link fields — AI is unaware of plants in our DB
@@ -384,12 +384,11 @@ function normalizeSchedules(entries?: PlantWateringSchedule[]): PlantWateringSch
     .filter((entry) => entry.season || entry.quantity !== undefined || entry.timePeriod)
 }
 
-type ContributorInput = PlantContributor | { id?: string | null; name?: string | null } | string | null | undefined
+type ContributorInput = PlantContributor | { id?: string | null; name?: string | null } | null | undefined
 
 /**
- * Merge any mix of legacy strings, {id,name} shapes, or profile ids into a
- * deduplicated list of PlantContributor rows. IDs dedupe first; nameless
- * strings dedupe case-insensitively on the trimmed name.
+ * Merge PlantContributor rows deduplicated by id. Entries without a valid id
+ * are dropped — contributors are always linked to a profile now.
  */
 const mergeContributors = (
   existing: unknown,
@@ -398,28 +397,15 @@ const mergeContributors = (
   const base = Array.isArray(existing) ? (existing as ContributorInput[]) : []
   const combined = [...base, ...extras]
   const seenIds = new Set<string>()
-  const seenNames = new Set<string>()
   const result: PlantContributor[] = []
   for (const entry of combined) {
-    if (entry == null) continue
-    let id: string | null = null
-    let name: string | null = null
-    if (typeof entry === "string") {
-      name = entry.trim() || null
-    } else if (typeof entry === "object") {
-      const raw = entry as { id?: unknown; name?: unknown }
-      if (typeof raw.id === "string" && raw.id.trim()) id = raw.id.trim()
-      if (typeof raw.name === "string" && raw.name.trim()) name = raw.name.trim()
-    }
-    if (!id && !name) continue
-    if (id) {
-      if (seenIds.has(id)) continue
-      seenIds.add(id)
-    } else if (name) {
-      const nameKey = name.toLowerCase()
-      if (seenNames.has(nameKey)) continue
-      seenNames.add(nameKey)
-    }
+    if (entry == null || typeof entry !== 'object') continue
+    const raw = entry as { id?: unknown; name?: unknown }
+    if (typeof raw.id !== 'string' || !raw.id.trim()) continue
+    const id = raw.id.trim()
+    if (seenIds.has(id)) continue
+    seenIds.add(id)
+    const name = typeof raw.name === 'string' && raw.name.trim() ? raw.name.trim() : null
     result.push({ id, name })
   }
   return result
@@ -651,37 +637,26 @@ async function upsertSources(plantId: string, sources?: PlantSource[]) {
 async function upsertContributors(plantId: string, contributors: PlantContributor[]) {
   await supabase.from('plant_contributors').delete().eq('plant_id', plantId)
   if (!contributors.length) return
-  // Each row must carry an id OR a non-empty name (DB check constraint).
-  // For id rows we still persist the snapshot name so legacy listeners that
-  // only read contributor_name keep working until they're migrated.
   const rows = contributors
-    .map((c) => {
-      const id = c.id && c.id.trim() ? c.id.trim() : null
-      const name = c.name && c.name.trim() ? c.name.trim() : null
-      if (!id && !name) return null
-      return { plant_id: plantId, contributor_id: id, contributor_name: name }
-    })
-    .filter((r): r is { plant_id: string; contributor_id: string | null; contributor_name: string | null } => Boolean(r))
+    .map((c) => (c.id && c.id.trim() ? { plant_id: plantId, contributor_id: c.id.trim() } : null))
+    .filter((r): r is { plant_id: string; contributor_id: string } => Boolean(r))
   if (!rows.length) return
   const { error } = await supabase.from('plant_contributors').insert(rows)
   if (error) throw new Error(error.message)
 }
 
 /**
- * Convert rows fetched via `select('contributor_id, contributor_name, profile:contributor_id(...)')`
- * into the PlantContributor shape used across the app. Prefers the live
- * display_name from the joined profile; falls back to the stored legacy name.
+ * Convert rows fetched via `select('contributor_id, profile:contributor_id(id, display_name)')`
+ * into the PlantContributor shape used across the app.
  */
 function contributorRowsToList(rows: unknown): PlantContributor[] {
   if (!Array.isArray(rows)) return []
   const out: PlantContributor[] = []
   for (const row of rows as Array<Record<string, any>>) {
     const id = typeof row?.contributor_id === 'string' ? row.contributor_id : null
+    if (!id) continue
     const profile = Array.isArray(row?.profile) ? row.profile[0] : row?.profile
-    const liveName = profile && typeof profile.display_name === 'string' ? profile.display_name.trim() || null : null
-    const snapshotName = typeof row?.contributor_name === 'string' ? row.contributor_name.trim() || null : null
-    const name = liveName || snapshotName
-    if (!id && !name) continue
+    const name = profile && typeof profile.display_name === 'string' ? profile.display_name.trim() || null : null
     out.push({ id, name })
   }
   return out
@@ -880,7 +855,7 @@ async function loadPlant(id: string, language?: string): Promise<Plant | null> {
   const { data: sources } = await supabase.from('plant_sources').select('id,name,url').eq('plant_id', id)
   const { data: contributorRows } = await supabase
     .from('plant_contributors')
-    .select('contributor_id, contributor_name, profile:contributor_id(id, display_name)')
+    .select('contributor_id, profile:contributor_id(id, display_name)')
     .eq('plant_id', id)
   const { data: recipeRows } = await supabase
     .from('plant_recipes')
@@ -1040,7 +1015,6 @@ async function loadPlant(id: string, language?: string): Promise<Plant | null> {
     },
     meta: {
       status: formatStatusForUi(data.status),
-      adminCommentary: data.admin_commentary || undefined,
       contributors: contributorRowsToList(contributorRows),
       createdBy: data.created_by || undefined,
       createdAt: data.created_time || undefined,
@@ -1202,7 +1176,6 @@ async function loadPlant(id: string, language?: string): Promise<Plant | null> {
 
   // Section 9: Meta
   flat.status = formatStatusForUi(data.status)
-  flat.adminCommentary = data.admin_commentary || plant.meta?.adminCommentary || undefined
   flat.contributors = contributorRowsToList(contributorRows)
 
   return plant
@@ -1327,11 +1300,12 @@ export const CreatePlantPage: React.FC<{ onCancel: () => void; onSaved?: (id: st
             .in('id', userIds)
           if (profilesError) throw new Error(profilesError.message)
           const contributors: PlantContributor[] = (profilesData || [])
-            .map((profile: any) => ({
-              id: typeof profile?.id === 'string' ? profile.id : null,
-              name: typeof profile?.display_name === 'string' ? profile.display_name.trim() || null : null,
-            }))
-            .filter((c) => c.id || c.name)
+            .map((profile: any): PlantContributor | null => {
+              if (typeof profile?.id !== 'string' || !profile.id) return null
+              const name = typeof profile?.display_name === 'string' ? profile.display_name.trim() || null : null
+              return { id: profile.id, name }
+            })
+            .filter((c): c is PlantContributor => Boolean(c))
           if (!contributors.length || cancelled) return
           setPlant((prev) => ({
             ...prev,
@@ -1739,10 +1713,10 @@ export const CreatePlantPage: React.FC<{ onCancel: () => void; onSaved?: (id: st
           : (plantToSave.meta?.createdAt || new Date().toISOString())
         const updatedByValue = profile?.display_name || plantToSave.meta?.updatedBy || null
         // Always seed in the current admin so editors are tracked by profile id.
-        const currentContributor: PlantContributor = {
-          id: profile?.id || null,
-          name: profile?.display_name || null,
-        }
+        // Skipped silently if the current user has no profile id (shouldn't happen for admins).
+        const currentContributor: ContributorInput = profile?.id
+          ? { id: profile.id, name: profile.display_name || null }
+          : null
         const contributorList = mergeContributors(
           plantToSave.meta?.contributors || plantToSave.contributors,
           [currentContributor],
@@ -1865,7 +1839,6 @@ export const CreatePlantPage: React.FC<{ onCancel: () => void; onSaved?: (id: st
             harmful_plants: filterValidUuids(p.harmfulPlants),
             // Section 9: Meta
             status: normalizedStatus,
-            admin_commentary: p.adminCommentary || p.meta?.adminCommentary || null,
             created_by: createdByValue,
             created_time: createdTimeValue,
             updated_by: updatedByValue,
@@ -1966,7 +1939,6 @@ export const CreatePlantPage: React.FC<{ onCancel: () => void; onSaved?: (id: st
             harmful_plants: filterValidUuids(p.harmfulPlants),
             // Section 9: Meta
             status: normalizedStatus,
-            admin_commentary: p.adminCommentary || p.meta?.adminCommentary || null,
             updated_by: updatedByValue,
             updated_time: new Date().toISOString(),
           }

--- a/plant-swipe/src/pages/CreatePlantPage.tsx
+++ b/plant-swipe/src/pages/CreatePlantPage.tsx
@@ -5,6 +5,8 @@ import { AlertCircle, ArrowLeft, ArrowUpRight, Check, Copy, ImagePlus, Loader2, 
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { supabase } from "@/lib/supabaseClient"
 import { PlantProfileForm, type PlantReport, type PlantVariety } from "@/components/plant/PlantProfileForm"
+import { AdminNotesThread } from "@/components/plant/AdminNotesThread"
+import { PlantHistoryPanel } from "@/components/plant/PlantHistoryPanel"
 import { fetchAiPlantFill, fetchAiPlantFillField } from "@/lib/aiPlantFill"
 import { fetchExternalPlantImages, uploadPlantImageFromUrl, uploadPlantImageFile, deletePlantImage, isManagedPlantImageUrl, IMAGE_SOURCES, type SourceResult, type ExternalImageSource } from "@/lib/externalImages"
 import type { Plant, PlantColor, PlantImage, PlantMeta, PlantRecipe, PlantSource, PlantWateringSchedule, MonthSlug } from "@/types/plant"
@@ -15,6 +17,8 @@ import { useLanguageNavigate, useLanguage } from "@/lib/i18nRouting"
 import { useNavigationHistory } from "@/hooks/useNavigationHistory"
 import { applyAiFieldToPlant, getCategoryForField } from "@/lib/applyAiField"
 import { translateArray, translateBatch, translateText } from "@/lib/deepl"
+import { logPlantHistory, logPlantHistoryBatch } from "@/lib/plantHistory"
+import { buildPlantFieldDiff } from "@/lib/plantHistoryDiff"
 import { buildCategoryProgress, createEmptyCategoryProgress, plantFormCategoryOrder, isFieldGatedOff, BOOLEAN_GATE_DEPS, UTILITY_GATE_DEPS, type CategoryProgress, type PlantFormCategory } from "@/lib/plantFormCategories"
 import { useParams, useSearchParams } from "react-router-dom"
 import { plantSchema } from "@/lib/plantSchema"
@@ -1305,6 +1309,11 @@ export const CreatePlantPage: React.FC<{ onCancel: () => void; onSaved?: (id: st
     const initialLoadCompleteRef = React.useRef(false)
     // Track the previous language to save edits before switching
     const previousLanguageRef = React.useRef<SupportedLanguage>(urlLanguage)
+    // Baseline for history diffing — set on load and after each successful save.
+    const lastSavedPlantRef = React.useRef<Plant | null>(null)
+    // Bump this to force the HistoryPanel / Notes thread to re-fetch.
+    const [historyVersion, setHistoryVersion] = React.useState(0)
+    const bumpHistoryVersion = React.useCallback(() => setHistoryVersion((v) => v + 1), [])
     
     // Handle language changes - save current edits and load new language data
     React.useEffect(() => {
@@ -1362,6 +1371,10 @@ export const CreatePlantPage: React.FC<{ onCancel: () => void; onSaved?: (id: st
             setLoadedLanguages(prev => new Set(prev).add(requestedLanguage))
             setExistingLoaded(true)
             initialLoadCompleteRef.current = true
+            // Establish the diff baseline from the freshly-loaded DB state.
+            if (requestedLanguage === 'en') {
+              lastSavedPlantRef.current = JSON.parse(JSON.stringify(loaded)) as Plant
+            }
           }
         } catch (e: any) {
           if (!ignore && languageRef.current === requestedLanguage) {
@@ -1608,7 +1621,7 @@ export const CreatePlantPage: React.FC<{ onCancel: () => void; onSaved?: (id: st
   }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    const savePlant = async (plantOverride?: Plant, options?: { skipOnSaved?: boolean }) => {
+    const savePlant = async (plantOverride?: Plant, options?: { skipOnSaved?: boolean; skipHistoryDiff?: boolean }) => {
       const saveLanguage = language
       const plantToSave = plantOverride || plant
       const trimmedName = plantToSave.name && typeof plantToSave.name === 'string' ? plantToSave.name.trim() : ''
@@ -2044,7 +2057,43 @@ export const CreatePlantPage: React.FC<{ onCancel: () => void; onSaved?: (id: st
             }))
             setLoadedLanguages(prev => new Set(prev).add(saveLanguage))
           }
-        if (isEnglish && !existingLoaded) setExistingLoaded(true)
+        const wasCreate = isEnglish && !existingLoaded
+        if (wasCreate) setExistingLoaded(true)
+
+        // Plant history: log create or per-field diff (English saves only — other
+        // languages just update translations and are noisy to diff against the EN baseline).
+        try {
+          const historyActor = { authorId: profile?.id || null, authorName: profile?.display_name || null }
+          if (wasCreate) {
+            await logPlantHistory({
+              plantId: savedId,
+              authorId: historyActor.authorId,
+              authorName: historyActor.authorName,
+              action: 'create',
+              summary: `Created plant "${trimmedName}"`,
+              newValue: trimmedName,
+            })
+          } else if (options?.skipHistoryDiff) {
+            // Caller will log its own summary entry (e.g. AI Fill).
+          } else if (isEnglish) {
+            const baseline = lastSavedPlantRef.current
+            const diff = buildPlantFieldDiff(savedId, baseline, plantToSave, historyActor)
+            if (diff.length) await logPlantHistoryBatch(diff)
+          } else {
+            await logPlantHistory({
+              plantId: savedId,
+              authorId: historyActor.authorId,
+              authorName: historyActor.authorName,
+              action: 'field_change',
+              field: `translation:${saveLanguage}`,
+              summary: `Updated ${saveLanguage.toUpperCase()} translation`,
+            })
+          }
+          lastSavedPlantRef.current = JSON.parse(JSON.stringify(savedPlant)) as Plant
+          bumpHistoryVersion()
+        } catch (historyErr) {
+          console.warn('[savePlant] history logging failed', historyErr)
+        }
         
         // Notify plant requesters if this plant was created from a request
         if (requestId && isEnglish && !existingLoaded) {
@@ -2452,7 +2501,17 @@ export const CreatePlantPage: React.FC<{ onCancel: () => void; onSaved?: (id: st
       const targetPlant = finalPlant || plant
       // Auto-save after AI fill but skip onSaved to prevent popup from closing
       // User can review the AI-filled data and manually save/close when ready
-      if (targetPlant) await savePlant(targetPlant, { skipOnSaved: true })
+      if (targetPlant) await savePlant(targetPlant, { skipOnSaved: true, skipHistoryDiff: true })
+      if (aiSucceeded && targetPlant?.id) {
+        await logPlantHistory({
+          plantId: targetPlant.id,
+          authorId: profile?.id || null,
+          authorName: profile?.display_name || null,
+          action: 'ai_fill',
+          summary: 'Launched AI Fill (all fields)',
+        })
+        bumpHistoryVersion()
+      }
     }
   }
 
@@ -2590,6 +2649,17 @@ export const CreatePlantPage: React.FC<{ onCancel: () => void; onSaved?: (id: st
         meta: { ...(prev.meta || {}), status: IN_PROGRESS_STATUS },
       }))
       await savePlant()
+      if (plant.id) {
+        await logPlantHistory({
+          plantId: plant.id,
+          authorId: profile?.id || null,
+          authorName: profile?.display_name || null,
+          action: 'translate',
+          summary: `Launched DeepL translation (${targets.length} ${targets.length === 1 ? 'language' : 'languages'})`,
+          newValue: targets.join(', '),
+        })
+        bumpHistoryVersion()
+      }
       } catch (e: any) {
         setError(e?.message || t('plantAdmin.errors.translation', 'Translation failed'))
     } finally {
@@ -3052,6 +3122,20 @@ export const CreatePlantPage: React.FC<{ onCancel: () => void; onSaved?: (id: st
             onUploadImages={() => { setManualUploadError(null); setManualUploadResults([]); setShowUploadDialog(true) }}
             plantReports={plantReports}
             plantVarieties={plantVarieties}
+            adminNotesSlot={
+              <AdminNotesThread
+                plantId={plant.id || id || null}
+                actor={{ id: profile?.id || null, name: profile?.display_name || null }}
+                refreshVersion={historyVersion}
+                onChanged={bumpHistoryVersion}
+              />
+            }
+            historySlot={
+              <PlantHistoryPanel
+                plantId={plant.id || id || null}
+                refreshVersion={historyVersion}
+              />
+            }
           />
         )}
 

--- a/plant-swipe/src/pages/CreatePlantPage.tsx
+++ b/plant-swipe/src/pages/CreatePlantPage.tsx
@@ -2070,7 +2070,6 @@ export const CreatePlantPage: React.FC<{ onCancel: () => void; onSaved?: (id: st
               authorId: historyActor.authorId,
               action: 'create',
               summary: `Created plant "${trimmedName}"`,
-              newValue: trimmedName,
             })
           } else if (options?.skipHistoryDiff) {
             // Caller will log its own summary entry (e.g. AI Fill).
@@ -2651,8 +2650,7 @@ export const CreatePlantPage: React.FC<{ onCancel: () => void; onSaved?: (id: st
           plantId: plant.id,
           authorId: profile?.id || null,
           action: 'translate',
-          summary: `Launched DeepL translation (${targets.length} ${targets.length === 1 ? 'language' : 'languages'})`,
-          newValue: targets.join(', '),
+          summary: `Launched DeepL translation (${targets.length === 1 ? targets[0].toUpperCase() : `${targets.length} languages`})`,
         })
         bumpHistoryVersion()
       }

--- a/plant-swipe/src/pages/PlantInfoPage.tsx
+++ b/plant-swipe/src/pages/PlantInfoPage.tsx
@@ -277,7 +277,10 @@ async function fetchPlantWithRelations(id: string, language?: string): Promise<P
     supabase.from('plant_watering_schedules').select('season,quantity,time_period').eq('plant_id', id),
     supabase.from('plant_sources').select('id,name,url').eq('plant_id', id),
     supabase.from('plant_infusion_mixes').select('mix_name,benefit').eq('plant_id', id),
-    supabase.from('plant_contributors').select('contributor_name').eq('plant_id', id),
+    supabase
+      .from('plant_contributors')
+      .select('contributor_id, contributor_name, profile:contributor_id(id, display_name)')
+      .eq('plant_id', id),
     supabase.from('plant_recipes').select('id,name,name_fr,category,time,link').eq('plant_id', id),
   ])
 
@@ -453,15 +456,32 @@ async function fetchPlantWithRelations(id: string, language?: string): Promise<P
     updatedBy: data.updated_by || undefined,
     updatedTime: data.updated_time || undefined,
     contributors: (() => {
-      const seen = new Map<string, string>()
+      // Dedupe by profile id first, then by case-insensitive display name so
+      // legacy rows (id=null, name=...) collapse cleanly against any newer
+      // id-carrying row with the same display name.
+      const seenIds = new Set<string>()
+      const seenNames = new Set<string>()
+      const out: { id: string | null; name: string | null }[] = []
       for (const row of (contributorRows || []) as any[]) {
-        const name = row?.contributor_name
-        if (typeof name === 'string' && name.trim()) {
+        const id = typeof row?.contributor_id === 'string' ? row.contributor_id : null
+        const profile = Array.isArray(row?.profile) ? row.profile[0] : row?.profile
+        const liveName = typeof profile?.display_name === 'string' ? profile.display_name.trim() : ''
+        const snapshotName = typeof row?.contributor_name === 'string' ? row.contributor_name.trim() : ''
+        const name = liveName || snapshotName
+        if (!id && !name) continue
+        if (id) {
+          if (seenIds.has(id)) continue
+          seenIds.add(id)
+          if (name) seenNames.add(name.toLowerCase())
+          out.push({ id, name: name || null })
+        } else if (name) {
           const key = name.toLowerCase()
-          if (!seen.has(key)) seen.set(key, name)
+          if (seenNames.has(key)) continue
+          seenNames.add(key)
+          out.push({ id: null, name })
         }
       }
-      return Array.from(seen.values())
+      return out
     })(),
 
     // Display
@@ -1957,11 +1977,14 @@ const MoreInformationSection: React.FC<{ plant: Plant; hideToxicityBanner?: bool
               <div className="mt-3 space-y-2 text-xs sm:text-sm text-stone-600 dark:text-stone-400">
                 <p>{t('plantInfo:contributors.thanks', 'Thank you to all plant lovers that participated:')}</p>
                 <div className="flex flex-wrap gap-2">
-                  {contributorsList.map((name) => (
-                    <Badge key={name} className="rounded-xl sm:rounded-2xl border-none bg-emerald-100/70 dark:bg-emerald-900/30 text-emerald-900 dark:text-emerald-100 text-[10px] sm:text-xs font-medium px-2 sm:px-3 py-0.5 sm:py-1">
-                      {name}
-                    </Badge>
-                  ))}
+                  {contributorsList.map((c, idx) => {
+                    const displayName = c.name || 'Unknown'
+                    return (
+                      <Badge key={c.id || `legacy-${idx}`} className="rounded-xl sm:rounded-2xl border-none bg-emerald-100/70 dark:bg-emerald-900/30 text-emerald-900 dark:text-emerald-100 text-[10px] sm:text-xs font-medium px-2 sm:px-3 py-0.5 sm:py-1">
+                        {displayName}
+                      </Badge>
+                    )
+                  })}
                 </div>
               </div>
             </details>

--- a/plant-swipe/src/pages/PlantInfoPage.tsx
+++ b/plant-swipe/src/pages/PlantInfoPage.tsx
@@ -279,7 +279,7 @@ async function fetchPlantWithRelations(id: string, language?: string): Promise<P
     supabase.from('plant_infusion_mixes').select('mix_name,benefit').eq('plant_id', id),
     supabase
       .from('plant_contributors')
-      .select('contributor_id, contributor_name, profile:contributor_id(id, display_name)')
+      .select('contributor_id, profile:contributor_id(id, display_name)')
       .eq('plant_id', id),
     supabase.from('plant_recipes').select('id,name,name_fr,category,time,link').eq('plant_id', id),
   ])
@@ -450,36 +450,20 @@ async function fetchPlantWithRelations(id: string, language?: string): Promise<P
 
     // Section 9: Meta
     status: data.status || undefined,
-    adminCommentary: data.admin_commentary || undefined,
     createdBy: data.created_by || undefined,
     createdTime: data.created_time || undefined,
     updatedBy: data.updated_by || undefined,
     updatedTime: data.updated_time || undefined,
     contributors: (() => {
-      // Dedupe by profile id first, then by case-insensitive display name so
-      // legacy rows (id=null, name=...) collapse cleanly against any newer
-      // id-carrying row with the same display name.
       const seenIds = new Set<string>()
-      const seenNames = new Set<string>()
-      const out: { id: string | null; name: string | null }[] = []
+      const out: { id: string; name: string | null }[] = []
       for (const row of (contributorRows || []) as any[]) {
         const id = typeof row?.contributor_id === 'string' ? row.contributor_id : null
+        if (!id || seenIds.has(id)) continue
+        seenIds.add(id)
         const profile = Array.isArray(row?.profile) ? row.profile[0] : row?.profile
-        const liveName = typeof profile?.display_name === 'string' ? profile.display_name.trim() : ''
-        const snapshotName = typeof row?.contributor_name === 'string' ? row.contributor_name.trim() : ''
-        const name = liveName || snapshotName
-        if (!id && !name) continue
-        if (id) {
-          if (seenIds.has(id)) continue
-          seenIds.add(id)
-          if (name) seenNames.add(name.toLowerCase())
-          out.push({ id, name: name || null })
-        } else if (name) {
-          const key = name.toLowerCase()
-          if (seenNames.has(key)) continue
-          seenNames.add(key)
-          out.push({ id: null, name })
-        }
+        const name = typeof profile?.display_name === 'string' ? profile.display_name.trim() || null : null
+        out.push({ id, name })
       }
       return out
     })(),

--- a/plant-swipe/src/types/plant.ts
+++ b/plant-swipe/src/types/plant.ts
@@ -320,7 +320,13 @@ export interface Plant {
   createdTime?: string
   updatedBy?: string
   updatedTime?: string
-  contributors?: string[]
+  /**
+   * Contributors to this plant entry. New rows always carry an `id` (profile
+   * FK). Legacy rows from before the id backfill may carry only a `name` —
+   * the UI resolves the live display_name by id when available and falls back
+   * to the stored name otherwise.
+   */
+  contributors?: PlantContributor[]
   sources?: PlantSource[]
 
   // -- Display / UI -----------------------------------------------------------
@@ -590,11 +596,18 @@ export interface PlantMiscellaneous {
   [key: string]: unknown
 }
 
+export interface PlantContributor {
+  /** Profile id. `null` for legacy rows that only carry a name. */
+  id: string | null
+  /** Display-name snapshot (fallback when id is null or profile deleted). */
+  name: string | null
+}
+
 /** @deprecated Use flat Plant interface */
 export interface PlantMeta {
   status?: string
   adminCommentary?: string
-  contributors?: string[]
+  contributors?: PlantContributor[]
   createdBy?: string
   createdTime?: string
   updatedBy?: string

--- a/plant-swipe/src/types/plant.ts
+++ b/plant-swipe/src/types/plant.ts
@@ -315,7 +315,7 @@ export interface Plant {
 
   // -- Section 9: Meta --------------------------------------------------------
   status?: PlantStatus
-  adminCommentary?: string
+  // adminCommentary removed — replaced by plant_admin_notes thread.
   createdBy?: string
   createdTime?: string
   updatedBy?: string
@@ -597,16 +597,16 @@ export interface PlantMiscellaneous {
 }
 
 export interface PlantContributor {
-  /** Profile id. `null` for legacy rows that only carry a name. */
-  id: string | null
-  /** Display-name snapshot (fallback when id is null or profile deleted). */
-  name: string | null
+  /** Profile id — required; no legacy name-only rows remain after cleanup. */
+  id: string
+  /** Display name resolved from profiles at read time (never persisted). */
+  name?: string | null
 }
 
 /** @deprecated Use flat Plant interface */
 export interface PlantMeta {
   status?: string
-  adminCommentary?: string
+  // adminCommentary removed — replaced by plant_admin_notes thread.
   contributors?: PlantContributor[]
   createdBy?: string
   createdTime?: string

--- a/plant-swipe/src/types/plantHistory.ts
+++ b/plant-swipe/src/types/plantHistory.ts
@@ -1,0 +1,32 @@
+export type PlantHistoryAction =
+  | 'field_change'
+  | 'translate'
+  | 'ai_fill'
+  | 'note_add'
+  | 'note_edit'
+  | 'note_delete'
+  | 'create'
+  | 'status_change'
+
+export interface PlantHistoryEntry {
+  id: string
+  plantId: string
+  authorId: string | null
+  authorName: string | null
+  action: PlantHistoryAction
+  field: string | null
+  summary: string | null
+  oldValue: string | null
+  newValue: string | null
+  createdAt: string
+}
+
+export interface PlantAdminNote {
+  id: string
+  plantId: string
+  authorId: string | null
+  authorName: string | null
+  body: string
+  createdAt: string
+  updatedAt: string
+}

--- a/plant-swipe/src/types/plantHistory.ts
+++ b/plant-swipe/src/types/plantHistory.ts
@@ -12,7 +12,6 @@ export interface PlantHistoryEntry {
   id: string
   plantId: string
   authorId: string | null
-  authorName: string | null
   action: PlantHistoryAction
   field: string | null
   summary: string | null
@@ -25,7 +24,6 @@ export interface PlantAdminNote {
   id: string
   plantId: string
   authorId: string | null
-  authorName: string | null
   body: string
   createdAt: string
   updatedAt: string

--- a/plant-swipe/src/types/plantHistory.ts
+++ b/plant-swipe/src/types/plantHistory.ts
@@ -15,8 +15,6 @@ export interface PlantHistoryEntry {
   action: PlantHistoryAction
   field: string | null
   summary: string | null
-  oldValue: string | null
-  newValue: string | null
   createdAt: string
 }
 

--- a/plant-swipe/supabase/DATABASE_SCHEMA.md
+++ b/plant-swipe/supabase/DATABASE_SCHEMA.md
@@ -1074,7 +1074,7 @@ Per-plant audit log. One row per discrete admin action across the Create/Edit Pl
 
 ```sql
 id              UUID PRIMARY KEY DEFAULT gen_random_uuid()
-plant_id        UUID NOT NULL REFERENCES plants(id) ON DELETE CASCADE
+plant_id        TEXT NOT NULL REFERENCES plants(id) ON DELETE CASCADE
 author_id       UUID REFERENCES profiles(id) ON DELETE SET NULL
 action          TEXT NOT NULL CHECK (action IN ('field_change','translate','ai_fill','note_add','note_edit','note_delete','create','status_change'))
 field           TEXT                    -- Plant field key for field_change/status_change; 'translation:<lang>' for translation saves
@@ -1090,7 +1090,7 @@ Chat-style editorial notes per plant. Replaces the legacy `plants.admin_commenta
 
 ```sql
 id              UUID PRIMARY KEY DEFAULT gen_random_uuid()
-plant_id        UUID NOT NULL REFERENCES plants(id) ON DELETE CASCADE
+plant_id        TEXT NOT NULL REFERENCES plants(id) ON DELETE CASCADE
 author_id       UUID REFERENCES profiles(id) ON DELETE SET NULL
 body            TEXT NOT NULL
 created_at      TIMESTAMPTZ NOT NULL DEFAULT now()

--- a/plant-swipe/supabase/DATABASE_SCHEMA.md
+++ b/plant-swipe/supabase/DATABASE_SCHEMA.md
@@ -28,6 +28,7 @@ The Aphylia database is built on Supabase (PostgreSQL) with extensive use of:
 - **Real-time subscriptions** for live updates
 
 ### Recent Updates (Keep Less than 10)
+- **Apr 22, 2026:** **Plant change history + admin notes thread.** New `plant_history` table logs per-plant admin actions (field edits, translations, AI fills, note add/edit/delete) — insert-only, admin/editor select. New `plant_admin_notes` table replaces the legacy `plants.admin_commentary` textarea with a chat-style thread (any admin can add/edit/delete any note; all mutations mirrored into `plant_history`). Schema file: `03_plants_and_colors.sql`.
 - **Apr 13, 2026:** **Native push tokens, tutorial, GDPR expansion, companion cleanup.** Added `user_fcm_tokens` table for native (Capacitor) FCM/APNs device tokens. Added `tutorial_completed` boolean column to `profiles` for onboarding tutorial persistence. Migration `20260408000000_clean_bad_companion_data.sql` bulk-cleans bad AI-filled companion data from `plants` table. Migration `20260408100000_fix_admin_event_notifications_rls.sql` fixes RLS so non-admin users can receive event notifications. GDPR delete handlers expanded to 10 additional tables (`15_gdpr_and_preferences.sql`). Schema files: `01_extensions_and_setup.sql`, `11_notifications_and_tasks.sql`, `15_gdpr_and_preferences.sql`, `17_admin_event_notifications.sql`.
 - **Apr 6, 2026:** **Events & Badges schema files.** Added `19_badges.sql` (badge catalog, translations, user badges) and `20_events.sql` (events, items, translations, registrations, user progress) to `sync_parts/`. Added `conservation_status` values `protected` and `protected_in_some_regions`. Unified `plant_part` and `edible_part` to share 12 items (added `tubers`). Fixed Phase 3 sync constraints for `conservation_status` and `plant_part`. Schema files: `03_plants_and_colors.sql`, `19_badges.sql`, `20_events.sql`.
 - **Mar 31, 2026:** **`events` admin UPDATE RLS.** The `events` table had SELECT-only policies; authenticated updates from `/admin/events` matched no policy and updated zero rows while the client still reported success. Added policy `events_update_admin` (`public.is_admin_user`) for UPDATE. Schema file: `20_events.sql`.
@@ -99,6 +100,8 @@ The schema is split into 20 files in `supabase/sync_parts/` for easier managemen
 | `plant_recipes` | Structured recipe ideas with category and time |
 | `plant_contributors` | Contributor names per plant (admin/editor write only) |
 | `plant_reports` | User-submitted reports about incorrect/outdated plant info |
+| `plant_history` | Per-plant admin change log (field edits, translations, AI fills, note actions). Insert-only; admin/editor select. |
+| `plant_admin_notes` | Chat-style editorial notes per plant. Any admin can add/edit/delete any note. Mutations mirrored into `plant_history`. |
 | `plant_pro_advices` | Professional growing tips |
 | `plant_images` | Plant image gallery |
 | `colors` | Color catalog |
@@ -1058,6 +1061,41 @@ note            TEXT NOT NULL
 image_url       TEXT
 created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
 ```
+
+### `plant_history`
+
+Per-plant audit log. One row per discrete admin action on the Create/Edit Plant page. Intentionally compact — short summary + optional old/new snippets. Insert-only for admins; no UPDATE or DELETE policy.
+
+```sql
+id              UUID PRIMARY KEY DEFAULT gen_random_uuid()
+plant_id        UUID NOT NULL REFERENCES plants(id) ON DELETE CASCADE
+author_id       UUID REFERENCES profiles(id) ON DELETE SET NULL
+author_name     TEXT
+action          TEXT NOT NULL CHECK (action IN ('field_change','translate','ai_fill','note_add','note_edit','note_delete','create','status_change'))
+field           TEXT                    -- Plant field key for field_change/status_change; 'translation:<lang>' for translation saves
+summary         TEXT                    -- Human-readable summary, e.g. "Changed Watering type"
+old_value       TEXT                    -- Clipped to 240 chars
+new_value       TEXT                    -- Clipped to 240 chars
+created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+```
+
+**RLS:** SELECT and INSERT restricted to users with `is_admin = true` or role `admin`/`editor`. No UPDATE or DELETE policies — history is immutable.
+
+### `plant_admin_notes`
+
+Chat-style editorial notes per plant. Replaces the legacy `plants.admin_commentary` free-text field. Any admin can add, edit, or delete any note; every mutation is mirrored as a `plant_history` row (note_add / note_edit / note_delete).
+
+```sql
+id              UUID PRIMARY KEY DEFAULT gen_random_uuid()
+plant_id        UUID NOT NULL REFERENCES plants(id) ON DELETE CASCADE
+author_id       UUID REFERENCES profiles(id) ON DELETE SET NULL
+author_name     TEXT
+body            TEXT NOT NULL
+created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+```
+
+**RLS:** SELECT/INSERT/UPDATE/DELETE all restricted to admins (is_admin = true) or users with role `admin`/`editor`.
 
 ### `friend_requests`
 

--- a/plant-swipe/supabase/DATABASE_SCHEMA.md
+++ b/plant-swipe/supabase/DATABASE_SCHEMA.md
@@ -1064,13 +1064,12 @@ created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
 
 ### `plant_history`
 
-Per-plant audit log. One row per discrete admin action on the Create/Edit Plant page. Intentionally compact — short summary + optional old/new snippets. Insert-only for admins; no UPDATE or DELETE policy.
+Per-plant audit log. One row per discrete admin action on the Create/Edit Plant page. Intentionally compact — short summary + optional old/new snippets. Insert-only for admins; no UPDATE or DELETE policy. The author's display name is **not** stored — the UI resolves it from `profiles` at read time via a batched lookup.
 
 ```sql
 id              UUID PRIMARY KEY DEFAULT gen_random_uuid()
 plant_id        UUID NOT NULL REFERENCES plants(id) ON DELETE CASCADE
 author_id       UUID REFERENCES profiles(id) ON DELETE SET NULL
-author_name     TEXT
 action          TEXT NOT NULL CHECK (action IN ('field_change','translate','ai_fill','note_add','note_edit','note_delete','create','status_change'))
 field           TEXT                    -- Plant field key for field_change/status_change; 'translation:<lang>' for translation saves
 summary         TEXT                    -- Human-readable summary, e.g. "Changed Watering type"
@@ -1083,13 +1082,12 @@ created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
 
 ### `plant_admin_notes`
 
-Chat-style editorial notes per plant. Replaces the legacy `plants.admin_commentary` free-text field. Any admin can add, edit, or delete any note; every mutation is mirrored as a `plant_history` row (note_add / note_edit / note_delete).
+Chat-style editorial notes per plant. Replaces the legacy `plants.admin_commentary` free-text field. Any admin can add, edit, or delete any note; every mutation is mirrored as a `plant_history` row (note_add / note_edit / note_delete). The author's display name is **not** stored — resolved from `profiles` at read time.
 
 ```sql
 id              UUID PRIMARY KEY DEFAULT gen_random_uuid()
 plant_id        UUID NOT NULL REFERENCES plants(id) ON DELETE CASCADE
 author_id       UUID REFERENCES profiles(id) ON DELETE SET NULL
-author_name     TEXT
 body            TEXT NOT NULL
 created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
 updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()

--- a/plant-swipe/supabase/DATABASE_SCHEMA.md
+++ b/plant-swipe/supabase/DATABASE_SCHEMA.md
@@ -28,6 +28,7 @@ The Aphylia database is built on Supabase (PostgreSQL) with extensive use of:
 - **Real-time subscriptions** for live updates
 
 ### Recent Updates (Keep Less than 10)
+- **Apr 23, 2026:** **Dropped legacy admin_commentary + contributor_name.** Now that the data migrations have been applied, `plants.admin_commentary` is dropped and `plant_contributors.contributor_name` is removed (along with its legacy unique index and the id-or-name check constraint). `plant_contributors.contributor_id` is now `NOT NULL` with `ON DELETE CASCADE` and the single unique is `(plant_id, contributor_id)`. Orphan contributor rows that couldn't be resolved to a profile during backfill are deleted by the idempotent cleanup block in `03_plants_and_colors.sql`. Client code purged of every `adminCommentary` / `contributor_name` reference across pages, services, schema, diff helper, and server.js.
 - **Apr 22, 2026:** **Contributors keyed by profile id.** Added `plant_contributors.contributor_id` (uuid FK to `profiles`, `ON DELETE SET NULL`) alongside the existing `contributor_name` (now nullable, kept only as legacy snapshot). Replaced the case-insensitive name unique index with two partial uniques (one per id, one per legacy name) and added a check constraint requiring either an id or a non-empty name. New admin UI uses a shared user-search picker (same `SearchItem` pattern as Admin Event notifications). Migration `20260422100000_backfill_plant_contributor_ids.sql` resolves existing names to profile ids via `display_name`. Schema file: `03_plants_and_colors.sql`.
 - **Apr 22, 2026:** **Plant change history + admin notes thread.** New `plant_history` table logs per-plant admin actions (field edits, translations, AI fills, note add/edit/delete) — insert-only, admin/editor select. New `plant_admin_notes` table replaces the legacy `plants.admin_commentary` textarea with a chat-style thread (any admin can add/edit/delete any note; all mutations mirrored into `plant_history`). Schema file: `03_plants_and_colors.sql`.
 - **Apr 13, 2026:** **Native push tokens, tutorial, GDPR expansion, companion cleanup.** Added `user_fcm_tokens` table for native (Capacitor) FCM/APNs device tokens. Added `tutorial_completed` boolean column to `profiles` for onboarding tutorial persistence. Migration `20260408000000_clean_bad_companion_data.sql` bulk-cleans bad AI-filled companion data from `plants` table. Migration `20260408100000_fix_admin_event_notifications_rls.sql` fixes RLS so non-admin users can receive event notifications. GDPR delete handlers expanded to 10 additional tables (`15_gdpr_and_preferences.sql`). Schema files: `01_extensions_and_setup.sql`, `11_notifications_and_tasks.sql`, `15_gdpr_and_preferences.sql`, `17_admin_event_notifications.sql`.
@@ -831,7 +832,7 @@ sponsored_shop_ids        TEXT[]                 -- Merchant IDs (future sponsor
 
 -- Section 9: Meta
 status                    TEXT                   -- CHECK: in_progress, rework, review, approved
-admin_commentary          TEXT
+-- admin_commentary removed — replaced by the plant_admin_notes thread.
 created_by                TEXT
 created_time              TIMESTAMPTZ NOT NULL DEFAULT now()
 updated_by                TEXT
@@ -982,20 +983,17 @@ created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
 
 ### `plant_contributors`
 
-Contributors per plant. Admin/editor write only; public read. New rows carry a profile id (`contributor_id`); `contributor_name` is kept only as a snapshot fallback for legacy rows inserted before the id backfill. Every row must have either an id or a non-empty name (CHECK constraint).
+Contributors per plant, identified solely by profile id. Admin/editor write only; public read. The legacy `contributor_name` column was dropped after the id-backfill migration ran; display names are resolved from `profiles` at read time.
 
 ```sql
-id                UUID PRIMARY KEY DEFAULT gen_random_uuid()
-plant_id          TEXT NOT NULL REFERENCES plants(id) ON DELETE CASCADE
-contributor_id    UUID REFERENCES profiles(id) ON DELETE SET NULL
-contributor_name  TEXT          -- legacy snapshot fallback
-created_at        TIMESTAMPTZ NOT NULL DEFAULT now()
-CHECK (contributor_id IS NOT NULL OR (contributor_name IS NOT NULL AND length(btrim(contributor_name)) > 0))
-UNIQUE(plant_id, contributor_id)           WHERE contributor_id IS NOT NULL
-UNIQUE(plant_id, lower(contributor_name))  WHERE contributor_id IS NULL
+id              UUID PRIMARY KEY DEFAULT gen_random_uuid()
+plant_id        TEXT NOT NULL REFERENCES plants(id) ON DELETE CASCADE
+contributor_id  UUID NOT NULL REFERENCES profiles(id) ON DELETE CASCADE
+created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+UNIQUE(plant_id, contributor_id)
 ```
 
-Backfill migration `20260422100000_backfill_plant_contributor_ids.sql` resolves existing `contributor_name` values to profile ids via `profiles.display_name` (case-insensitive) and removes would-be duplicates before update. The Plant Create/Edit page now uses a shared `SearchItem`-powered user picker (`PlantContributorsPicker`) to add contributors by id; PlantInfoPage resolves the live `display_name` via a joined `profile:contributor_id(id, display_name)` select.
+The Plant Create/Edit page uses a shared `SearchItem`-backed user picker (`PlantContributorsPicker`); PlantInfoPage joins `profile:contributor_id(id, display_name)` to render the current display name. Renaming a profile updates every plant page where they appear.
 
 ### `plant_infusion_mixes`
 

--- a/plant-swipe/supabase/DATABASE_SCHEMA.md
+++ b/plant-swipe/supabase/DATABASE_SCHEMA.md
@@ -1064,7 +1064,7 @@ created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
 
 ### `plant_history`
 
-Per-plant audit log. One row per discrete admin action on the Create/Edit Plant page. Intentionally compact — short summary + optional old/new snippets. Insert-only for admins; no UPDATE or DELETE policy. The author's display name is **not** stored — the UI resolves it from `profiles` at read time via a batched lookup.
+Per-plant audit log. One row per discrete admin action across the Create/Edit Plant page, the AI Plant Request flow, and the Quick Actions on the plant admin listing. Intentionally compact — author, action, field, short summary. **Old/new field values are deliberately not stored** (only who changed what, when). Insert-only for admins; no UPDATE or DELETE policy. The author's display name is **not** stored — the UI resolves it from `profiles` at read time via a batched lookup.
 
 ```sql
 id              UUID PRIMARY KEY DEFAULT gen_random_uuid()
@@ -1073,8 +1073,6 @@ author_id       UUID REFERENCES profiles(id) ON DELETE SET NULL
 action          TEXT NOT NULL CHECK (action IN ('field_change','translate','ai_fill','note_add','note_edit','note_delete','create','status_change'))
 field           TEXT                    -- Plant field key for field_change/status_change; 'translation:<lang>' for translation saves
 summary         TEXT                    -- Human-readable summary, e.g. "Changed Watering type"
-old_value       TEXT                    -- Clipped to 240 chars
-new_value       TEXT                    -- Clipped to 240 chars
 created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
 ```
 

--- a/plant-swipe/supabase/DATABASE_SCHEMA.md
+++ b/plant-swipe/supabase/DATABASE_SCHEMA.md
@@ -28,6 +28,7 @@ The Aphylia database is built on Supabase (PostgreSQL) with extensive use of:
 - **Real-time subscriptions** for live updates
 
 ### Recent Updates (Keep Less than 10)
+- **Apr 22, 2026:** **Contributors keyed by profile id.** Added `plant_contributors.contributor_id` (uuid FK to `profiles`, `ON DELETE SET NULL`) alongside the existing `contributor_name` (now nullable, kept only as legacy snapshot). Replaced the case-insensitive name unique index with two partial uniques (one per id, one per legacy name) and added a check constraint requiring either an id or a non-empty name. New admin UI uses a shared user-search picker (same `SearchItem` pattern as Admin Event notifications). Migration `20260422100000_backfill_plant_contributor_ids.sql` resolves existing names to profile ids via `display_name`. Schema file: `03_plants_and_colors.sql`.
 - **Apr 22, 2026:** **Plant change history + admin notes thread.** New `plant_history` table logs per-plant admin actions (field edits, translations, AI fills, note add/edit/delete) — insert-only, admin/editor select. New `plant_admin_notes` table replaces the legacy `plants.admin_commentary` textarea with a chat-style thread (any admin can add/edit/delete any note; all mutations mirrored into `plant_history`). Schema file: `03_plants_and_colors.sql`.
 - **Apr 13, 2026:** **Native push tokens, tutorial, GDPR expansion, companion cleanup.** Added `user_fcm_tokens` table for native (Capacitor) FCM/APNs device tokens. Added `tutorial_completed` boolean column to `profiles` for onboarding tutorial persistence. Migration `20260408000000_clean_bad_companion_data.sql` bulk-cleans bad AI-filled companion data from `plants` table. Migration `20260408100000_fix_admin_event_notifications_rls.sql` fixes RLS so non-admin users can receive event notifications. GDPR delete handlers expanded to 10 additional tables (`15_gdpr_and_preferences.sql`). Schema files: `01_extensions_and_setup.sql`, `11_notifications_and_tasks.sql`, `15_gdpr_and_preferences.sql`, `17_admin_event_notifications.sql`.
 - **Apr 6, 2026:** **Events & Badges schema files.** Added `19_badges.sql` (badge catalog, translations, user badges) and `20_events.sql` (events, items, translations, registrations, user progress) to `sync_parts/`. Added `conservation_status` values `protected` and `protected_in_some_regions`. Unified `plant_part` and `edible_part` to share 12 items (added `tubers`). Fixed Phase 3 sync constraints for `conservation_status` and `plant_part`. Schema files: `03_plants_and_colors.sql`, `19_badges.sql`, `20_events.sql`.
@@ -981,15 +982,20 @@ created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
 
 ### `plant_contributors`
 
-Contributor names per plant. Admin/editor write only; public read.
+Contributors per plant. Admin/editor write only; public read. New rows carry a profile id (`contributor_id`); `contributor_name` is kept only as a snapshot fallback for legacy rows inserted before the id backfill. Every row must have either an id or a non-empty name (CHECK constraint).
 
 ```sql
 id                UUID PRIMARY KEY DEFAULT gen_random_uuid()
 plant_id          TEXT NOT NULL REFERENCES plants(id) ON DELETE CASCADE
-contributor_name  TEXT NOT NULL
+contributor_id    UUID REFERENCES profiles(id) ON DELETE SET NULL
+contributor_name  TEXT          -- legacy snapshot fallback
 created_at        TIMESTAMPTZ NOT NULL DEFAULT now()
-UNIQUE(plant_id, lower(contributor_name))
+CHECK (contributor_id IS NOT NULL OR (contributor_name IS NOT NULL AND length(btrim(contributor_name)) > 0))
+UNIQUE(plant_id, contributor_id)           WHERE contributor_id IS NOT NULL
+UNIQUE(plant_id, lower(contributor_name))  WHERE contributor_id IS NULL
 ```
+
+Backfill migration `20260422100000_backfill_plant_contributor_ids.sql` resolves existing `contributor_name` values to profile ids via `profiles.display_name` (case-insensitive) and removes would-be duplicates before update. The Plant Create/Edit page now uses a shared `SearchItem`-powered user picker (`PlantContributorsPicker`) to add contributors by id; PlantInfoPage resolves the live `display_name` via a joined `profile:contributor_id(id, display_name)` select.
 
 ### `plant_infusion_mixes`
 

--- a/plant-swipe/supabase/migrations/20260422000000_migrate_admin_commentary_to_notes.sql
+++ b/plant-swipe/supabase/migrations/20260422000000_migrate_admin_commentary_to_notes.sql
@@ -1,0 +1,68 @@
+-- ============================================================================
+-- Migrate legacy plants.admin_commentary free-text into the new
+-- public.plant_admin_notes thread.
+--
+-- Rules (per product request):
+--   • One note per newline-separated chunk of the existing commentary.
+--   • Blank chunks skipped.
+--   • author_id  = Xavier Sabar's profile id (looked up by display_name).
+--   • author_name = 'Xavier Sabar' (snapshot).
+--   • created_at / updated_at = migration run time (now()).
+--
+-- Idempotent: per-plant we skip if a Xavier-authored note already exists for
+-- that plant (prevents duplicating on re-run). Plants whose commentary has
+-- changed since the last run will still be migrated only if no Xavier note
+-- exists for that plant yet.
+-- ============================================================================
+
+do $$
+declare
+  v_xavier_id uuid;
+  r record;
+  raw_line text;
+  trimmed_line text;
+  inserted integer := 0;
+  plants_touched integer := 0;
+begin
+  select p.id
+    into v_xavier_id
+    from public.profiles p
+    where lower(p.display_name) = lower('Xavier Sabar')
+    limit 1;
+
+  if v_xavier_id is null then
+    raise warning '[migrate_admin_commentary] Xavier Sabar profile not found; aborting migration.';
+    return;
+  end if;
+
+  for r in
+    select p.id as plant_id, p.admin_commentary as body
+      from public.plants p
+     where p.admin_commentary is not null
+       and length(btrim(p.admin_commentary)) > 0
+       and not exists (
+         select 1
+           from public.plant_admin_notes n
+          where n.plant_id = p.id
+            and n.author_id = v_xavier_id
+       )
+  loop
+    plants_touched := plants_touched + 1;
+    foreach raw_line in array regexp_split_to_array(coalesce(r.body, ''), E'\r?\n')
+    loop
+      trimmed_line := btrim(raw_line);
+      if length(trimmed_line) = 0 then
+        continue;
+      end if;
+      insert into public.plant_admin_notes
+        (plant_id, author_id, author_name, body, created_at, updated_at)
+      values
+        (r.plant_id, v_xavier_id, 'Xavier Sabar', trimmed_line, now(), now());
+      inserted := inserted + 1;
+    end loop;
+  end loop;
+
+  raise notice '[migrate_admin_commentary] Xavier id=%, plants_migrated=%, notes_inserted=%',
+    v_xavier_id, plants_touched, inserted;
+end
+$$;

--- a/plant-swipe/supabase/migrations/20260422000000_migrate_admin_commentary_to_notes.sql
+++ b/plant-swipe/supabase/migrations/20260422000000_migrate_admin_commentary_to_notes.sql
@@ -5,33 +5,26 @@
 -- Rules (per product request):
 --   • One note per newline-separated chunk of the existing commentary.
 --   • Blank chunks skipped.
---   • author_id  = Xavier Sabar's profile id (looked up by display_name).
---   • author_name = 'Xavier Sabar' (snapshot).
+--   • author_id = Xavier Sabar's profile id (hardcoded below).
 --   • created_at / updated_at = migration run time (now()).
+--   • The plant_admin_notes / plant_history tables do NOT store a snapshot
+--     display name — the UI resolves names from profiles at read time.
 --
 -- Idempotent: per-plant we skip if a Xavier-authored note already exists for
--- that plant (prevents duplicating on re-run). Plants whose commentary has
--- changed since the last run will still be migrated only if no Xavier note
--- exists for that plant yet.
+-- that plant (prevents duplicating on re-run).
 -- ============================================================================
 
 do $$
 declare
-  v_xavier_id uuid;
+  v_xavier_id constant uuid := '007f393d-7627-4e2d-929a-97584ecf74fc';
   r record;
   raw_line text;
   trimmed_line text;
   inserted integer := 0;
   plants_touched integer := 0;
 begin
-  select p.id
-    into v_xavier_id
-    from public.profiles p
-    where lower(p.display_name) = lower('Xavier Sabar')
-    limit 1;
-
-  if v_xavier_id is null then
-    raise warning '[migrate_admin_commentary] Xavier Sabar profile not found; aborting migration.';
+  if not exists (select 1 from public.profiles where id = v_xavier_id) then
+    raise warning '[migrate_admin_commentary] Xavier profile % not found; aborting.', v_xavier_id;
     return;
   end if;
 
@@ -55,9 +48,9 @@ begin
         continue;
       end if;
       insert into public.plant_admin_notes
-        (plant_id, author_id, author_name, body, created_at, updated_at)
+        (plant_id, author_id, body, created_at, updated_at)
       values
-        (r.plant_id, v_xavier_id, 'Xavier Sabar', trimmed_line, now(), now());
+        (r.plant_id, v_xavier_id, trimmed_line, now(), now());
       inserted := inserted + 1;
     end loop;
   end loop;

--- a/plant-swipe/supabase/migrations/20260422100000_backfill_plant_contributor_ids.sql
+++ b/plant-swipe/supabase/migrations/20260422100000_backfill_plant_contributor_ids.sql
@@ -1,0 +1,67 @@
+-- ============================================================================
+-- Backfill public.plant_contributors.contributor_id by matching the existing
+-- contributor_name (free text) against profiles.display_name case-insensitively.
+--
+-- Rows whose name doesn't match any profile are left alone — they keep the
+-- legacy contributor_name and render as "Unknown" avatars on the UI.
+--
+-- Idempotent: only touches rows where contributor_id is still null.
+-- ============================================================================
+
+do $$
+declare
+  updated integer := 0;
+  collisions integer := 0;
+begin
+  with candidates as (
+    select pc.id as row_id,
+           pc.plant_id,
+           pc.contributor_name,
+           (
+             select p.id
+               from public.profiles p
+              where lower(p.display_name) = lower(btrim(pc.contributor_name))
+              limit 1
+           ) as matched_id
+      from public.plant_contributors pc
+     where pc.contributor_id is null
+       and pc.contributor_name is not null
+       and length(btrim(pc.contributor_name)) > 0
+  ),
+  resolved as (
+    select row_id, plant_id, matched_id
+      from candidates
+     where matched_id is not null
+  ),
+  -- A plant could already have a row for the matched profile (e.g. the admin
+  -- was added by id earlier). Drop would-be duplicates before updating.
+  to_delete as (
+    select r.row_id
+      from resolved r
+      join public.plant_contributors existing
+        on existing.plant_id = r.plant_id
+       and existing.contributor_id = r.matched_id
+       and existing.id <> r.row_id
+  ),
+  deleted as (
+    delete from public.plant_contributors pc
+     using to_delete d
+     where pc.id = d.row_id
+    returning 1
+  ),
+  upd as (
+    update public.plant_contributors pc
+       set contributor_id = r.matched_id
+      from resolved r
+     where pc.id = r.row_id
+       and pc.id not in (select row_id from to_delete)
+    returning 1
+  )
+  select
+    (select count(*) from upd),
+    (select count(*) from deleted)
+    into updated, collisions;
+
+  raise notice '[backfill_plant_contributor_ids] updated=%, duplicates_removed=%', updated, collisions;
+end
+$$;

--- a/plant-swipe/supabase/sync_parts/01_extensions_and_setup.sql
+++ b/plant-swipe/supabase/sync_parts/01_extensions_and_setup.sql
@@ -94,6 +94,8 @@ do $$ declare
     'plant_reports',
     'plant_pro_advices',
     'plant_images',
+    'plant_history',
+    'plant_admin_notes',
     'colors',
     'plant_colors',
     'color_translations',

--- a/plant-swipe/supabase/sync_parts/03_plants_and_colors.sql
+++ b/plant-swipe/supabase/sync_parts/03_plants_and_colors.sql
@@ -2179,11 +2179,11 @@ end $$;
 -- ========== Plant change history ==========
 -- Per-plant audit log written by admins on edits, translations, AI fills, and note actions.
 -- Intentionally compact: one row per discrete action with short summary + optional old/new snippets.
+-- The author's display_name is NOT stored — always resolved from profiles at read time.
 create table if not exists public.plant_history (
   id uuid primary key default gen_random_uuid(),
   plant_id uuid not null references public.plants(id) on delete cascade,
   author_id uuid references public.profiles(id) on delete set null,
-  author_name text,
   action text not null check (action in (
     'field_change','translate','ai_fill','note_add','note_edit','note_delete','create','status_change'
   )),
@@ -2194,6 +2194,8 @@ create table if not exists public.plant_history (
   created_at timestamptz not null default now()
 );
 comment on table public.plant_history is 'Per-plant admin change log: field edits, translations, AI fills, note actions.';
+-- Drop legacy snapshot column if present from an earlier schema revision.
+alter table public.plant_history drop column if exists author_name;
 create index if not exists plant_history_plant_time_idx on public.plant_history (plant_id, created_at desc);
 create index if not exists plant_history_author_idx on public.plant_history (author_id, created_at desc);
 
@@ -2231,16 +2233,18 @@ end $$;
 -- ========== Plant admin notes (chat-style) ==========
 -- Thread of editorial notes per plant. Any admin can add, edit or delete any note.
 -- All note mutations should also write a plant_history row.
+-- The author's display_name is NOT stored — always resolved from profiles at read time.
 create table if not exists public.plant_admin_notes (
   id uuid primary key default gen_random_uuid(),
   plant_id uuid not null references public.plants(id) on delete cascade,
   author_id uuid references public.profiles(id) on delete set null,
-  author_name text,
   body text not null,
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now()
 );
 comment on table public.plant_admin_notes is 'Editorial chat-style notes per plant. Any admin can CRUD any note.';
+-- Drop legacy snapshot column if present from an earlier schema revision.
+alter table public.plant_admin_notes drop column if exists author_name;
 create index if not exists plant_admin_notes_plant_time_idx on public.plant_admin_notes (plant_id, created_at desc);
 create index if not exists plant_admin_notes_author_idx on public.plant_admin_notes (author_id, created_at desc);
 

--- a/plant-swipe/supabase/sync_parts/03_plants_and_colors.sql
+++ b/plant-swipe/supabase/sync_parts/03_plants_and_colors.sql
@@ -2226,7 +2226,7 @@ end $$;
 -- The author's display_name is NOT stored — always resolved from profiles at read time.
 create table if not exists public.plant_history (
   id uuid primary key default gen_random_uuid(),
-  plant_id uuid not null references public.plants(id) on delete cascade,
+  plant_id text not null references public.plants(id) on delete cascade,
   author_id uuid references public.profiles(id) on delete set null,
   action text not null check (action in (
     'field_change','translate','ai_fill','note_add','note_edit','note_delete','create','status_change'
@@ -2280,7 +2280,7 @@ end $$;
 -- The author's display_name is NOT stored — always resolved from profiles at read time.
 create table if not exists public.plant_admin_notes (
   id uuid primary key default gen_random_uuid(),
-  plant_id uuid not null references public.plants(id) on delete cascade,
+  plant_id text not null references public.plants(id) on delete cascade,
   author_id uuid references public.profiles(id) on delete set null,
   body text not null,
   created_at timestamptz not null default now(),

--- a/plant-swipe/supabase/sync_parts/03_plants_and_colors.sql
+++ b/plant-swipe/supabase/sync_parts/03_plants_and_colors.sql
@@ -1627,14 +1627,57 @@ do $$ begin
 end $$;
 
 -- ========== Plant contributors ==========
+-- Contributors are identified by profile id (contributor_id). A legacy
+-- contributor_name column is kept only as a snapshot fallback for rows that
+-- were inserted before we stored ids; new rows always set contributor_id.
 create table if not exists public.plant_contributors (
   id uuid primary key default gen_random_uuid(),
   plant_id text not null references public.plants(id) on delete cascade,
-  contributor_name text not null,
+  contributor_name text,
   created_at timestamptz not null default now()
 );
+-- Relax contributor_name NOT NULL for rows that only carry an id.
+alter table public.plant_contributors alter column contributor_name drop not null;
+-- Add contributor_id column + FK (set null when the profile is removed so the
+-- historical "someone contributed here" signal is preserved as a blank avatar).
+alter table public.plant_contributors add column if not exists contributor_id uuid;
+do $$ begin
+  if not exists (
+    select 1 from information_schema.table_constraints
+    where table_schema = 'public'
+      and table_name = 'plant_contributors'
+      and constraint_name = 'plant_contributors_contributor_fk'
+  ) then
+    alter table public.plant_contributors
+      add constraint plant_contributors_contributor_fk
+      foreign key (contributor_id) references public.profiles(id) on delete set null;
+  end if;
+end $$;
+-- Ensure at least one identifier is present.
+do $$ begin
+  if not exists (
+    select 1 from information_schema.table_constraints
+    where table_schema = 'public'
+      and table_name = 'plant_contributors'
+      and constraint_name = 'plant_contributors_id_or_name_chk'
+  ) then
+    alter table public.plant_contributors
+      add constraint plant_contributors_id_or_name_chk
+      check (contributor_id is not null or (contributor_name is not null and length(btrim(contributor_name)) > 0));
+  end if;
+end $$;
 create index if not exists plant_contributors_plant_id_idx on public.plant_contributors(plant_id);
-create unique index if not exists plant_contributors_unique_name_idx on public.plant_contributors(plant_id, lower(contributor_name));
+create index if not exists plant_contributors_contributor_id_idx on public.plant_contributors(contributor_id);
+-- Replace the legacy name-based uniqueness with two partial uniques:
+--  • one ID per plant
+--  • one legacy name per plant (for rows without an id)
+drop index if exists plant_contributors_unique_name_idx;
+create unique index if not exists plant_contributors_unique_id_idx
+  on public.plant_contributors(plant_id, contributor_id)
+  where contributor_id is not null;
+create unique index if not exists plant_contributors_unique_legacy_name_idx
+  on public.plant_contributors(plant_id, lower(contributor_name))
+  where contributor_id is null;
 alter table public.plant_contributors enable row level security;
 do $$ begin
   if exists (select 1 from pg_policies where schemaname='public' and tablename='plant_contributors' and policyname='plant_contributors_select_all') then

--- a/plant-swipe/supabase/sync_parts/03_plants_and_colors.sql
+++ b/plant-swipe/supabase/sync_parts/03_plants_and_colors.sql
@@ -2175,3 +2175,136 @@ do $$ begin
       )
     );
 end $$;
+
+-- ========== Plant change history ==========
+-- Per-plant audit log written by admins on edits, translations, AI fills, and note actions.
+-- Intentionally compact: one row per discrete action with short summary + optional old/new snippets.
+create table if not exists public.plant_history (
+  id uuid primary key default gen_random_uuid(),
+  plant_id uuid not null references public.plants(id) on delete cascade,
+  author_id uuid references public.profiles(id) on delete set null,
+  author_name text,
+  action text not null check (action in (
+    'field_change','translate','ai_fill','note_add','note_edit','note_delete','create','status_change'
+  )),
+  field text,
+  summary text,
+  old_value text,
+  new_value text,
+  created_at timestamptz not null default now()
+);
+comment on table public.plant_history is 'Per-plant admin change log: field edits, translations, AI fills, note actions.';
+create index if not exists plant_history_plant_time_idx on public.plant_history (plant_id, created_at desc);
+create index if not exists plant_history_author_idx on public.plant_history (author_id, created_at desc);
+
+alter table public.plant_history enable row level security;
+
+do $$ begin
+  if exists (select 1 from pg_policies where schemaname='public' and tablename='plant_history' and policyname='plant_history_admin_select') then
+    drop policy plant_history_admin_select on public.plant_history;
+  end if;
+  create policy plant_history_admin_select on public.plant_history for select to authenticated
+    using (
+      exists (
+        select 1 from public.profiles p
+        where p.id = (select auth.uid())
+          and (p.is_admin = true or coalesce(public.has_any_role((select auth.uid()), array['admin','editor']), false))
+      )
+    );
+end $$;
+
+do $$ begin
+  if exists (select 1 from pg_policies where schemaname='public' and tablename='plant_history' and policyname='plant_history_admin_insert') then
+    drop policy plant_history_admin_insert on public.plant_history;
+  end if;
+  -- History is immutable: inserts only. Admins cannot update or delete rows.
+  create policy plant_history_admin_insert on public.plant_history for insert to authenticated
+    with check (
+      exists (
+        select 1 from public.profiles p
+        where p.id = (select auth.uid())
+          and (p.is_admin = true or coalesce(public.has_any_role((select auth.uid()), array['admin','editor']), false))
+      )
+    );
+end $$;
+
+-- ========== Plant admin notes (chat-style) ==========
+-- Thread of editorial notes per plant. Any admin can add, edit or delete any note.
+-- All note mutations should also write a plant_history row.
+create table if not exists public.plant_admin_notes (
+  id uuid primary key default gen_random_uuid(),
+  plant_id uuid not null references public.plants(id) on delete cascade,
+  author_id uuid references public.profiles(id) on delete set null,
+  author_name text,
+  body text not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+comment on table public.plant_admin_notes is 'Editorial chat-style notes per plant. Any admin can CRUD any note.';
+create index if not exists plant_admin_notes_plant_time_idx on public.plant_admin_notes (plant_id, created_at desc);
+create index if not exists plant_admin_notes_author_idx on public.plant_admin_notes (author_id, created_at desc);
+
+alter table public.plant_admin_notes enable row level security;
+
+do $$ begin
+  if exists (select 1 from pg_policies where schemaname='public' and tablename='plant_admin_notes' and policyname='plant_admin_notes_admin_select') then
+    drop policy plant_admin_notes_admin_select on public.plant_admin_notes;
+  end if;
+  create policy plant_admin_notes_admin_select on public.plant_admin_notes for select to authenticated
+    using (
+      exists (
+        select 1 from public.profiles p
+        where p.id = (select auth.uid())
+          and (p.is_admin = true or coalesce(public.has_any_role((select auth.uid()), array['admin','editor']), false))
+      )
+    );
+end $$;
+
+do $$ begin
+  if exists (select 1 from pg_policies where schemaname='public' and tablename='plant_admin_notes' and policyname='plant_admin_notes_admin_insert') then
+    drop policy plant_admin_notes_admin_insert on public.plant_admin_notes;
+  end if;
+  create policy plant_admin_notes_admin_insert on public.plant_admin_notes for insert to authenticated
+    with check (
+      exists (
+        select 1 from public.profiles p
+        where p.id = (select auth.uid())
+          and (p.is_admin = true or coalesce(public.has_any_role((select auth.uid()), array['admin','editor']), false))
+      )
+    );
+end $$;
+
+do $$ begin
+  if exists (select 1 from pg_policies where schemaname='public' and tablename='plant_admin_notes' and policyname='plant_admin_notes_admin_update') then
+    drop policy plant_admin_notes_admin_update on public.plant_admin_notes;
+  end if;
+  create policy plant_admin_notes_admin_update on public.plant_admin_notes for update to authenticated
+    using (
+      exists (
+        select 1 from public.profiles p
+        where p.id = (select auth.uid())
+          and (p.is_admin = true or coalesce(public.has_any_role((select auth.uid()), array['admin','editor']), false))
+      )
+    )
+    with check (
+      exists (
+        select 1 from public.profiles p
+        where p.id = (select auth.uid())
+          and (p.is_admin = true or coalesce(public.has_any_role((select auth.uid()), array['admin','editor']), false))
+      )
+    );
+end $$;
+
+do $$ begin
+  if exists (select 1 from pg_policies where schemaname='public' and tablename='plant_admin_notes' and policyname='plant_admin_notes_admin_delete') then
+    drop policy plant_admin_notes_admin_delete on public.plant_admin_notes;
+  end if;
+  create policy plant_admin_notes_admin_delete on public.plant_admin_notes for delete to authenticated
+    using (
+      exists (
+        select 1 from public.profiles p
+        where p.id = (select auth.uid())
+          and (p.is_admin = true or coalesce(public.has_any_role((select auth.uid()), array['admin','editor']), false))
+      )
+    );
+end $$;

--- a/plant-swipe/supabase/sync_parts/03_plants_and_colors.sql
+++ b/plant-swipe/supabase/sync_parts/03_plants_and_colors.sql
@@ -2178,7 +2178,8 @@ end $$;
 
 -- ========== Plant change history ==========
 -- Per-plant audit log written by admins on edits, translations, AI fills, and note actions.
--- Intentionally compact: one row per discrete action with short summary + optional old/new snippets.
+-- Intentionally compact: one row per discrete action with a short summary.
+-- We DO NOT store the old/new field values — only who changed what, when.
 -- The author's display_name is NOT stored — always resolved from profiles at read time.
 create table if not exists public.plant_history (
   id uuid primary key default gen_random_uuid(),
@@ -2189,13 +2190,13 @@ create table if not exists public.plant_history (
   )),
   field text,
   summary text,
-  old_value text,
-  new_value text,
   created_at timestamptz not null default now()
 );
 comment on table public.plant_history is 'Per-plant admin change log: field edits, translations, AI fills, note actions.';
--- Drop legacy snapshot column if present from an earlier schema revision.
+-- Drop columns left over from earlier schema revisions.
 alter table public.plant_history drop column if exists author_name;
+alter table public.plant_history drop column if exists old_value;
+alter table public.plant_history drop column if exists new_value;
 create index if not exists plant_history_plant_time_idx on public.plant_history (plant_id, created_at desc);
 create index if not exists plant_history_author_idx on public.plant_history (author_id, created_at desc);
 

--- a/plant-swipe/supabase/sync_parts/03_plants_and_colors.sql
+++ b/plant-swipe/supabase/sync_parts/03_plants_and_colors.sql
@@ -284,7 +284,7 @@ create table if not exists public.plants (
 
   -- Section 9: Meta
   status text check (status in ('in_progress','rework','review','approved')),
-  admin_commentary text,
+  -- admin_commentary removed — replaced by public.plant_admin_notes (chat-style thread).
   created_by text,
   created_time timestamptz not null default now(),
   updated_by text,
@@ -574,7 +574,7 @@ declare
     array['sponsored_shop_ids', 'text[] not null default ''{}''::text[]'],
     -- Section 9: Meta
     array['status', 'text'],
-    array['admin_commentary', 'text'],
+    -- admin_commentary removed — replaced by public.plant_admin_notes thread.
     array['created_by', 'text'],
     array['created_time', 'timestamptz not null default now()'],
     array['updated_by', 'text'],
@@ -1413,6 +1413,8 @@ alter table if exists public.plants drop column if exists water_freq_amount;
 alter table if exists public.plants drop column if exists water_freq_unit;
 alter table if exists public.plants drop column if exists water_freq_value;
 alter table if exists public.plants drop column if exists updated_at;
+-- admin_commentary replaced by the plant_admin_notes thread (data already migrated).
+alter table if exists public.plants drop column if exists admin_commentary;
 
 -- ========== Phase 4: Column whitelist — drops any column not in the new schema ==========
 do $$ declare
@@ -1501,7 +1503,7 @@ do $$ declare
     'sponsored_shop_ids',
     -- Section 9: Meta
     'status',
-    'admin_commentary',
+    -- admin_commentary removed — replaced by public.plant_admin_notes thread.
     'created_by',
     'created_time',
     'updated_by',
@@ -1627,57 +1629,47 @@ do $$ begin
 end $$;
 
 -- ========== Plant contributors ==========
--- Contributors are identified by profile id (contributor_id). A legacy
--- contributor_name column is kept only as a snapshot fallback for rows that
--- were inserted before we stored ids; new rows always set contributor_id.
+-- Contributors are identified solely by profile id. The legacy contributor_name
+-- column and its associated constraints/indexes have been removed now that the
+-- backfill migration has run.
 create table if not exists public.plant_contributors (
   id uuid primary key default gen_random_uuid(),
   plant_id text not null references public.plants(id) on delete cascade,
-  contributor_name text,
+  contributor_id uuid not null references public.profiles(id) on delete cascade,
   created_at timestamptz not null default now()
 );
--- Relax contributor_name NOT NULL for rows that only carry an id.
-alter table public.plant_contributors alter column contributor_name drop not null;
--- Add contributor_id column + FK (set null when the profile is removed so the
--- historical "someone contributed here" signal is preserved as a blank avatar).
-alter table public.plant_contributors add column if not exists contributor_id uuid;
+-- Idempotent cleanup for installs that still have the legacy layout.
 do $$ begin
-  if not exists (
-    select 1 from information_schema.table_constraints
+  if exists (
+    select 1 from information_schema.columns
     where table_schema = 'public'
       and table_name = 'plant_contributors'
-      and constraint_name = 'plant_contributors_contributor_fk'
+      and column_name = 'contributor_name'
   ) then
-    alter table public.plant_contributors
-      add constraint plant_contributors_contributor_fk
-      foreign key (contributor_id) references public.profiles(id) on delete set null;
+    drop index if exists plant_contributors_unique_legacy_name_idx;
+    drop index if exists plant_contributors_unique_name_idx;
+    alter table public.plant_contributors drop constraint if exists plant_contributors_id_or_name_chk;
+    -- Orphan rows that the id-backfill couldn't resolve (name didn't match any
+    -- current profile). Dropping them matches the "no snapshot" data policy.
+    delete from public.plant_contributors where contributor_id is null;
+    alter table public.plant_contributors drop column contributor_name;
   end if;
 end $$;
--- Ensure at least one identifier is present.
+-- contributor_id is now the sole identifier; enforce NOT NULL + CASCADE on
+-- profile delete (previously SET NULL was used alongside the snapshot column).
+alter table public.plant_contributors alter column contributor_id set not null;
 do $$ begin
-  if not exists (
-    select 1 from information_schema.table_constraints
-    where table_schema = 'public'
-      and table_name = 'plant_contributors'
-      and constraint_name = 'plant_contributors_id_or_name_chk'
-  ) then
-    alter table public.plant_contributors
-      add constraint plant_contributors_id_or_name_chk
-      check (contributor_id is not null or (contributor_name is not null and length(btrim(contributor_name)) > 0));
-  end if;
+  alter table public.plant_contributors drop constraint if exists plant_contributors_contributor_fk;
+  alter table public.plant_contributors
+    add constraint plant_contributors_contributor_fk
+    foreign key (contributor_id) references public.profiles(id) on delete cascade;
 end $$;
+-- Replace the old partial unique (where contributor_id is not null) with a plain one.
+drop index if exists plant_contributors_unique_id_idx;
+create unique index if not exists plant_contributors_unique_contributor_idx
+  on public.plant_contributors(plant_id, contributor_id);
 create index if not exists plant_contributors_plant_id_idx on public.plant_contributors(plant_id);
 create index if not exists plant_contributors_contributor_id_idx on public.plant_contributors(contributor_id);
--- Replace the legacy name-based uniqueness with two partial uniques:
---  • one ID per plant
---  • one legacy name per plant (for rows without an id)
-drop index if exists plant_contributors_unique_name_idx;
-create unique index if not exists plant_contributors_unique_id_idx
-  on public.plant_contributors(plant_id, contributor_id)
-  where contributor_id is not null;
-create unique index if not exists plant_contributors_unique_legacy_name_idx
-  on public.plant_contributors(plant_id, lower(contributor_name))
-  where contributor_id is null;
 alter table public.plant_contributors enable row level security;
 do $$ begin
   if exists (select 1 from pg_policies where schemaname='public' and tablename='plant_contributors' and policyname='plant_contributors_select_all') then


### PR DESCRIPTION
## Summary
Introduces a comprehensive audit and collaboration system for plant records, enabling admins to track all changes and maintain a chat-style discussion thread per plant.

## Key Changes

### Database Schema
- **`plant_history` table**: Insert-only audit log recording all admin actions (field edits, translations, AI fills, note mutations, status changes). Indexed by plant and author for efficient querying. RLS policies restrict access to admin/editor roles.
- **`plant_admin_notes` table**: Replaces the legacy `plants.admin_commentary` textarea with a chat-style thread. Admins can create, edit, and delete notes; all mutations are automatically mirrored to `plant_history` for full traceability.

### Frontend Components
- **`PlantHistoryPanel`**: Collapsible history viewer showing grouped entries by author and hour, with day headings and action-specific icons/colors. Displays up to 300 entries with smart time formatting (Today/Yesterday/date).
- **`AdminNotesThread`**: Chat-style note interface with create, edit, and delete capabilities. Shows author initials, timestamps, and edit indicators. Supports Ctrl/⌘+Enter to post.

### Utilities
- **`plantHistoryDiff.ts`**: Compares old and new plant objects to generate history entries for changed fields. Includes field label mapping, value normalization (handles empty strings/arrays/objects), and snippet generation (max 180 chars). Ignores system fields (id, timestamps, nested aggregates).
- **`plantHistory.ts`**: Database layer for logging single and batch history entries, fetching history with pagination.
- **`plantAdminNotes.ts`**: CRUD operations for admin notes with automatic history logging on create/update/delete.

### Integration
- **`CreatePlantPage`**: Wired history diffing on plant save, tracking baseline state and bumping refresh version to sync history panel and notes thread. Passes admin notes slot to form.
- **`PlantProfileForm`**: Added `adminNotesSlot` prop to render the notes thread in place of the legacy textarea.

## Implementation Details
- History entries are immutable (insert-only) to maintain audit integrity.
- Field changes are normalized (trimmed strings, empty arrays/objects → null) before comparison to reduce noise.
- Value snippets are capped at 180 characters with ellipsis for readability.
- Notes thread auto-refreshes when history panel is refreshed (via `refreshVersion` prop).
- All note mutations (add/edit/delete) automatically log to history with appropriate action types and summaries.
- RLS policies ensure only authenticated admins/editors can view and modify history and notes.

https://claude.ai/code/session_019xPuzNTPuP6sGDY9xctQaR