### PR TITLE
🎨 Palette: Add ARIA labels and focus rings to icon-only buttons

### DIFF
--- a/plant-swipe/src/components/admin/AdminBadgesPanel.tsx
+++ b/plant-swipe/src/components/admin/AdminBadgesPanel.tsx
@@ -545,7 +545,9 @@ export const AdminBadgesPanel: React.FC = () => {
           </h3>
           <button
             onClick={handleCancel}
-            className="p-1 rounded-lg hover:bg-stone-100 dark:hover:bg-stone-800 transition-colors"
+            className="p-1 rounded-lg hover:bg-stone-100 dark:hover:bg-stone-800 transition-colors focus-visible:ring-2 focus-visible:ring-emerald-500/50 focus-visible:outline-none"
+            aria-label="Cancel edit"
+            title="Cancel edit"
           >
             <X className="h-4 w-4 text-stone-500" />
           </button>

--- a/plant-swipe/src/components/admin/AdminBugsPanel.tsx
+++ b/plant-swipe/src/components/admin/AdminBugsPanel.tsx
@@ -785,7 +785,9 @@ export const AdminBugsPanel: React.FC = () => {
             {actionSearch && (
               <button
                 onClick={() => setActionSearch('')}
-                className="absolute right-3 top-1/2 -translate-y-1/2 text-stone-400 hover:text-stone-600"
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-stone-400 hover:text-stone-600 focus-visible:ring-2 focus-visible:ring-emerald-500/50 focus-visible:outline-none rounded-sm"
+                aria-label="Clear search"
+                title="Clear search"
               >
                 <X className="h-4 w-4" />
               </button>

--- a/plant-swipe/src/components/admin/AdminEventsPanel.tsx
+++ b/plant-swipe/src/components/admin/AdminEventsPanel.tsx
@@ -510,7 +510,12 @@ export const AdminEventsPanel: React.FC = () => {
           <h3 className="text-sm font-semibold text-stone-900 dark:text-white">
             Edit Event
           </h3>
-          <button onClick={handleCancel} className="p-1 rounded-lg hover:bg-stone-100 dark:hover:bg-stone-800 transition-colors">
+          <button
+            onClick={handleCancel}
+            className="p-1 rounded-lg hover:bg-stone-100 dark:hover:bg-stone-800 transition-colors focus-visible:ring-2 focus-visible:ring-emerald-500/50 focus-visible:outline-none"
+            aria-label="Cancel edit"
+            title="Cancel edit"
+          >
             <X className="h-4 w-4 text-stone-500" />
           </button>
         </div>

--- a/plant-swipe/src/components/garden/GardenJournalSection.tsx
+++ b/plant-swipe/src/components/garden/GardenJournalSection.tsx
@@ -983,7 +983,13 @@ export const GardenJournalSection: React.FC<GardenJournalSectionProps> = ({
               className="w-full h-9 pl-9 pr-8 rounded-xl border border-stone-200 dark:border-stone-700 bg-white dark:bg-[#1f1f1f] text-sm placeholder:text-stone-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/30 focus:border-emerald-400"
             />
             {searchQuery && (
-              <button type="button" onClick={() => setSearchQuery("")} className="absolute right-2.5 top-1/2 -translate-y-1/2 text-stone-400 hover:text-stone-600">
+              <button
+                type="button"
+                onClick={() => setSearchQuery("")}
+                className="absolute right-2.5 top-1/2 -translate-y-1/2 text-stone-400 hover:text-stone-600 focus-visible:ring-2 focus-visible:ring-emerald-500/50 focus-visible:outline-none rounded-sm"
+                aria-label={t("common.clear", { defaultValue: "Clear" })}
+                title={t("common.clear", { defaultValue: "Clear" })}
+              >
                 <X className="w-3.5 h-3.5" />
               </button>
             )}


### PR DESCRIPTION
💡 **What**: Added accessibility attributes (`aria-label` and `title`) and keyboard focus visual indicators (`focus-visible` classes) to several icon-only `<button>` elements that contained only `<X />` icons.
🎯 **Why**: Previously, these buttons lacked explicit context for screen readers and did not show distinct visual feedback when focused via keyboard, hampering usability.
♿ **Accessibility**: Enhanced screen reader compatibility and keyboard navigation across admin panels and the garden journal view.

---
*PR created automatically by Jules for task [16260132253091955166](https://jules.google.com/task/16260132253091955166) started by @FrenchFive*