### PR TITLE
🎨 Palette: Add a11y to clear search button in Garden Journal

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -51,3 +51,6 @@
 ## 2026-04-17 - Accessible Error Dismissal Buttons
 **Learning:** Icon-only error dismissal buttons (`<X>`) across admin panels lacked `aria-label`/`title` for screen readers and tooltips, and didn't have keyboard focus indicators (`focus-visible:ring-2`). Even text-based "dismiss" buttons missed the focus indicators.
 **Action:** Always add explicit `aria-label` and `title` to icon-only buttons. Add `focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:outline-none rounded-sm` to ensure keyboard users can navigate to and activate these error alert dismissals.
+## 2024-04-23 - Icon-only search reset buttons
+**Learning:** Icon-only 'clear search' or input reset buttons (e.g., `<X>` icons inside search bars) are a recurring pattern that frequently lack context for screen readers and lack visual focus indicators for keyboard users.
+**Action:** Always add `aria-label` and `title` attributes (translated via `t()`), along with `focus-visible` utility classes (e.g., `focus-visible:ring-2`) to ensure proper accessibility for screen readers and keyboard navigation.

--- a/plant-swipe/src/components/garden/GardenJournalSection.tsx
+++ b/plant-swipe/src/components/garden/GardenJournalSection.tsx
@@ -983,7 +983,13 @@ export const GardenJournalSection: React.FC<GardenJournalSectionProps> = ({
               className="w-full h-9 pl-9 pr-8 rounded-xl border border-stone-200 dark:border-stone-700 bg-white dark:bg-[#1f1f1f] text-sm placeholder:text-stone-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/30 focus:border-emerald-400"
             />
             {searchQuery && (
-              <button type="button" onClick={() => setSearchQuery("")} className="absolute right-2.5 top-1/2 -translate-y-1/2 text-stone-400 hover:text-stone-600">
+              <button
+                type="button"
+                onClick={() => setSearchQuery("")}
+                className="absolute right-2.5 top-1/2 -translate-y-1/2 text-stone-400 hover:text-stone-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 rounded-sm"
+                aria-label={t("common.clear", { defaultValue: "Clear" })}
+                title={t("common.clear", { defaultValue: "Clear" })}
+              >
                 <X className="w-3.5 h-3.5" />
               </button>
             )}


### PR DESCRIPTION
💡 **What:** Added `aria-label`, `title`, and `focus-visible` utility classes to the clear search (`<X>`) icon-only button in `GardenJournalSection.tsx`.

🎯 **Why:** To improve accessibility for screen readers (providing context to the generic icon) and keyboard users (adding a visible focus ring), ensuring that clearing the search input is an accessible action.

♿ **Accessibility:**
- Added `aria-label={t("common.clear", { defaultValue: "Clear" })}` for screen reader context.
- Added `title={t("common.clear", { defaultValue: "Clear" })}` for sighted mouse users.
- Added `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 rounded-sm` for proper keyboard focus indication.

---
*PR created automatically by Jules for task [17125873489201540499](https://jules.google.com/task/17125873489201540499) started by @FrenchFive*