### PR TITLE
🎨 Palette: Improve keyboard accessibility for message actions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -51,3 +51,7 @@
 ## 2026-04-17 - Accessible Error Dismissal Buttons
 **Learning:** Icon-only error dismissal buttons (`<X>`) across admin panels lacked `aria-label`/`title` for screen readers and tooltips, and didn't have keyboard focus indicators (`focus-visible:ring-2`). Even text-based "dismiss" buttons missed the focus indicators.
 **Action:** Always add explicit `aria-label` and `title` to icon-only buttons. Add `focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:outline-none rounded-sm` to ensure keyboard users can navigate to and activate these error alert dismissals.
+
+## 2024-04-26 - Accessible Action Buttons within Preview Cards
+**Learning:** Action buttons overlaid on media/link preview cards (like Download or External Link icons) often lack explicit screen reader labels and keyboard focus indicators (`focus-visible`). This makes these contextual actions completely inaccessible to users relying on assistive technology or keyboard navigation.
+**Action:** Always add `aria-label` (translated via `t()`) and `focus-visible` utility classes (e.g. `focus-visible:ring-2 focus-visible:outline-none`) to any overlaid icon-only action button inside preview components. Also, ensure the preview container itself (if interactive/clickable) has a clear focus indicator.

--- a/plant-swipe/src/components/messaging/ConversationSearch.tsx
+++ b/plant-swipe/src/components/messaging/ConversationSearch.tsx
@@ -206,7 +206,7 @@ export const ConversationSearch: React.FC<ConversationSearchProps> = ({
                   onClick={handleClear}
                   aria-label={t('common.clear', { defaultValue: 'Clear' })}
                   title={t('common.clear', { defaultValue: 'Clear' })}
-                  className="p-1.5 -mr-1.5 rounded-full hover:bg-stone-200 dark:hover:bg-stone-600 active:bg-stone-300 dark:active:bg-stone-500 transition-colors"
+                  className="p-1.5 -mr-1.5 rounded-full hover:bg-stone-200 dark:hover:bg-stone-600 active:bg-stone-300 dark:active:bg-stone-500 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500"
                 >
                   <X className="h-5 w-5 text-stone-500 dark:text-stone-400" />
                 </button>

--- a/plant-swipe/src/components/messaging/InternalLinkPreview.tsx
+++ b/plant-swipe/src/components/messaging/InternalLinkPreview.tsx
@@ -227,14 +227,16 @@ const LinkPreviewCard: React.FC<{
             )}>
               <button
                 onClick={handleDownload}
-                className="p-2 rounded-full bg-white/90 hover:bg-white text-stone-700 shadow-lg transition-transform hover:scale-110"
+                className="p-2 rounded-full bg-white/90 hover:bg-white text-stone-700 shadow-lg transition-transform hover:scale-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                aria-label={t('messages.download', { defaultValue: 'Download' })}
                 title={t('messages.download', { defaultValue: 'Download' })}
               >
                 <Download className="h-5 w-5" />
               </button>
               <button
                 onClick={handleClick}
-                className="p-2 rounded-full bg-white/90 hover:bg-white text-stone-700 shadow-lg transition-transform hover:scale-110"
+                className="p-2 rounded-full bg-white/90 hover:bg-white text-stone-700 shadow-lg transition-transform hover:scale-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                aria-label={t('messages.openInNewTab', { defaultValue: 'Open in new tab' })}
                 title={t('messages.openInNewTab', { defaultValue: 'Open in new tab' })}
               >
                 <ExternalLink className="h-5 w-5" />
@@ -284,7 +286,7 @@ const LinkPreviewCard: React.FC<{
       onClick={handleClick}
       className={cn(
         'mt-2 flex items-stretch overflow-hidden rounded-xl w-full text-left transition-all active:scale-[0.98]',
-        'border',
+        'border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500',
         isOwn 
           ? 'border-blue-400/30 bg-blue-400/20 hover:bg-blue-400/30'
           : 'border-stone-200/50 dark:border-[#3a3a3d]/50 bg-white/50 dark:bg-[#1f1f1f]/50 hover:bg-white/80 dark:hover:bg-[#1f1f1f]/80'


### PR DESCRIPTION
🎨 Palette: Improve keyboard accessibility for message actions

### 💡 What
Added missing accessibility attributes and keyboard focus styles to icon-only action buttons within message components (`InternalLinkPreview.tsx` and `ConversationSearch.tsx`).

### 🎯 Why
- Action buttons overlaid on link previews (Download, Open in new tab) were previously inaccessible to screen readers because they lacked `aria-label` attributes.
- These buttons, the link preview container itself, and the search clear button lacked visible focus states, making keyboard navigation difficult or impossible for users relying on it.

### ♿ Accessibility
- Added `aria-label` to the Download and External Link icon buttons in `InternalLinkPreview.tsx`.
- Added `focus-visible:ring-2` and `focus-visible:outline-none` to the preview action buttons and the main preview container in `InternalLinkPreview.tsx`.
- Added `focus-visible:ring-2` to the clear (`X`) button in `ConversationSearch.tsx`.

---
*PR created automatically by Jules for task [6524187751620676007](https://jules.google.com/task/6524187751620676007) started by @FrenchFive*