### PR TITLE
Remove unused gp variable from OverviewSection

### DIFF
--- a/plant-swipe/src/pages/GardenDashboardPage.tsx
+++ b/plant-swipe/src/pages/GardenDashboardPage.tsx
@@ -4958,7 +4958,6 @@ function OverviewSection({
         variety: gp.plant?.variety || null,
         imageUrl: primaryImageUrl,
         plantId: gp.plant?.id,
-        gp,
         plantsOnHand: Number(gp.plantsOnHand || 0),
         healthStatus: gp.healthStatus || null,
         taskCount: taskInfo.total,


### PR DESCRIPTION
## Summary
Removed an unused variable assignment from the OverviewSection component to clean up the codebase and improve code clarity.

## Key Changes
- Removed the `gp` property from the object being constructed in OverviewSection, as it was not being used by any downstream consumers

## Implementation Details
The `gp` (garden plant) object was being passed into the mapped object but was redundant since all necessary properties from `gp` were already being extracted individually (plant, plantsOnHand, healthStatus, etc.). This cleanup reduces unnecessary data passing and makes the code more maintainable.

https://claude.ai/code/session_01V4CJNcxwPEYrMZMEy3HbhU