### PR TITLE
🎨 Palette: Add accessibility attributes to clear search button in Garden Journal

### DIFF
--- a/plant-swipe/src/components/garden/GardenJournalSection.tsx
+++ b/plant-swipe/src/components/garden/GardenJournalSection.tsx
@@ -984,7 +984,7 @@ export const GardenJournalSection: React.FC<GardenJournalSectionProps> = ({
               className="w-full h-9 pl-9 pr-8 rounded-xl border border-stone-200 dark:border-stone-700 bg-white dark:bg-[#1f1f1f] text-sm placeholder:text-stone-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/30 focus:border-emerald-400"
             />
             {searchQuery && (
-              <button type="button" onClick={() => setSearchQuery("")} className="absolute right-2.5 top-1/2 -translate-y-1/2 text-stone-400 hover:text-stone-600">
+              <button type="button" onClick={() => setSearchQuery("")} aria-label={t("common.clear", { defaultValue: "Clear" })} title={t("common.clear", { defaultValue: "Clear" })} className="absolute right-2.5 top-1/2 -translate-y-1/2 text-stone-400 hover:text-stone-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500">
                 <X className="w-3.5 h-3.5" />
               </button>
             )}


### PR DESCRIPTION
### 💡 What
Added \`aria-label\`, \`title\`, and \`focus-visible\` utility classes to the icon-only 'clear search' button in the \`GardenJournalSection\` component.

### 🎯 Why
Icon-only buttons must provide explicit text context for screen reader users and a visible tool tip for mouse users. They also require a clear visual focus state for keyboard navigation. This change ensures the clear search button is fully accessible.

### 📸 Before/After
*(No visual changes to the resting state, but keyboard focus now displays an emerald ring and hovering shows a 'Clear' tooltip)*

### ♿ Accessibility
- Added \`aria-label='Clear'\` for screen readers.
- Added \`title='Clear'\` for native hover tooltips.
- Added \`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500\` for keyboard focus visibility.

---
*PR created automatically by Jules for task [17543206601396987521](https://jules.google.com/task/17543206601396987521) started by @FrenchFive*