### PR TITLE
Reorganize admin panel: move Refresh Aphydle to main actions

### DIFF
--- a/plant-swipe/src/pages/AdminPage.tsx
+++ b/plant-swipe/src/pages/AdminPage.tsx
@@ -7550,6 +7550,18 @@ export const AdminPage: React.FC = () => {
                                 {gitPulling ? "Pulling..." : "Git Pull Only"}
                               </Button>
 
+                              {/* Refresh Aphydle Button */}
+                              <Button
+                                variant="outline"
+                                className="w-full rounded-xl justify-start gap-2"
+                                onClick={refreshAphydle}
+                                disabled={refreshingAphydle}
+                                title="Pull latest Aphydle main and rebuild"
+                              >
+                                <Sprout className={`h-4 w-4 ${refreshingAphydle ? "animate-pulse" : ""}`} />
+                                {refreshingAphydle ? "Refreshing..." : "Refresh Aphydle"}
+                              </Button>
+
                               {/* Clear Memory Button */}
                               <Button
                                 variant="outline"
@@ -7742,7 +7754,7 @@ export const AdminPage: React.FC = () => {
                             <span className="text-sm font-semibold">Quick Actions</span>
                           </div>
                           {/* Action buttons */}
-                          <div className="grid grid-cols-2 sm:grid-cols-5 gap-2">
+                          <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
                           <Button
                             className="rounded-xl w-full text-xs px-2 py-2 h-auto"
                             size="sm"
@@ -7764,19 +7776,6 @@ export const AdminPage: React.FC = () => {
                             <Github className="h-3.5 w-3.5 flex-shrink-0" />
                             <span className="truncate">
                               {pulling ? "Pulling..." : "Pull & Build"}
-                            </span>
-                          </Button>
-                          <Button
-                            className="rounded-xl w-full text-xs px-2 py-2 h-auto"
-                            size="sm"
-                            variant="secondary"
-                            onClick={refreshAphydle}
-                            disabled={refreshingAphydle}
-                            title="Pull latest Aphydle main and rebuild"
-                          >
-                            <Sprout className="h-3.5 w-3.5 flex-shrink-0" />
-                            <span className="truncate">
-                              {refreshingAphydle ? "Refreshing..." : "Refresh Aphydle"}
                             </span>
                           </Button>
                           <Button


### PR DESCRIPTION
## Summary
Reorganized the admin panel layout by moving the "Refresh Aphydle" button from the Quick Actions grid to the main action buttons section, and adjusted the grid layout accordingly.

## Key Changes
- Moved "Refresh Aphydle" button from Quick Actions grid (small button variant) to main action buttons section (full-width outline variant)
- Updated the Quick Actions grid from 5 columns to 4 columns on small screens (`sm:grid-cols-5` → `sm:grid-cols-4`)
- Changed button styling from secondary variant with small text to outline variant with full width and proper spacing
- Removed the truncate text handling as the new button layout provides more space

## Implementation Details
- The button maintains the same functionality (`refreshAphydle` callback and `refreshingAphydle` state)
- Visual feedback (pulse animation on the Sprout icon) is preserved
- The button is now more prominent in the main actions section, reflecting its importance as a primary admin operation
- Grid adjustment ensures the Quick Actions section remains properly balanced with 4 columns instead of 5

https://claude.ai/code/session_01Ueov6XXQjT1n3RXXXp13cw