### PR TITLE
feat(admin): add Refresh Aphydle button to admin panel

### DIFF
--- a/admin_api/app.py
+++ b/admin_api/app.py
@@ -414,6 +414,10 @@ def _refresh_script_path(repo_root: str) -> str:
     return str(Path(repo_root) / "scripts" / "refresh-plant-swipe.sh")
 
 
+def _aphydle_refresh_script_path(repo_root: str) -> str:
+    return str(Path(repo_root) / "scripts" / "refresh-aphydle.sh")
+
+
 def _supabase_script_path(repo_root: str) -> str:
     return str(Path(repo_root) / "scripts" / "deploy-supabase-functions.sh")
 
@@ -701,6 +705,76 @@ def admin_refresh():
     except Exception:
         pass
     return _run_refresh(branch, stream=False)
+
+
+def _run_aphydle_refresh(stream: bool):
+    repo_root = _get_repo_root()
+    script_path = _aphydle_refresh_script_path(repo_root)
+    if not os.path.isfile(script_path):
+        abort(500, description=f"Aphydle refresh script not found at {script_path}")
+    _ensure_executable(script_path)
+    env = os.environ.copy()
+    env.setdefault("CI", os.environ.get("CI", "true"))
+    env["PLANTSWIPE_REPO_DIR"] = repo_root
+    if stream:
+        def generate():
+            yield "event: open\ndata: {\"ok\": true, \"message\": \"Starting Aphydle refresh...\"}\n\n"
+            try:
+                p = subprocess.Popen(
+                    [script_path],
+                    cwd=repo_root,
+                    env=env,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    bufsize=1,
+                    universal_newlines=True,
+                )
+            except Exception as e:
+                yield f"event: error\ndata: {str(e)}\n\n"
+                return
+            try:
+                assert p.stdout is not None
+                for line in p.stdout:
+                    txt = line.rstrip("\n\r")
+                    if not txt:
+                        continue
+                    if len(txt) > 4000:
+                        txt = txt[:4000] + "..."
+                    yield f"data: {txt}\n\n"
+            finally:
+                code = p.wait()
+                if code == 0:
+                    yield "event: done\ndata: {\"ok\": true}\n\n"
+                else:
+                    yield f"event: done\ndata: {{\"ok\": false, \"code\": {code} }}\n\n"
+        return Response(generate(), mimetype="text/event-stream")
+    else:
+        try:
+            subprocess.Popen([script_path], cwd=repo_root, env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            return jsonify({"ok": True, "started": True})
+        except Exception as e:
+            return jsonify({"ok": False, "error": str(e) or "failed to start"}), 500
+
+
+@app.get("/admin/refresh-aphydle/stream")
+def admin_refresh_aphydle_stream():
+    _verify_request()
+    try:
+        _log_admin_action("refresh_aphydle", "stream")
+    except Exception:
+        pass
+    return _run_aphydle_refresh(stream=True)
+
+
+@app.get("/admin/refresh-aphydle")
+@app.post("/admin/refresh-aphydle")
+def admin_refresh_aphydle():
+    _verify_request()
+    try:
+        _log_admin_action("refresh_aphydle", "")
+    except Exception:
+        pass
+    return _run_aphydle_refresh(stream=False)
 
 
 @app.get("/admin/deploy-edge-functions")

--- a/admin_api/nginx-snippet.conf
+++ b/admin_api/nginx-snippet.conf
@@ -46,6 +46,24 @@ location = /admin/pull-code/stream {
     proxy_read_timeout 1h;
 }
 
+# Refresh Aphydle (fire-and-forget; GET/POST)
+location = /admin/refresh-aphydle {
+    proxy_pass http://127.0.0.1:5001/admin/refresh-aphydle;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_read_timeout 15m;
+}
+
+# Refresh Aphydle streaming logs (SSE)
+location = /admin/refresh-aphydle/stream {
+    limit_except GET { deny all; }
+    proxy_pass http://127.0.0.1:5001/admin/refresh-aphydle/stream;
+    proxy_http_version 1.1;
+    proxy_set_header Connection "";
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_buffering off;
+    proxy_read_timeout 1h;
+}
+
 # Sync database schema (GET/POST)
 location = /admin/sync-schema {
     proxy_pass http://127.0.0.1:5001/admin/sync-schema;

--- a/plant-swipe/server.js
+++ b/plant-swipe/server.js
@@ -17998,6 +17998,99 @@ app.get('/api/admin/pull-code/stream', async (req, res) => {
   }
 })
 
+// Admin: stream Aphydle refresh logs via Server-Sent Events (SSE)
+app.get('/api/admin/refresh-aphydle/stream', async (req, res) => {
+  try {
+    const adminId = await ensureAdmin(req, res)
+    if (!adminId) return
+
+    res.setHeader('Content-Type', 'text/event-stream; charset=utf-8')
+    res.setHeader('Cache-Control', 'no-cache, no-transform')
+    res.setHeader('Connection', 'keep-alive')
+    res.setHeader('X-Accel-Buffering', 'no')
+    res.flushHeaders?.()
+
+    const send = (event, data) => {
+      try {
+        if (event) res.write(`event: ${event}\n`)
+        const payload = typeof data === 'string' ? data : JSON.stringify(data)
+        const lines = String(payload).split(/\r?\n/) || []
+        for (const line of lines) res.write(`data: ${line}\n`)
+        res.write('\n')
+      } catch { }
+    }
+
+    send('open', { ok: true, message: 'Starting Aphydle refresh…' })
+
+    const repoRoot = await getRepoRoot()
+
+    try {
+      const caller = await getUserFromRequest(req)
+      const callerId = caller?.id || null
+      let adminName = null
+      if (sql && callerId) {
+        try {
+          const rows = await sql`select coalesce(display_name, '') as name from public.profiles where id = ${callerId} limit 1`
+          adminName = (rows?.[0]?.name || '').trim() || null
+        } catch { }
+      }
+      let logged = false
+      if (sql) {
+        try { await sql`insert into public.admin_activity_logs (admin_id, admin_name, action, target, detail) values (${callerId}, ${adminName}, 'refresh_aphydle', ${null}, ${sql.json({ source: 'stream' })})`; logged = true } catch { }
+      }
+      if (!logged) {
+        try { await insertAdminActivityViaRest(req, { admin_id: callerId, admin_name: adminName, action: 'refresh_aphydle', target: null, detail: { source: 'stream' } }) } catch { }
+      }
+    } catch { }
+
+    const scriptPath = path.resolve(repoRoot, 'scripts', 'refresh-aphydle.sh')
+    try { await fs.access(scriptPath) } catch {
+      send('error', { error: `Aphydle refresh script not found at ${scriptPath}` })
+      res.end()
+      return
+    }
+    try { await fs.chmod(scriptPath, 0o755) } catch { }
+
+    const childEnv = { ...process.env, CI: process.env.CI || 'true', PLANTSWIPE_REPO_DIR: repoRoot }
+
+    const child = spawnChild(scriptPath, [], {
+      cwd: repoRoot,
+      env: childEnv,
+      shell: false,
+    })
+
+    const heartbeatId = setInterval(() => { try { res.write(': ping\n\n') } catch { } }, 15000)
+    let streamClosedGracefully = false
+
+    child.stdout?.on('data', (buf) => { send('log', buf.toString()) })
+    child.stderr?.on('data', (buf) => { send('log', buf.toString()) })
+    child.on('error', (err) => { send('error', { error: err?.message || 'spawn failed' }) })
+    child.on('close', (code) => {
+      const ok = code === 0
+      if (!streamClosedGracefully) {
+        send('done', { ok, code })
+      }
+      streamClosedGracefully = true
+      try { clearInterval(heartbeatId) } catch { }
+      try { res.end() } catch { }
+    })
+
+    req.on('close', () => {
+      if (streamClosedGracefully) return
+      try { clearInterval(heartbeatId) } catch { }
+      console.warn('[refresh-aphydle] SSE client disconnected; refresh continues in background.')
+    })
+  } catch (e) {
+    try { res.status(500).json({ error: e?.message || 'stream failed' }) } catch { }
+  }
+})
+
+app.options('/api/admin/refresh-aphydle/stream', (_req, res) => {
+  res.setHeader('Access-Control-Allow-Methods', 'GET,OPTIONS')
+  res.setHeader('Access-Control-Allow-Headers', 'Authorization, Content-Type')
+  res.status(204).end()
+})
+
 // Admin: list remote branches and current branch
 app.get('/api/admin/branches', async (req, res) => {
   try {

--- a/plant-swipe/src/pages/AdminPage.tsx
+++ b/plant-swipe/src/pages/AdminPage.tsx
@@ -858,6 +858,7 @@ export const AdminPage: React.FC = () => {
 
   const [restarting, setRestarting] = React.useState(false);
   const [pulling, setPulling] = React.useState(false);
+  const [refreshingAphydle, setRefreshingAphydle] = React.useState(false);
   const [consoleOpen, setConsoleOpen] = React.useState<boolean>(false);
   const [consoleLines, setConsoleLines] = React.useState<string[]>([]);
   const [reloadReady, setReloadReady] = React.useState<boolean>(false);
@@ -5109,6 +5110,120 @@ export const AdminPage: React.FC = () => {
     }
   };
 
+  const refreshAphydle = async () => {
+    if (refreshingAphydle) return;
+    setRefreshingAphydle(true);
+    try {
+      setConsoleLines([]);
+      setConsoleOpen(true);
+      appendConsole("[aphydle] Refresh Aphydle: starting…");
+
+      const session = (await supabase.auth.getSession()).data.session;
+      const token = session?.access_token;
+      let adminToken: string | null = null;
+      try {
+        adminToken =
+          ((globalThis as EnvWithAdminToken)?.__ENV__?.VITE_ADMIN_STATIC_TOKEN as
+            | string
+            | undefined
+            | null) || null;
+      } catch {
+        adminToken = null;
+      }
+      const sseHeaders: Record<string, string> = {};
+      if (token) sseHeaders["Authorization"] = `Bearer ${token}`;
+      if (adminToken) sseHeaders["X-Admin-Token"] = String(adminToken);
+      const adminSseHeaders: Record<string, string> = {};
+      if (adminToken) adminSseHeaders["X-Admin-Token"] = String(adminToken);
+      const adminJsonPostHeaders = {
+        ...adminSseHeaders,
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      };
+
+      let resp: Response | null = null;
+      try {
+        resp = await fetch("/api/admin/refresh-aphydle/stream", {
+          method: "GET",
+          headers: sseHeaders,
+          credentials: "same-origin",
+        });
+      } catch {}
+      if (!resp || !resp.ok || !resp.body) {
+        try {
+          resp = await fetch("/admin/refresh-aphydle/stream", {
+            method: "GET",
+            headers: adminSseHeaders,
+            credentials: "same-origin",
+          });
+        } catch {}
+      }
+      if (!resp || !resp.ok || !resp.body) {
+        const bg = await fetch("/admin/refresh-aphydle", {
+          method: "POST",
+          headers: adminJsonPostHeaders,
+          credentials: "same-origin",
+          body: "{}",
+        });
+        const bgBody = await safeJson(bg);
+        if (!bg.ok || bgBody?.ok !== true) {
+          throw new Error(bgBody?.error || `Aphydle refresh failed (${bg.status})`);
+        }
+        appendConsole("[aphydle] Started background refresh via Admin API.");
+        return;
+      }
+
+      const reader = resp.body.getReader();
+      const decoder = new TextDecoder();
+      let buf = "";
+      let currentEvent: string | null = null;
+      let sawDoneEvent = false;
+      let buildOk = false;
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buf += decoder.decode(value, { stream: true });
+        let idx;
+        while ((idx = buf.indexOf("\n")) >= 0) {
+          const raw = buf.slice(0, idx);
+          buf = buf.slice(idx + 1);
+          const line = raw.replace(/\r$/, "");
+          if (!line) continue;
+          if (line.startsWith("event:")) {
+            currentEvent = line.slice(6).trim();
+          } else if (line.startsWith("data:")) {
+            const payload = line.slice(5).trimStart();
+            if (currentEvent === "done") {
+              try {
+                const obj = JSON.parse(payload);
+                if (obj && typeof obj.ok === "boolean") {
+                  sawDoneEvent = true;
+                  buildOk = !!obj.ok;
+                }
+              } catch {}
+            }
+            appendConsole(payload);
+          } else if (!/^(:|event:|id:|retry:)/.test(line)) {
+            appendConsole(line);
+          }
+        }
+      }
+
+      if (sawDoneEvent && buildOk) {
+        appendConsole("[aphydle] ✓ Aphydle refresh complete.");
+      } else if (sawDoneEvent && !buildOk) {
+        appendConsole("[aphydle] ✗ Aphydle refresh failed. See logs above.");
+      } else {
+        appendConsole("[aphydle] Stream ended without terminal status.");
+      }
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : String(e);
+      appendConsole(`[aphydle] Failed to refresh Aphydle: ${message}`);
+    } finally {
+      setRefreshingAphydle(false);
+    }
+  };
+
   // Backup UI disabled for now
 
     // Loader for total registered accounts & plants (DB first via admin API; fallback to client count)
@@ -7627,7 +7742,7 @@ export const AdminPage: React.FC = () => {
                             <span className="text-sm font-semibold">Quick Actions</span>
                           </div>
                           {/* Action buttons */}
-                          <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+                          <div className="grid grid-cols-2 sm:grid-cols-5 gap-2">
                           <Button
                             className="rounded-xl w-full text-xs px-2 py-2 h-auto"
                             size="sm"
@@ -7649,6 +7764,19 @@ export const AdminPage: React.FC = () => {
                             <Github className="h-3.5 w-3.5 flex-shrink-0" />
                             <span className="truncate">
                               {pulling ? "Pulling..." : "Pull & Build"}
+                            </span>
+                          </Button>
+                          <Button
+                            className="rounded-xl w-full text-xs px-2 py-2 h-auto"
+                            size="sm"
+                            variant="secondary"
+                            onClick={refreshAphydle}
+                            disabled={refreshingAphydle}
+                            title="Pull latest Aphydle main and rebuild"
+                          >
+                            <Sprout className="h-3.5 w-3.5 flex-shrink-0" />
+                            <span className="truncate">
+                              {refreshingAphydle ? "Refreshing..." : "Refresh Aphydle"}
                             </span>
                           </Button>
                           <Button


### PR DESCRIPTION
Adds a Quick Actions button that pulls Aphydle's latest main and rebuilds, streaming the live output of scripts/refresh-aphydle.sh into the existing admin console - mirroring the Pull & Build flow.

- admin_api: /admin/refresh-aphydle and /admin/refresh-aphydle/stream (SSE)
- Node server.js: /api/admin/refresh-aphydle/stream proxy with admin auth
- nginx-snippet.conf: route the new admin paths to the Admin API
- AdminPage.tsx: refreshAphydle handler + button in the Quick Actions grid

https://claude.ai/code/session_0193vqzEPMxHyiHcRgwi6ABb