### PR TITLE
Add AI and scan usage monitoring with admin escalation protection

### DIFF
--- a/plant-swipe/server.js
+++ b/plant-swipe/server.js
@@ -3545,6 +3545,7 @@ async function generateFieldData(options) {
     },
     { timeout }
   )
+  logAiUsage({ feature: 'admin_plant_fill_field', model: openaiModel, response, metadata: { fieldKey } })
 
   const outputText = typeof response?.output_text === 'string' ? response.output_text.trim() : ''
   if (!outputText) {
@@ -3607,6 +3608,7 @@ async function verifyPlantNameCandidate(plantName) {
     },
     { timeout: Number(process.env.OPENAI_TIMEOUT_MS || 300000) },
   )
+  logAiUsage({ feature: 'admin_plant_verify', model: openaiModelNano, response, metadata: { plantName } })
 
   const outputText = typeof response?.output_text === 'string' ? response.output_text.trim() : ''
   if (!outputText) {
@@ -3764,6 +3766,50 @@ postgresOptions.idle_timeout = parseInt(process.env.PG_IDLE_TIMEOUT || '20', 10)
 postgresOptions.connect_timeout = parseInt(process.env.PG_CONNECT_TIMEOUT || '10', 10) // seconds to wait for new conn
 
 const sql = connectionString ? postgres(connectionString, postgresOptions) : null
+
+// Usage monitoring helpers. These are best-effort: any failure is logged and
+// swallowed so that instrumentation never breaks a user request. No limits
+// are enforced yet — these writes feed admin/analytics queries.
+function isUuid(value) {
+  return typeof value === 'string' && /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value)
+}
+
+async function logAiUsage({ userId = null, feature, model = null, provider = 'openai', response = null, metadata = null } = {}) {
+  if (!sql || !feature) return
+  try {
+    const usage = response?.usage || {}
+    // OpenAI Responses API returns input_tokens/output_tokens; Chat Completions
+    // returns prompt_tokens/completion_tokens. Accept either shape.
+    const promptTokens = Number(usage.prompt_tokens ?? usage.input_tokens ?? 0) || 0
+    const completionTokens = Number(usage.completion_tokens ?? usage.output_tokens ?? 0) || 0
+    const totalTokens = Number(usage.total_tokens ?? (promptTokens + completionTokens)) || 0
+    const requestId = typeof response?.id === 'string' ? response.id : null
+    const safeUserId = isUuid(userId) ? userId : null
+    await sql`
+      insert into public.ai_usage_events
+        (user_id, feature, provider, model, prompt_tokens, completion_tokens, total_tokens, request_id, metadata)
+      values
+        (${safeUserId}, ${feature}, ${provider}, ${model}, ${promptTokens}, ${completionTokens}, ${totalTokens}, ${requestId}, ${sql.json(metadata || {})})
+    `
+  } catch (err) {
+    console.error('[ai-usage] failed to record event', feature, err?.message || err)
+  }
+}
+
+async function logScanUsage({ userId, scanId = null, provider = 'kindwise', tokens = 1, classificationLevel = null, success = true, metadata = null } = {}) {
+  if (!sql) return
+  if (!isUuid(userId)) return
+  try {
+    await sql`
+      insert into public.scan_usage_events
+        (user_id, scan_id, provider, tokens, classification_level, success, metadata)
+      values
+        (${userId}, ${isUuid(scanId) ? scanId : null}, ${provider}, ${tokens}, ${classificationLevel}, ${success}, ${sql.json(metadata || {})})
+    `
+  } catch (err) {
+    console.error('[scan-usage] failed to record event', err?.message || err)
+  }
+}
 
 let adminMediaUploadsEnsured = false
 async function ensureAdminMediaUploadsTable() {
@@ -4925,6 +4971,7 @@ Examples:
       instructions,
       input: prompt,
     })
+    logAiUsage({ userId: caller, feature: 'admin_plant_fill_name', model: openaiModelNano, response, metadata: { plantName } })
 
     const outputText = (response.output_text || '').trim()
 
@@ -8601,6 +8648,7 @@ app.post('/api/blog/summarize', async (req, res) => {
         },
         { timeout: Number(process.env.OPENAI_TIMEOUT_MS || 600000) },
       )
+      logAiUsage({ userId: adminPrincipal, feature: 'blog_metadata', model: openaiModel, response, metadata: { title } })
       const rawOutput = typeof response?.output_text === 'string' ? response.output_text.trim() : '{}'
       // Parse the JSON response, handling potential markdown code blocks
       let parsed = {}
@@ -8647,6 +8695,7 @@ app.post('/api/blog/summarize', async (req, res) => {
       },
       { timeout: Number(process.env.OPENAI_TIMEOUT_MS || 300000) },
     )
+    logAiUsage({ userId: adminPrincipal, feature: 'blog_summary', model: openaiModel, response, metadata: { title } })
     const summary = typeof response?.output_text === 'string' ? response.output_text.trim() : ''
     res.json({ summary })
   } catch (err) {
@@ -21363,6 +21412,16 @@ app.post('/api/scan/upload-and-identify', async (req, res) => {
 
         identificationResult = await apiResponse.json()
         console.log('[scan] Kindwise API success, status:', identificationResult.status)
+        logScanUsage({
+          userId: user.id,
+          classificationLevel: sanitizedClassificationLevel,
+          success: true,
+          metadata: {
+            status: identificationResult?.status || null,
+            hasLocation: latitude !== undefined && longitude !== undefined,
+            accessToken: identificationResult?.access_token || null,
+          },
+        })
       } catch (apiErr) {
         console.error('[scan] Error calling Kindwise API:', apiErr?.message || apiErr)
         res.status(500).json({ error: 'Failed to identify plant', details: apiErr?.message })
@@ -23948,6 +24007,7 @@ Include specific observations from the photos in your advice.`
           },
           { timeout: 300000 }
         )
+        logAiUsage({ userId: user?.id, feature: 'garden_advice', model: openaiModel, response, metadata: { gardenId } })
 
         aiResponse = typeof response?.output_text === 'string' ? response.output_text.trim() : ''
         tokensUsed = response.usage?.total_tokens || 0
@@ -25390,15 +25450,17 @@ Be specific and reference what you actually see in the images. If you notice any
     }
 
     // Use Responses API for both text and vision
+    const journalModel = photos.length > 0 ? openaiModel : openaiModelNano
     const response = await openaiClient.responses.create(
       {
-        model: photos.length > 0 ? openaiModel : openaiModelNano, // Use larger model for vision
+        model: journalModel, // Use larger model for vision
         reasoning: { effort: photos.length > 0 ? 'medium' : 'low' },
         instructions: journalInstructions,
         input: [{ role: 'user', content: inputContent }],
       },
       { timeout: photos.length > 0 ? 120000 : 60000 }
     )
+    logAiUsage({ userId: user?.id, feature: 'garden_journal_feedback', model: journalModel, response, metadata: { gardenId, entryId, hasPhotos: photos.length > 0 } })
 
     feedback = typeof response?.output_text === 'string' ? response.output_text.trim() : ''
     tokensUsed = response.usage?.total_tokens || 0
@@ -29005,7 +29067,8 @@ app.post('/api/ai/garden-chat', async (req, res) => {
             },
             { timeout: 60000 }
           )
-          
+          logAiUsage({ userId: user?.id, feature: 'garden_chat_tools', model: openaiModelNano, response: toolCheckResponse, metadata: { gardenId: gardenIdForTools, mode: 'stream' } })
+
           // Check if response contains tool calls
           if (toolCheckResponse.output && Array.isArray(toolCheckResponse.output)) {
             const toolUseOutputs = toolCheckResponse.output.filter(o => o.type === 'tool_use')
@@ -29045,7 +29108,9 @@ app.post('/api/ai/garden-chat', async (req, res) => {
         
         let fullContent = ''
         let totalTokens = 0
-        
+        let streamUsage = null
+        let streamResponseId = null
+
         for await (const event of streamResponse) {
           // Handle different event types from the Responses API stream
           if (event.type === 'response.output_text.delta') {
@@ -29057,9 +29122,18 @@ app.post('/api/ai/garden-chat', async (req, res) => {
           } else if (event.type === 'response.completed' || event.type === 'response.done') {
             if (event.response?.usage) {
               totalTokens = event.response.usage.total_tokens || 0
+              streamUsage = event.response.usage
+              streamResponseId = event.response.id || null
             }
           }
         }
+        logAiUsage({
+          userId: user?.id,
+          feature: 'garden_chat_stream',
+          model: openaiModelNano,
+          response: { usage: streamUsage, id: streamResponseId },
+          metadata: { gardenId: gardenIdForTools || null, mode: 'stream' },
+        })
         
         // Send done event with complete message
         const messageId = crypto.randomUUID()
@@ -29100,14 +29174,15 @@ app.post('/api/ai/garden-chat', async (req, res) => {
           },
           { timeout: 60000 }
         )
-        
+        logAiUsage({ userId: user?.id, feature: 'garden_chat_tools', model: openaiModelNano, response: toolCheckResponse, metadata: { gardenId: gardenIdForTools, mode: 'sync' } })
+
         // Check if response contains tool calls
         if (toolCheckResponse.output && Array.isArray(toolCheckResponse.output)) {
           const toolUseOutputs = toolCheckResponse.output.filter(o => o.type === 'tool_use')
           if (toolUseOutputs.length > 0) {
             const { toolCallsExecuted: executed, toolResultItems } = await executeToolsIfNeeded(toolUseOutputs)
             toolCallsExecuted = executed
-            
+
             // Pass tool calls and results as structured Responses API input items.
             // See streaming path comment for full rationale on why we avoid plain
             // text concatenation of tool results (prompt injection prevention).
@@ -29119,7 +29194,7 @@ app.post('/api/ai/garden-chat', async (req, res) => {
           }
         }
       }
-      
+
       // Final response using Responses API
       const response = await openaiClient.responses.create(
         {
@@ -29130,7 +29205,8 @@ app.post('/api/ai/garden-chat', async (req, res) => {
         },
         { timeout: 120000 }
       )
-      
+      logAiUsage({ userId: user?.id, feature: 'garden_chat', model: openaiModelNano, response, metadata: { gardenId: gardenIdForTools || null, mode: 'sync' } })
+
       const outputText = typeof response?.output_text === 'string' ? response.output_text.trim() : ''
       const messageId = crypto.randomUUID()
       

--- a/plant-swipe/supabase/migrations/20260422000000_prevent_self_admin_escalation.sql
+++ b/plant-swipe/supabase/migrations/20260422000000_prevent_self_admin_escalation.sql
@@ -1,0 +1,70 @@
+-- Prevent non-admin users from granting themselves admin privileges.
+--
+-- The RLS policy `profiles_update_self` permits authenticated users to update
+-- any column on their own row, including `is_admin` and `roles`. That means a
+-- malicious user could bypass the UI and call the Supabase client directly to
+-- flip `is_admin = true` or push 'admin' into `roles`. RLS in Postgres is
+-- row-based, not column-based, so we enforce column protection via a trigger.
+--
+-- The trigger allows the change only when:
+--   * the caller is already an admin (is_admin_user(auth.uid()) returns true), or
+--   * auth.uid() is null, which is the case for service_role / server-side
+--     connections that do not carry an end-user JWT. Our admin promote/demote
+--     endpoints in server.js run with the service role and must keep working.
+
+create or replace function public.prevent_self_admin_escalation()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  caller uuid := auth.uid();
+  caller_is_admin boolean := false;
+  old_has_admin_role boolean;
+  new_has_admin_role boolean;
+begin
+  -- Service role / server-side calls have no JWT and auth.uid() is null.
+  if caller is null then
+    return new;
+  end if;
+
+  caller_is_admin := public.is_admin_user(caller);
+  if caller_is_admin then
+    return new;
+  end if;
+
+  -- is_admin column must not change for non-admin callers.
+  if tg_op = 'INSERT' then
+    if coalesce(new.is_admin, false) is distinct from false then
+      raise exception 'Only admins can set is_admin'
+        using errcode = '42501';
+    end if;
+  elsif tg_op = 'UPDATE' then
+    if new.is_admin is distinct from old.is_admin then
+      raise exception 'Only admins can modify is_admin'
+        using errcode = '42501';
+    end if;
+  end if;
+
+  -- 'admin' role in the roles array is treated the same as is_admin.
+  old_has_admin_role := case
+    when tg_op = 'UPDATE' then 'admin' = any(coalesce(old.roles, '{}'))
+    else false
+  end;
+  new_has_admin_role := 'admin' = any(coalesce(new.roles, '{}'));
+
+  if new_has_admin_role and not old_has_admin_role then
+    raise exception 'Only admins can grant the admin role'
+      using errcode = '42501';
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists profiles_prevent_self_admin_escalation on public.profiles;
+create trigger profiles_prevent_self_admin_escalation
+  before insert or update on public.profiles
+  for each row
+  execute function public.prevent_self_admin_escalation();

--- a/plant-swipe/supabase/migrations/20260422000001_add_ai_and_scan_usage.sql
+++ b/plant-swipe/supabase/migrations/20260422000001_add_ai_and_scan_usage.sql
@@ -1,0 +1,77 @@
+-- Monitoring tables for AI (OpenAI) usage and plant-scan usage.
+-- No limits are enforced yet; these tables exist so we can measure abuse
+-- and later price plans against observed consumption.
+
+-- ========== AI usage events ==========
+create table if not exists public.ai_usage_events (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references auth.users(id) on delete set null,
+  feature text not null,
+  provider text not null default 'openai',
+  model text,
+  prompt_tokens integer not null default 0,
+  completion_tokens integer not null default 0,
+  total_tokens integer not null default 0,
+  request_id text,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_ai_usage_events_user_created
+  on public.ai_usage_events (user_id, created_at desc);
+create index if not exists idx_ai_usage_events_feature_created
+  on public.ai_usage_events (feature, created_at desc);
+create index if not exists idx_ai_usage_events_created
+  on public.ai_usage_events (created_at desc);
+
+alter table public.ai_usage_events enable row level security;
+
+do $$ begin
+  if exists (select 1 from pg_policies where schemaname='public' and tablename='ai_usage_events' and policyname='ai_usage_events_select_self_or_admin') then
+    drop policy ai_usage_events_select_self_or_admin on public.ai_usage_events;
+  end if;
+  create policy ai_usage_events_select_self_or_admin on public.ai_usage_events
+    for select to authenticated
+    using (
+      user_id = (select auth.uid())
+      or public.is_admin_user((select auth.uid()))
+    );
+end $$;
+
+-- No INSERT/UPDATE/DELETE policies: only the server (service role / pooler
+-- postgres role) writes to this table. Clients are read-only.
+grant select on public.ai_usage_events to authenticated;
+
+-- ========== Scan usage events ==========
+create table if not exists public.scan_usage_events (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  scan_id uuid references public.plant_scans(id) on delete set null,
+  provider text not null default 'kindwise',
+  tokens integer not null default 1,
+  classification_level text,
+  success boolean not null default true,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_scan_usage_events_user_created
+  on public.scan_usage_events (user_id, created_at desc);
+create index if not exists idx_scan_usage_events_created
+  on public.scan_usage_events (created_at desc);
+
+alter table public.scan_usage_events enable row level security;
+
+do $$ begin
+  if exists (select 1 from pg_policies where schemaname='public' and tablename='scan_usage_events' and policyname='scan_usage_events_select_self_or_admin') then
+    drop policy scan_usage_events_select_self_or_admin on public.scan_usage_events;
+  end if;
+  create policy scan_usage_events_select_self_or_admin on public.scan_usage_events
+    for select to authenticated
+    using (
+      user_id = (select auth.uid())
+      or public.is_admin_user((select auth.uid()))
+    );
+end $$;
+
+grant select on public.scan_usage_events to authenticated;

--- a/plant-swipe/supabase/migrations/20260422000002_harden_profile_and_usage.sql
+++ b/plant-swipe/supabase/migrations/20260422000002_harden_profile_and_usage.sql
@@ -1,0 +1,110 @@
+-- Harden public.profiles against client tampering of sensitive fields, and
+-- explicitly revoke write privileges on the usage-monitoring tables so a
+-- malicious client cannot delete or rewrite their tokens.
+--
+-- The previous trigger only protected `is_admin` and the 'admin' role. Extend
+-- it to cover every column that a user must not be able to flip themselves:
+--
+--   * is_admin           - already covered, unchanged
+--   * roles              - any change is admin-only (no client code writes it)
+--   * threat_level       - non-admins may only INCREASE (self-ban from legal
+--                          decline is allowed; lowering a shadow ban is not)
+--   * bug_points         - awarded server-side, must not be self-mutated
+--   * shadow_ban_backup  - moderation internal, server/admin only
+--   * last_active_at     - heartbeat written by the server only
+--
+-- Service-role/server connections (auth.uid() is null) and existing admins
+-- continue to bypass the trigger so admin endpoints still work.
+
+create or replace function public.prevent_self_admin_escalation()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  caller uuid := auth.uid();
+  old_has_admin_role boolean;
+  new_has_admin_role boolean;
+begin
+  if caller is null then
+    return new;
+  end if;
+  if public.is_admin_user(caller) then
+    return new;
+  end if;
+
+  if tg_op = 'INSERT' then
+    if coalesce(new.is_admin, false) is distinct from false then
+      raise exception 'Only admins can set is_admin' using errcode = '42501';
+    end if;
+    if 'admin' = any(coalesce(new.roles, '{}')) then
+      raise exception 'Only admins can grant the admin role' using errcode = '42501';
+    end if;
+    -- INSERT during signup: enforce that protected counters/state start at
+    -- their defaults. We compare against the column defaults so a user
+    -- cannot pre-seed bug_points or a fake shadow_ban_backup at signup.
+    if coalesce(new.bug_points, 0) <> 0 then
+      raise exception 'Only the server can set bug_points' using errcode = '42501';
+    end if;
+    if coalesce(new.threat_level, 0) <> 0 then
+      raise exception 'Only the server can set threat_level on insert' using errcode = '42501';
+    end if;
+    if new.shadow_ban_backup is not null then
+      raise exception 'Only admins can set shadow_ban_backup' using errcode = '42501';
+    end if;
+    if new.last_active_at is not null then
+      raise exception 'Only the server can set last_active_at' using errcode = '42501';
+    end if;
+    return new;
+  end if;
+
+  -- UPDATE branch
+  if new.is_admin is distinct from old.is_admin then
+    raise exception 'Only admins can modify is_admin' using errcode = '42501';
+  end if;
+
+  old_has_admin_role := 'admin' = any(coalesce(old.roles, '{}'));
+  new_has_admin_role := 'admin' = any(coalesce(new.roles, '{}'));
+  if new_has_admin_role and not old_has_admin_role then
+    raise exception 'Only admins can grant the admin role' using errcode = '42501';
+  end if;
+  -- Lock the entire roles array. No client-side flow writes roles today; any
+  -- change must come from the server (service role) or an admin.
+  if coalesce(new.roles, '{}') is distinct from coalesce(old.roles, '{}') then
+    raise exception 'Only admins can modify roles' using errcode = '42501';
+  end if;
+
+  -- threat_level may only increase. The legal-decline flow self-bans by
+  -- setting it to 3; we must not let a banned user set it back to 0.
+  if coalesce(new.threat_level, 0) < coalesce(old.threat_level, 0) then
+    raise exception 'Only admins can lower threat_level' using errcode = '42501';
+  end if;
+
+  if coalesce(new.bug_points, 0) is distinct from coalesce(old.bug_points, 0) then
+    raise exception 'Only admins can modify bug_points' using errcode = '42501';
+  end if;
+
+  if new.shadow_ban_backup is distinct from old.shadow_ban_backup then
+    raise exception 'Only admins can modify shadow_ban_backup' using errcode = '42501';
+  end if;
+
+  if new.last_active_at is distinct from old.last_active_at then
+    raise exception 'Only the server can update last_active_at' using errcode = '42501';
+  end if;
+
+  return new;
+end;
+$$;
+
+-- The trigger from the previous migration already binds this function; no
+-- need to redefine it. CREATE OR REPLACE on the function above is enough.
+
+-- ========== Lock down usage-monitoring tables ==========
+-- RLS already blocks all writes (no INSERT/UPDATE/DELETE policies exist), but
+-- revoke the privileges as well so even with a misconfigured policy a client
+-- cannot tamper with their own usage rows or wipe them to dodge limits.
+revoke insert, update, delete on public.ai_usage_events from authenticated;
+revoke insert, update, delete on public.ai_usage_events from anon;
+revoke insert, update, delete on public.scan_usage_events from authenticated;
+revoke insert, update, delete on public.scan_usage_events from anon;

--- a/plant-swipe/supabase/sync_parts/02_profiles_and_purge.sql
+++ b/plant-swipe/supabase/sync_parts/02_profiles_and_purge.sql
@@ -197,6 +197,60 @@ end $$;
 GRANT SELECT, INSERT, UPDATE, DELETE ON public.profiles TO authenticated;
 GRANT SELECT ON public.profiles TO anon;
 
+-- Column-level protection: RLS is row-based only, so a user could otherwise
+-- call .update({ is_admin: true }) directly on their own row and escalate to
+-- admin. The trigger below blocks any non-admin caller from changing is_admin
+-- or adding 'admin' to their roles array. Service-role/server calls (auth.uid()
+-- is null) and existing admins are allowed through so the promote/demote
+-- endpoints keep working.
+create or replace function public.prevent_self_admin_escalation()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  caller uuid := auth.uid();
+  old_has_admin_role boolean;
+  new_has_admin_role boolean;
+begin
+  if caller is null then
+    return new;
+  end if;
+  if public.is_admin_user(caller) then
+    return new;
+  end if;
+
+  if tg_op = 'INSERT' then
+    if coalesce(new.is_admin, false) is distinct from false then
+      raise exception 'Only admins can set is_admin' using errcode = '42501';
+    end if;
+  elsif tg_op = 'UPDATE' then
+    if new.is_admin is distinct from old.is_admin then
+      raise exception 'Only admins can modify is_admin' using errcode = '42501';
+    end if;
+  end if;
+
+  old_has_admin_role := case
+    when tg_op = 'UPDATE' then 'admin' = any(coalesce(old.roles, '{}'))
+    else false
+  end;
+  new_has_admin_role := 'admin' = any(coalesce(new.roles, '{}'));
+
+  if new_has_admin_role and not old_has_admin_role then
+    raise exception 'Only admins can grant the admin role' using errcode = '42501';
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists profiles_prevent_self_admin_escalation on public.profiles;
+create trigger profiles_prevent_self_admin_escalation
+  before insert or update on public.profiles
+  for each row
+  execute function public.prevent_self_admin_escalation();
+
 -- Aggregated like counts from bookmarks (security definer to bypass RLS)
 create or replace function public.top_liked_plants(limit_count integer default 5)
 returns table (plant_id text, likes bigint)

--- a/plant-swipe/supabase/sync_parts/02_profiles_and_purge.sql
+++ b/plant-swipe/supabase/sync_parts/02_profiles_and_purge.sql
@@ -199,10 +199,21 @@ GRANT SELECT ON public.profiles TO anon;
 
 -- Column-level protection: RLS is row-based only, so a user could otherwise
 -- call .update({ is_admin: true }) directly on their own row and escalate to
--- admin. The trigger below blocks any non-admin caller from changing is_admin
--- or adding 'admin' to their roles array. Service-role/server calls (auth.uid()
--- is null) and existing admins are allowed through so the promote/demote
--- endpoints keep working.
+-- admin. The trigger below blocks any non-admin caller from changing
+-- privileged or server-managed columns. Service-role/server calls
+-- (auth.uid() is null) and existing admins are allowed through so promote/
+-- demote endpoints, the heartbeat, bug-points awards, and moderation tools
+-- keep working.
+--
+-- Locked columns for non-admin callers:
+--   is_admin, roles                            (privilege escalation)
+--   threat_level                               (only monotonic increase
+--                                               allowed, so the legal-decline
+--                                               self-ban still works but a
+--                                               banned user cannot un-ban)
+--   bug_points                                 (server-awarded only)
+--   shadow_ban_backup                          (moderation internal)
+--   last_active_at                             (server heartbeat only)
 create or replace function public.prevent_self_admin_escalation()
 returns trigger
 language plpgsql
@@ -225,20 +236,52 @@ begin
     if coalesce(new.is_admin, false) is distinct from false then
       raise exception 'Only admins can set is_admin' using errcode = '42501';
     end if;
-  elsif tg_op = 'UPDATE' then
-    if new.is_admin is distinct from old.is_admin then
-      raise exception 'Only admins can modify is_admin' using errcode = '42501';
+    if 'admin' = any(coalesce(new.roles, '{}')) then
+      raise exception 'Only admins can grant the admin role' using errcode = '42501';
     end if;
+    if coalesce(new.bug_points, 0) <> 0 then
+      raise exception 'Only the server can set bug_points' using errcode = '42501';
+    end if;
+    if coalesce(new.threat_level, 0) <> 0 then
+      raise exception 'Only the server can set threat_level on insert' using errcode = '42501';
+    end if;
+    if new.shadow_ban_backup is not null then
+      raise exception 'Only admins can set shadow_ban_backup' using errcode = '42501';
+    end if;
+    if new.last_active_at is not null then
+      raise exception 'Only the server can set last_active_at' using errcode = '42501';
+    end if;
+    return new;
   end if;
 
-  old_has_admin_role := case
-    when tg_op = 'UPDATE' then 'admin' = any(coalesce(old.roles, '{}'))
-    else false
-  end;
-  new_has_admin_role := 'admin' = any(coalesce(new.roles, '{}'));
+  -- UPDATE branch
+  if new.is_admin is distinct from old.is_admin then
+    raise exception 'Only admins can modify is_admin' using errcode = '42501';
+  end if;
 
+  old_has_admin_role := 'admin' = any(coalesce(old.roles, '{}'));
+  new_has_admin_role := 'admin' = any(coalesce(new.roles, '{}'));
   if new_has_admin_role and not old_has_admin_role then
     raise exception 'Only admins can grant the admin role' using errcode = '42501';
+  end if;
+  if coalesce(new.roles, '{}') is distinct from coalesce(old.roles, '{}') then
+    raise exception 'Only admins can modify roles' using errcode = '42501';
+  end if;
+
+  if coalesce(new.threat_level, 0) < coalesce(old.threat_level, 0) then
+    raise exception 'Only admins can lower threat_level' using errcode = '42501';
+  end if;
+
+  if coalesce(new.bug_points, 0) is distinct from coalesce(old.bug_points, 0) then
+    raise exception 'Only admins can modify bug_points' using errcode = '42501';
+  end if;
+
+  if new.shadow_ban_backup is distinct from old.shadow_ban_backup then
+    raise exception 'Only admins can modify shadow_ban_backup' using errcode = '42501';
+  end if;
+
+  if new.last_active_at is distinct from old.last_active_at then
+    raise exception 'Only the server can update last_active_at' using errcode = '42501';
   end if;
 
   return new;

--- a/plant-swipe/supabase/sync_parts/21_ai_and_scan_usage.sql
+++ b/plant-swipe/supabase/sync_parts/21_ai_and_scan_usage.sql
@@ -1,0 +1,73 @@
+-- ========== AI & Scan usage monitoring ==========
+-- Tracks OpenAI token spend per feature and per-user plant-scan counts.
+-- Used for monitoring abuse; limits are not enforced yet.
+
+create table if not exists public.ai_usage_events (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references auth.users(id) on delete set null,
+  feature text not null,
+  provider text not null default 'openai',
+  model text,
+  prompt_tokens integer not null default 0,
+  completion_tokens integer not null default 0,
+  total_tokens integer not null default 0,
+  request_id text,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_ai_usage_events_user_created
+  on public.ai_usage_events (user_id, created_at desc);
+create index if not exists idx_ai_usage_events_feature_created
+  on public.ai_usage_events (feature, created_at desc);
+create index if not exists idx_ai_usage_events_created
+  on public.ai_usage_events (created_at desc);
+
+alter table public.ai_usage_events enable row level security;
+
+do $$ begin
+  if exists (select 1 from pg_policies where schemaname='public' and tablename='ai_usage_events' and policyname='ai_usage_events_select_self_or_admin') then
+    drop policy ai_usage_events_select_self_or_admin on public.ai_usage_events;
+  end if;
+  create policy ai_usage_events_select_self_or_admin on public.ai_usage_events
+    for select to authenticated
+    using (
+      user_id = (select auth.uid())
+      or public.is_admin_user((select auth.uid()))
+    );
+end $$;
+
+grant select on public.ai_usage_events to authenticated;
+
+create table if not exists public.scan_usage_events (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  scan_id uuid references public.plant_scans(id) on delete set null,
+  provider text not null default 'kindwise',
+  tokens integer not null default 1,
+  classification_level text,
+  success boolean not null default true,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_scan_usage_events_user_created
+  on public.scan_usage_events (user_id, created_at desc);
+create index if not exists idx_scan_usage_events_created
+  on public.scan_usage_events (created_at desc);
+
+alter table public.scan_usage_events enable row level security;
+
+do $$ begin
+  if exists (select 1 from pg_policies where schemaname='public' and tablename='scan_usage_events' and policyname='scan_usage_events_select_self_or_admin') then
+    drop policy scan_usage_events_select_self_or_admin on public.scan_usage_events;
+  end if;
+  create policy scan_usage_events_select_self_or_admin on public.scan_usage_events
+    for select to authenticated
+    using (
+      user_id = (select auth.uid())
+      or public.is_admin_user((select auth.uid()))
+    );
+end $$;
+
+grant select on public.scan_usage_events to authenticated;

--- a/plant-swipe/supabase/sync_parts/21_ai_and_scan_usage.sql
+++ b/plant-swipe/supabase/sync_parts/21_ai_and_scan_usage.sql
@@ -71,3 +71,12 @@ do $$ begin
 end $$;
 
 grant select on public.scan_usage_events to authenticated;
+
+-- Defence in depth: RLS already blocks all writes (no INSERT/UPDATE/DELETE
+-- policies exist), but explicitly revoke the privileges so a future policy
+-- mistake or schema-level grant cannot let a client tamper with their own
+-- usage rows or wipe them to dodge limits.
+revoke insert, update, delete on public.ai_usage_events from authenticated;
+revoke insert, update, delete on public.ai_usage_events from anon;
+revoke insert, update, delete on public.scan_usage_events from authenticated;
+revoke insert, update, delete on public.scan_usage_events from anon;


### PR DESCRIPTION
## Summary
This PR adds comprehensive usage monitoring for AI (OpenAI) and plant-scan operations, along with security hardening to prevent non-admin users from escalating their privileges.

## Key Changes

### Usage Monitoring
- **AI Usage Tracking**: Added `logAiUsage()` helper function to record OpenAI API calls across all features (admin plant operations, blog summarization, garden advice, journal feedback, garden chat)
- **Scan Usage Tracking**: Added `logScanUsage()` helper function to monitor plant identification scans via Kindwise API
- **Database Tables**: Created `ai_usage_events` and `scan_usage_events` tables with appropriate indexes and RLS policies for tracking token consumption and scan metrics
- **Feature Coverage**: Instrumented 10+ API endpoints and internal functions to log usage data including token counts, models used, request IDs, and contextual metadata

### Security Hardening
- **Admin Escalation Prevention**: Added `prevent_self_admin_escalation()` trigger on the `profiles` table to block non-admin users from modifying their own `is_admin` flag or adding 'admin' to their `roles` array
- **Service Role Bypass**: Trigger allows service-role/server-side connections (where `auth.uid()` is null) to continue working for legitimate admin promotion/demotion endpoints
- **Column-Level Protection**: Implements column-level security constraints since PostgreSQL RLS is row-based only

## Implementation Details

- Usage logging is **best-effort**: any database write failures are logged and swallowed to prevent instrumentation from breaking user requests
- No rate limits are enforced yet; the tables exist for measuring consumption and future pricing plan decisions
- Token extraction handles both OpenAI Responses API format (`input_tokens`/`output_tokens`) and Chat Completions format (`prompt_tokens`/`completion_tokens`)
- RLS policies allow users to view their own usage events and admins to view all events
- Migration files provided for both standard migrations and sync_parts (for schema synchronization)

https://claude.ai/code/session_01HkpkDfNRudLb5ZPahp7Cs2