### PR TITLE
⚡ Bolt: Optimize Set initialization in ProfileActions

### DIFF
--- a/plant-swipe/src/components/profile/ProfileActions.tsx
+++ b/plant-swipe/src/components/profile/ProfileActions.tsx
@@ -224,7 +224,15 @@ export function ProfileActions({ userId }: Props) {
 
   React.useEffect(() => {
     if (!data) return
-    const nowDone = new Set(PROFILE_ACTIONS.filter((a) => isActionDone(a, data, dbStatuses)).map((a) => a.id))
+    // ⚡ Bolt: Initialize Set using single-pass for loop to avoid intermediate array allocations
+    // from .filter() and .map() that create garbage collection pressure
+    const nowDone = new Set<string>()
+    for (let i = 0; i < PROFILE_ACTIONS.length; i++) {
+      const a = PROFILE_ACTIONS[i]
+      if (a && isActionDone(a, data, dbStatuses)) {
+        nowDone.add(a.id)
+      }
+    }
     for (const id of nowDone) {
       if (!prevCompletedRef.current.has(id)) {
         setJustCompleted(id)


### PR DESCRIPTION
💡 What: Replaced a chained `.filter().map()` array operation with a single-pass `for` loop when initializing the `nowDone` Set in `ProfileActions.tsx`.
🎯 Why: The previous implementation created two intermediate array allocations (one for the filtered array, one for the mapped IDs) every time the `useEffect` dependencies changed. This hot path optimization reduces intermediate memory allocations.
📊 Impact: Reduces garbage collection pressure in `ProfileActions` by eliminating two intermediate arrays per execution of the `useEffect` hook.
🔬 Measurement: Verify build succeeds and no functionality changes, as the single-pass loop is functionally equivalent.

---
*PR created automatically by Jules for task [14194937477953447058](https://jules.google.com/task/14194937477953447058) started by @FrenchFive*