### PR TITLE
docs: weekly documentation sync — 2026-04-27

### DIFF
--- a/EXTERNAL_APIS.md
+++ b/EXTERNAL_APIS.md
@@ -1,7 +1,7 @@
 # External APIs Used in Aphylia
 
 > **Comprehensive list of all third-party services and APIs**  
-> Last updated: April 20, 2026
+> Last updated: April 27, 2026
 
 ---
 
@@ -452,9 +452,30 @@ wss://*.supabase.co (WebSocket)
 
 ---
 
+## Push Notifications
+
+### 12. Firebase Cloud Messaging (FCM HTTP v1)
+
+**API Endpoint:** `https://fcm.googleapis.com/v1/projects/{project_id}/messages:send`
+
+**Authentication:** OAuth2 service-account token from `fcm_keyfile.json` (placed at the repo root, next to `server.js`). Override the path with `FCM_SERVICE_ACCOUNT_FILE`. The legacy `FCM_LEGACY_SERVER_KEY` endpoint was turned down by Google on 2024-06-20 and is no longer supported.
+
+**Files:**
+- `plant-swipe/server.js` (push delivery)
+- `plant-swipe/src/platform/nativePushRegistration.ts` (client token upload)
+
+**Features:**
+- Native push notifications on Android (FCM) and iOS (APNs via FCM)
+- Device token stored in `user_fcm_tokens` table
+- Foreground notifications bridged to in-app toasts via `@capacitor/push-notifications`
+
+**CI note:** The `capacitor-mobile` workflow materialises `google-services.json` from the `GOOGLE_SERVICES_JSON` secret so Gradle can apply the Google Services plugin at build time.
+
+---
+
 ## Fonts & Assets
 
-### 12. Google Fonts
+### 13. Google Fonts
 
 **URLs:**
 - `https://fonts.googleapis.com` (CSS)
@@ -527,6 +548,7 @@ https://fonts.googleapis.com/css2?family=Quicksand:wght@600;700&display=swap
 | Sentry | Monitoring | ✅ Yes | Freemium | ✅ Yes | Error tracking |
 | Resend | Email | ✅ Yes | Paid | ✅ Yes | Transactional email |
 | Supabase | Backend | ✅ Yes | Freemium | ✅ Yes | Full stack |
+| FCM HTTP v1 | Push | ✅ Yes | Free | ✅ Yes | Native push (Android/iOS) |
 | Google Fonts | Assets | ❌ No | Free | ✅ Yes | Typography |
 
 ---
@@ -642,7 +664,7 @@ Potential future additions:
 - **Cloudinary:** Image optimization and CDN
 - **Algolia:** Advanced plant search
 - **Mapbox:** Enhanced map features
-- **Firebase Cloud Messaging:** Push notifications
+- ~~**Firebase Cloud Messaging**~~ — Now active (see FCM HTTP v1 section below)
 
 ---
 
@@ -668,4 +690,4 @@ For API-related questions:
 
 ---
 
-*Last updated: April 20, 2026*
+*Last updated: April 27, 2026*

--- a/plant-swipe/SECURITY_AUDIT_REPORT.md
+++ b/plant-swipe/SECURITY_AUDIT_REPORT.md
@@ -221,6 +221,11 @@ Key dependencies are up-to-date:
 #### ✅ Command Injection Remediation (April 2026)
 - Admin **`/api/admin/system-health`** endpoint previously used `child_process.exec()` for disk stats, which was vulnerable to shell injection via crafted input. Replaced with `child_process.execFile()` which bypasses shell interpolation entirely.
 
+#### ✅ Admin Escalation Prevention (April 2026)
+- **`prevent_self_admin_escalation` trigger** on `profiles` blocks non-admin callers from setting `is_admin = true` or adding `'admin'` to `roles`. Service-role connections pass through.
+- Trigger extended to also protect `threat_level` (non-admins may only increase, preventing shadow-ban escape), `bug_points`, `shadow_ban_backup`, `last_active_at`, and all non-admin `roles` changes.
+- **Usage tables hardened:** `ai_usage_events` and `scan_usage_events` have no write RLS policies, and `INSERT/UPDATE/DELETE` is explicitly `REVOKE`d from `authenticated`/`anon` for defence in depth.
+
 #### ⚠️ Potential Concerns
 - No automated dependency vulnerability scanning in CI/CD (recommend adding)
 - `'unsafe-eval'` in CSP (required for some libraries but increases risk)

--- a/plant-swipe/src/REUSABLE_COMPONENTS.md
+++ b/plant-swipe/src/REUSABLE_COMPONENTS.md
@@ -88,6 +88,52 @@ const tabs = [
 
 ---
 
+### `AppSelect`
+
+**File:** `src/components/ui/app-select.tsx`
+
+A custom select dropdown built on Radix Popover. Replaces native HTML `<select>` app-wide for consistent styling, keyboard navigation, and support for icons/descriptions per option. Generic over the value type.
+
+**Props:**
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `value` | `T \| null \| undefined` | — | Currently selected value |
+| `onChange` | `(value: T) => void` | — | Called when an option is selected |
+| `options` | `AppSelectOption<T>[]` | — | Array of `{ value, label, description?, icon?, disabled? }` |
+| `placeholder` | `ReactNode` | — | Shown when no value is selected |
+| `disabled` | `boolean` | `false` | Disables the trigger |
+| `className` | `string` | — | Wrapper class |
+| `triggerClassName` | `string` | — | Extra classes on the trigger button |
+| `contentClassName` | `string` | — | Extra classes on the dropdown panel |
+| `align` | `'start' \| 'center' \| 'end'` | `'start'` | Popover alignment |
+| `ariaLabel` | `string` | — | Accessible label |
+| `size` | `'sm' \| 'md'` | `'md'` | Trigger size variant |
+
+**Example:**
+
+```tsx
+import { AppSelect } from "@/components/ui/app-select"
+
+const options = [
+  { value: "name", label: "Name" },
+  { value: "date", label: "Date", icon: <CalendarIcon /> },
+]
+
+<AppSelect value={sort} onChange={setSort} options={options} placeholder="Sort by…" />
+```
+
+**Features:**
+- Keyboard navigation (arrow keys, Enter, Escape)
+- Check icon on selected option
+- Dark mode support
+- Optional per-option description and icon
+- Two size variants (`sm` / `md`)
+
+**Used in:** Encyclopedia sort, Discovery filters, admin panels — replaces all native `<select>` elements.
+
+---
+
 ### `ValidatedInput`
 
 **File:** `src/components/ui/validated-input.tsx`

--- a/plant-swipe/supabase/DATABASE_SCHEMA.md
+++ b/plant-swipe/supabase/DATABASE_SCHEMA.md
@@ -1,6 +1,6 @@
 # Aphylia Database Schema Documentation
 
-> **Last Updated:** March 31, 2026
+> **Last Updated:** April 27, 2026
 > **Database:** PostgreSQL (Supabase)  
 > **Total Tables:** 75+  
 > **RLS Policies:** 250+
@@ -28,18 +28,15 @@ The Aphylia database is built on Supabase (PostgreSQL) with extensive use of:
 - **Real-time subscriptions** for live updates
 
 ### Recent Updates (Keep Less than 10)
+- **Apr 26, 2026:** **Profile field hardening + usage table REVOKE.** Extended the `prevent_self_admin_escalation` trigger to protect `roles`, `threat_level` (non-admins may only increase), `bug_points`, `shadow_ban_backup`, and `last_active_at` from client tampering. INSERT defaults also enforced. Explicitly `REVOKE INSERT/UPDATE/DELETE` on `ai_usage_events` and `scan_usage_events` from `authenticated`/`anon` for defence in depth. Migration: `20260422000002_harden_profile_and_usage.sql`. Schema files: `02_profiles_and_purge.sql`, `21_ai_and_scan_usage.sql`.
+- **Apr 22, 2026:** **AI & scan usage monitoring.** New `ai_usage_events` table logs every OpenAI request (user, feature, model, prompt/completion/total tokens, request_id, metadata). New `scan_usage_events` table logs every Kindwise plant scan (1 scan = 1 token, classification_level, success). RLS: users read own rows, admins see all. No write policies — server (service role) inserts only. No limits enforced yet; tables exist for abuse detection and future plan pricing. Schema file: `21_ai_and_scan_usage.sql`. Migration: `20260422000001_add_ai_and_scan_usage.sql`.
+- **Apr 22, 2026:** **Admin escalation prevention.** Added `BEFORE INSERT/UPDATE` trigger `prevent_self_admin_escalation` on `profiles` that blocks non-admin callers from setting `is_admin = true` or adding `'admin'` to `roles`. Service-role calls (`auth.uid() IS NULL`) pass through so server endpoints keep working. Migration: `20260422000000_prevent_self_admin_escalation.sql`. Schema file: `02_profiles_and_purge.sql`.
 - **Apr 23, 2026:** **Dropped legacy admin_commentary + contributor_name.** Now that the data migrations have been applied, `plants.admin_commentary` is dropped and `plant_contributors.contributor_name` is removed (along with its legacy unique index and the id-or-name check constraint). `plant_contributors.contributor_id` is now `NOT NULL` with `ON DELETE CASCADE` and the single unique is `(plant_id, contributor_id)`. Orphan contributor rows that couldn't be resolved to a profile during backfill are deleted by the idempotent cleanup block in `03_plants_and_colors.sql`. Client code purged of every `adminCommentary` / `contributor_name` reference across pages, services, schema, diff helper, and server.js.
 - **Apr 22, 2026:** **Contributors keyed by profile id.** Added `plant_contributors.contributor_id` (uuid FK to `profiles`, `ON DELETE SET NULL`) alongside the existing `contributor_name` (now nullable, kept only as legacy snapshot). Replaced the case-insensitive name unique index with two partial uniques (one per id, one per legacy name) and added a check constraint requiring either an id or a non-empty name. New admin UI uses a shared user-search picker (same `SearchItem` pattern as Admin Event notifications). Migration `20260422100000_backfill_plant_contributor_ids.sql` resolves existing names to profile ids via `display_name`. Schema file: `03_plants_and_colors.sql`.
 - **Apr 22, 2026:** **Plant change history + admin notes thread.** New `plant_history` table logs per-plant admin actions (field edits, translations, AI fills, note add/edit/delete) — insert-only, admin/editor select. New `plant_admin_notes` table replaces the legacy `plants.admin_commentary` textarea with a chat-style thread (any admin can add/edit/delete any note; all mutations mirrored into `plant_history`). Schema file: `03_plants_and_colors.sql`.
 - **Apr 13, 2026:** **Native push tokens, tutorial, GDPR expansion, companion cleanup.** Added `user_fcm_tokens` table for native (Capacitor) FCM/APNs device tokens. Added `tutorial_completed` boolean column to `profiles` for onboarding tutorial persistence. Migration `20260408000000_clean_bad_companion_data.sql` bulk-cleans bad AI-filled companion data from `plants` table. Migration `20260408100000_fix_admin_event_notifications_rls.sql` fixes RLS so non-admin users can receive event notifications. GDPR delete handlers expanded to 10 additional tables (`15_gdpr_and_preferences.sql`). Schema files: `01_extensions_and_setup.sql`, `11_notifications_and_tasks.sql`, `15_gdpr_and_preferences.sql`, `17_admin_event_notifications.sql`.
 - **Apr 6, 2026:** **Events & Badges schema files.** Added `19_badges.sql` (badge catalog, translations, user badges) and `20_events.sql` (events, items, translations, registrations, user progress) to `sync_parts/`. Added `conservation_status` values `protected` and `protected_in_some_regions`. Unified `plant_part` and `edible_part` to share 12 items (added `tubers`). Fixed Phase 3 sync constraints for `conservation_status` and `plant_part`. Schema files: `03_plants_and_colors.sql`, `19_badges.sql`, `20_events.sql`.
 - **Mar 31, 2026:** **`events` admin UPDATE RLS.** The `events` table had SELECT-only policies; authenticated updates from `/admin/events` matched no policy and updated zero rows while the client still reported success. Added policy `events_update_admin` (`public.is_admin_user`) for UPDATE. Schema file: `20_events.sql`.
-- **Mar 25, 2026:** **Seedling Tray Garden Type.** Added `seedling` to `garden_type` CHECK constraint and `living_space` values. Added `tray_rows` and `tray_cols` INTEGER columns to `gardens` table (used when `garden_type = 'seedling'`). New `seedling_tray_cells` table with per-cell tracking (position, plant, stage, sow date, watering, notes). Stages: `empty`, `sown`, `germinating`, `sprouted`, `ready`. RLS policies for garden member access. Schema file: `12_audit_and_analytics.sql`. Migration: `20260325000000_add_seedling_tray.sql`.
-- **Mar 16, 2026:** **Garden Living Space & Roadmap Persistence.** Added `living_space` text[] column to `gardens` table (values: indoor, outdoor, terrarium, greenhouse) — used for plant suggestions and beginner onboarding. New `garden_roadmap_completions` table tracks beginner roadmap step completions per garden (persistent, never reverted). RPC: `complete_roadmap_step(uuid, text)`. Schema file: `12_audit_and_analytics.sql`.
-- **Mar 14, 2026:** **Admin Event Notifications.** Added `admin_event_notifications` table for configurable push notifications sent to selected admins when special events occur (user reports, bug reports, plant reports, plant requests). Each event type has its own enable/disable toggle, custom message template with `{{variable}}` interpolation, and selectable list of admin recipients. Schema file: `17_admin_event_notifications.sql`. New admin panel: "Event Alerts" tab.
-- **Mar 11, 2026:** **Email timezone bug fix.** Added `original_scheduled_for` column to `admin_email_campaigns` — stores the admin's intended send time immutably. The campaign runner edge function now uses this column for per-user timezone calculations instead of `scheduled_for`, which gets overwritten with cron wake-up times after partial sends, preventing timezone offset compounding. Added detailed column documentation for `admin_email_campaigns` and `admin_campaign_sends` tables.
-- **Mar 10, 2026:** **Performance optimizations.** Added new RPC `get_enriched_occurrences_for_gardens(uuid[], timestamptz, timestamptz)` that returns task occurrences pre-joined with task metadata (type, emoji) in a single query — replaces 3-step fetch-tasks → fetch-occurrences → client-merge pattern. Added performance indexes: `idx_task_occurrences_due_completed (due_at, completed_at)`, `idx_task_occurrences_task_id (task_id)`, `idx_garden_plant_tasks_garden_id (garden_id)`. Server-side: postgres connection pooling (max 10), health-check caching (5s TTL with request coalescing), parallelised GDPR export queries.
-- **Mar 6, 2026:** Merged Likes into Bookmarks system. Added `is_like` boolean column to `bookmarks` table with unique partial index (one per user). New user trigger now creates a private Likes bookmark instead of a Default public bookmark. `profiles.liked_plant_ids` deprecated — likes now stored via `bookmark_items` in the user's Likes bookmark.
 
 ### Required Extensions
 ```sql
@@ -52,7 +49,7 @@ pg_net        -- HTTP requests from database (edge functions)
 
 ## Schema Files Structure
 
-The schema is split into 20 files in `supabase/sync_parts/` for easier management:
+The schema is split into 21 files in `supabase/sync_parts/` for easier management:
 
 | File | Description |
 |------|-------------|
@@ -76,6 +73,7 @@ The schema is split into 20 files in `supabase/sync_parts/` for easier managemen
 | `18_discovery_history.sql` | Discovery seen-plants history for personalized scoring |
 | `19_badges.sql` | Badge catalog, translations, and user badge awards |
 | `20_events.sql` | Event system: events, items, translations, registrations, user progress |
+| `21_ai_and_scan_usage.sql` | AI (OpenAI) token usage and plant-scan usage monitoring |
 
 ---
 
@@ -211,6 +209,8 @@ The schema is split into 20 files in `supabase/sync_parts/` for easier managemen
 | `garden_task_audit_log` | Task change audit |
 | `gdpr_audit_log` | GDPR compliance audit |
 | `impressions` | Page view impressions for plants and blog posts (admin read-only) |
+| `ai_usage_events` | Per-request OpenAI token usage (feature, model, tokens). Server-insert only. |
+| `scan_usage_events` | Per-scan Kindwise plant identification usage (1 scan = 1 token). Server-insert only. |
 
 ### Events & Badges
 
@@ -1348,6 +1348,52 @@ updated_at        TIMESTAMPTZ DEFAULT now()  -- Auto-updated via trigger
 
 **Seeded defaults:** One row per event type is inserted on migration with `enabled = false`.
 
+### `ai_usage_events`
+
+Per-request OpenAI token usage. One row per `openaiClient.responses.create` call across all server features (plant fill, plant verify, blog metadata, blog summary, garden advice, journal feedback, garden-chat). Server-insert only; no client write policies.
+
+```sql
+id                  UUID PRIMARY KEY DEFAULT gen_random_uuid()
+user_id             UUID REFERENCES auth.users(id) ON DELETE SET NULL
+feature             TEXT NOT NULL            -- e.g. 'plant_fill', 'blog_summary', 'garden_advice'
+provider            TEXT NOT NULL DEFAULT 'openai'
+model               TEXT                     -- e.g. 'gpt-4o'
+prompt_tokens       INTEGER NOT NULL DEFAULT 0
+completion_tokens   INTEGER NOT NULL DEFAULT 0
+total_tokens        INTEGER NOT NULL DEFAULT 0
+request_id          TEXT                     -- OpenAI request ID for tracing
+metadata            JSONB NOT NULL DEFAULT '{}'
+created_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+```
+
+**RLS:** SELECT only — users read own rows; admins see all. No INSERT/UPDATE/DELETE policies. `REVOKE INSERT, UPDATE, DELETE` on `authenticated`/`anon` for defence in depth.
+
+**Indexes:** `(user_id, created_at DESC)`, `(feature, created_at DESC)`, `(created_at DESC)`.
+
+**Schema file:** `21_ai_and_scan_usage.sql`. Migration: `20260422000001_add_ai_and_scan_usage.sql`.
+
+### `scan_usage_events`
+
+Per-scan Kindwise plant identification usage. One row per successful scan, 1 scan = 1 token. Server-insert only; no client write policies.
+
+```sql
+id                      UUID PRIMARY KEY DEFAULT gen_random_uuid()
+user_id                 UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE
+scan_id                 UUID REFERENCES plant_scans(id) ON DELETE SET NULL
+provider                TEXT NOT NULL DEFAULT 'kindwise'
+tokens                  INTEGER NOT NULL DEFAULT 1
+classification_level    TEXT
+success                 BOOLEAN NOT NULL DEFAULT true
+metadata                JSONB NOT NULL DEFAULT '{}'
+created_at              TIMESTAMPTZ NOT NULL DEFAULT now()
+```
+
+**RLS:** SELECT only — users read own rows; admins see all. No INSERT/UPDATE/DELETE policies. `REVOKE INSERT, UPDATE, DELETE` on `authenticated`/`anon` for defence in depth.
+
+**Indexes:** `(user_id, created_at DESC)`, `(created_at DESC)`.
+
+**Schema file:** `21_ai_and_scan_usage.sql`. Migration: `20260422000001_add_ai_and_scan_usage.sql`.
+
 ---
 
 ## Row Level Security (RLS)
@@ -1413,6 +1459,9 @@ CREATE POLICY "Admins can manage all" ON table_name
 | `impressions` | Admin SELECT only; server writes via service role |
 | `plant_stocks` | Authenticated users can SELECT; only admins can INSERT/UPDATE/DELETE |
 | `events` | Anyone can SELECT; only admins can UPDATE (`events_update_admin` via `is_admin_user`) |
+| `ai_usage_events` | SELECT: own rows or admin; no INSERT/UPDATE/DELETE policies; `REVOKE` enforced |
+| `scan_usage_events` | SELECT: own rows or admin; no INSERT/UPDATE/DELETE policies; `REVOKE` enforced |
+| `profiles` | `prevent_self_admin_escalation` trigger blocks non-admin changes to `is_admin`, `roles`, `threat_level` (decrease), `bug_points`, `shadow_ban_backup`, `last_active_at` |
 
 ---
 


### PR DESCRIPTION
## Weekly Docs Sync — 2026-04-27

Auto-generated documentation updates based on this week's merged PRs and commits.

### Summary

**PRs reviewed:** 25
**Commits reviewed:** 70+

Updates cover the admin escalation prevention trigger, AI/scan usage monitoring tables, profile field hardening, FCM HTTP v1 migration, and the new AppSelect component.

### Files Updated
- `plant-swipe/supabase/DATABASE_SCHEMA.md` — Added 3 new Recent Updates entries (usage monitoring, admin escalation prevention, profile field hardening). Added `21_ai_and_scan_usage.sql` to schema file list. Added `ai_usage_events` and `scan_usage_events` to table lists with full table reference docs. Added profiles trigger to Special RLS table. Trimmed old entries to stay under 10.
- `plant-swipe/SECURITY_AUDIT_REPORT.md` — Added "Admin Escalation Prevention (April 2026)" section covering the `prevent_self_admin_escalation` trigger, extended field protection, and usage table REVOKE hardening.
- `plant-swipe/src/REUSABLE_COMPONENTS.md` — Added `AppSelect` component documentation (props, example, features, usage locations).
- `EXTERNAL_APIS.md` — Added FCM HTTP v1 as active API (#12) with endpoint, auth, files, and CI notes. Moved FCM out of "Future API Integrations". Updated summary table. Bumped "Last updated" date.

### No Update Needed
- `README.md` — Already updated (Aphylia branding, FIVE/Neolite/Lau credits) in earlier commits this week
- `plant-swipe/README.md` — Already updated (credits) in earlier commits this week
- `AGENTS.md` — No related changes this week
- `plant-swipe/docs/BUILD_ANDROID.md` — Already references FCM v1 and google-services.json from earlier updates
- `plant-swipe/docs/CAPACITOR_SETUP_NOTES.md` — Still accurate
- `plant-swipe/docs/MOBILE_ARCHITECTURE.md` — Still accurate
- `plant-swipe/GARDEN_TYPES.md` — Seedling tray references are correct (feature exists in codebase)
- `plant-swipe/docs/gdpr-audit/2026-04-22.md` — Added earlier this week, still current
- `CONTRIBUTING.md` — Does not exist; no dev setup docs to update

### Flagged for Human Review
- `plant-swipe/SECURITY_AUDIT_REPORT.md` — Dependencies list (express 4.19.2, etc.) may be stale; consider verifying current versions
- Dependabot reports 14 vulnerabilities (4 high, 10 moderate) on the default branch — may warrant a separate triage pass

https://claude.ai/code/session_01SFQnKZzmgWUzh6F3b2yKC5

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFQnKZzmgWUzh6F3b2yKC5)_