### PR TITLE
Patch Aphydle for CORS image proxy and Aphylia branding

### DIFF
--- a/scripts/aphydle-patch-branding.mjs
+++ b/scripts/aphydle-patch-branding.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+// Patch the upstream Aphydle clone to use Aphylia/PlantSwipe branding.
+//
+// Why this exists:
+//   - Aphydle ships no favicon, so the browser's automatic /favicon.ico fetch
+//     404s in the console.
+//   - Its in-app brand mark is a CSS-grid mosaic leaf (`MosaicLeaf`) and we
+//     want every Aphylia surface to wear the same plant icon for consistency
+//     while Aphydle doesn't yet have its own art direction.
+//
+// What this does:
+//   - Inserts `<link rel="icon">` tags into Aphydle's `index.html` pointing
+//     at the PlantSwipe icons that scripts/refresh-aphydle.sh copies into
+//     dist/icons/ post-build.
+//   - Rewrites `src/components/ui/MosaicLeaf.jsx` so every callsite renders
+//     the PlantSwipe icon SVG instead of the procedural mosaic.
+//   - Idempotent (skip if marker present), and fails loudly if the upstream
+//     source no longer matches, so a future refactor can't silently regress.
+//
+// Invoked from scripts/refresh-aphydle.sh between `git pull` and `bun install`.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import process from "node:process";
+
+const APHYDLE_DIR = process.argv[2] || process.env.APHYDLE_DIR;
+if (!APHYDLE_DIR) {
+  console.error("[aphydle-branding] APHYDLE_DIR not provided (argv[2] or env)");
+  process.exit(2);
+}
+
+const MARKER = "__APHYLIA_BRANDING_PATCH__";
+
+// ── 1. Inject favicon links into index.html ──────────────────────────────────
+const INDEX_PATH = resolve(APHYDLE_DIR, "index.html");
+let indexHtml;
+try {
+  indexHtml = readFileSync(INDEX_PATH, "utf8");
+} catch (err) {
+  console.error(`[aphydle-branding] cannot read ${INDEX_PATH}: ${err.message}`);
+  process.exit(1);
+}
+
+if (indexHtml.includes(MARKER)) {
+  console.log(`[aphydle-branding] ${INDEX_PATH} already patched — skipping`);
+} else {
+  if (!indexHtml.includes("</head>")) {
+    console.error(`[aphydle-branding] ${INDEX_PATH} has no </head> tag — refusing to patch`);
+    process.exit(1);
+  }
+  const FAVICON_BLOCK = `    <!-- ${MARKER}: branding sourced from Aphylia/PlantSwipe; files copied into dist/icons/ post-build by scripts/refresh-aphydle.sh -->
+    <link rel="icon" type="image/svg+xml" href="/icons/plant-swipe-icon.svg" />
+    <link rel="icon" type="image/png" sizes="192x192" href="/icons/icon-192x192.png" />
+    <link rel="icon" type="image/png" sizes="512x512" href="/icons/icon-512x512.png" />
+    <link rel="apple-touch-icon" href="/icons/icon-192x192.png" />
+  </head>`;
+  indexHtml = indexHtml.replace("</head>", FAVICON_BLOCK);
+  writeFileSync(INDEX_PATH, indexHtml);
+  console.log(`[aphydle-branding] patched ${INDEX_PATH}`);
+}
+
+// ── 2. Replace MosaicLeaf with the Aphylia logo image ───────────────────────
+const LEAF_PATH = resolve(APHYDLE_DIR, "src/components/ui/MosaicLeaf.jsx");
+let leafSrc;
+try {
+  leafSrc = readFileSync(LEAF_PATH, "utf8");
+} catch (err) {
+  console.error(`[aphydle-branding] cannot read ${LEAF_PATH}: ${err.message}`);
+  process.exit(1);
+}
+
+if (leafSrc.includes(MARKER)) {
+  console.log(`[aphydle-branding] ${LEAF_PATH} already patched — skipping`);
+} else {
+  // Pin against the upstream signature so a meaningful refactor (e.g. someone
+  // renames the component or changes its prop shape) trips this script
+  // instead of silently leaving the Aphylia logo behind.
+  if (!/export\s+function\s+MosaicLeaf\s*\(/.test(leafSrc)) {
+    console.error(
+      `[aphydle-branding] FAILED: MosaicLeaf export not found in ${LEAF_PATH}. ` +
+        `Aphydle upstream has changed; update scripts/aphydle-patch-branding.mjs ` +
+        `before running refresh-aphydle.sh again.`,
+    );
+    process.exit(1);
+  }
+  const REPLACEMENT = `// ${MARKER}: rendered as the Aphylia/PlantSwipe icon so Aphydle and its host
+// share the same brand mark. The original procedural mosaic-leaf renderer
+// lives in git history if a standalone Aphydle ever needs it back.
+export function MosaicLeaf({ size = 22 }) {
+  const px = typeof size === "number" ? \`\${size}px\` : size;
+  return (
+    <img
+      src="/icons/plant-swipe-icon.svg"
+      alt="Aphylia"
+      width={size}
+      height={size}
+      style={{
+        width: px,
+        height: px,
+        display: "block",
+        objectFit: "contain",
+        userSelect: "none",
+        pointerEvents: "none",
+      }}
+      draggable={false}
+    />
+  );
+}
+`;
+  writeFileSync(LEAF_PATH, REPLACEMENT);
+  console.log(`[aphydle-branding] patched ${LEAF_PATH}`);
+}

--- a/scripts/aphydle-patch-branding.mjs
+++ b/scripts/aphydle-patch-branding.mjs
@@ -1,25 +1,28 @@
 #!/usr/bin/env node
-// Patch the upstream Aphydle clone to use Aphylia/PlantSwipe branding.
+// Patch the upstream Aphydle clone to wire the Aphylia/PlantSwipe brand mark
+// into the favicon and the in-app logo.
 //
 // Why this exists:
-//   - Aphydle ships no favicon, so the browser's automatic /favicon.ico fetch
-//     404s in the console.
-//   - Its in-app brand mark is a CSS-grid mosaic leaf (`MosaicLeaf`) and we
-//     want every Aphylia surface to wear the same plant icon for consistency
-//     while Aphydle doesn't yet have its own art direction.
+//   - Aphydle's upstream `index.html` ships no favicon, so the browser's
+//     automatic /favicon.ico fetch 404s in the console.
+//   - Its in-app brand mark is a procedural CSS-grid mosaic leaf
+//     (`MosaicLeaf`) and we want every Aphylia surface to wear the same
+//     plant icon while Aphydle doesn't yet have its own art direction.
 //
 // What this does:
-//   - Inserts `<link rel="icon">` tags into Aphydle's `index.html` pointing
-//     at the PlantSwipe icons that scripts/refresh-aphydle.sh copies into
-//     dist/icons/ post-build.
+//   - Inserts a `<link rel="icon">` into Aphydle's `index.html` pointing at
+//     `src/assets/FINAL.png`. The path is relative so Vite picks it up
+//     during build, hashes it, and emits a content-addressed asset URL.
 //   - Rewrites `src/components/ui/MosaicLeaf.jsx` so every callsite renders
-//     the PlantSwipe icon SVG instead of the procedural mosaic.
-//   - Idempotent (skip if marker present), and fails loudly if the upstream
-//     source no longer matches, so a future refactor can't silently regress.
+//     the same PNG via an ES-module import, again letting Vite hash and
+//     cache-bust the asset.
+//   - Idempotent (skip if marker present), and fails loudly if upstream
+//     Aphydle removes the assets or the MosaicLeaf export so a future
+//     refactor can't silently regress the branding.
 //
 // Invoked from scripts/refresh-aphydle.sh between `git pull` and `bun install`.
 
-import { readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import process from "node:process";
 
@@ -31,7 +34,20 @@ if (!APHYDLE_DIR) {
 
 const MARKER = "__APHYLIA_BRANDING_PATCH__";
 
-// ── 1. Inject favicon links into index.html ──────────────────────────────────
+// Aphydle ships the brand PNG at src/assets/FINAL.png. Bail loudly if it's
+// missing — the patch would otherwise build a bundle that 404s every icon.
+const ASSET_REL = "src/assets/FINAL.png";
+const ASSET_ABS = resolve(APHYDLE_DIR, ASSET_REL);
+if (!existsSync(ASSET_ABS)) {
+  console.error(
+    `[aphydle-branding] FAILED: ${ASSET_ABS} is missing. Update Aphydle ` +
+      `upstream so the brand asset exists, or change the path in ` +
+      `scripts/aphydle-patch-branding.mjs.`,
+  );
+  process.exit(1);
+}
+
+// ── 1. Inject favicon link into index.html ──────────────────────────────────
 const INDEX_PATH = resolve(APHYDLE_DIR, "index.html");
 let indexHtml;
 try {
@@ -48,11 +64,12 @@ if (indexHtml.includes(MARKER)) {
     console.error(`[aphydle-branding] ${INDEX_PATH} has no </head> tag — refusing to patch`);
     process.exit(1);
   }
-  const FAVICON_BLOCK = `    <!-- ${MARKER}: branding sourced from Aphylia/PlantSwipe; files copied into dist/icons/ post-build by scripts/refresh-aphydle.sh -->
-    <link rel="icon" type="image/svg+xml" href="/icons/plant-swipe-icon.svg" />
-    <link rel="icon" type="image/png" sizes="192x192" href="/icons/icon-192x192.png" />
-    <link rel="icon" type="image/png" sizes="512x512" href="/icons/icon-512x512.png" />
-    <link rel="apple-touch-icon" href="/icons/icon-192x192.png" />
+  // Relative path → Vite hashes the asset and rewrites href= to the emitted
+  // /assets/<hash>.png. Absolute /src/assets/... would bypass Vite asset
+  // handling and 404 in production.
+  const FAVICON_BLOCK = `    <!-- ${MARKER}: brand icon shared with Aphylia/PlantSwipe; Vite hashes and emits this on build -->
+    <link rel="icon" type="image/png" href="./${ASSET_REL}" />
+    <link rel="apple-touch-icon" href="./${ASSET_REL}" />
   </head>`;
   indexHtml = indexHtml.replace("</head>", FAVICON_BLOCK);
   writeFileSync(INDEX_PATH, indexHtml);
@@ -83,14 +100,18 @@ if (leafSrc.includes(MARKER)) {
     );
     process.exit(1);
   }
-  const REPLACEMENT = `// ${MARKER}: rendered as the Aphylia/PlantSwipe icon so Aphydle and its host
-// share the same brand mark. The original procedural mosaic-leaf renderer
-// lives in git history if a standalone Aphydle ever needs it back.
+  // Import path is relative to src/components/ui/MosaicLeaf.jsx
+  // (i.e. ../../assets/FINAL.png).
+  const REPLACEMENT = `// ${MARKER}: rendered as the shared Aphylia/PlantSwipe brand mark so Aphydle
+// and its host wear the same icon. The original procedural mosaic-leaf
+// renderer lives in git history if a standalone Aphydle ever needs it back.
+import aphyliaIcon from "../../assets/FINAL.png";
+
 export function MosaicLeaf({ size = 22 }) {
   const px = typeof size === "number" ? \`\${size}px\` : size;
   return (
     <img
-      src="/icons/plant-swipe-icon.svg"
+      src={aphyliaIcon}
       alt="Aphylia"
       width={size}
       height={size}

--- a/scripts/aphydle-patch-image-proxy.mjs
+++ b/scripts/aphydle-patch-image-proxy.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+// Patch the upstream Aphydle clone so image URLs from `plant_images.link` are
+// fetched through PlantSwipe's CORS-enabled image proxy.
+//
+// Why this exists:
+//   - Aphydle (a separate repo at github.com/Duckxel/Aphydle) talks to Supabase
+//     directly and renders `plant_images.link` URLs into a <canvas> via
+//     `img.crossOrigin = "anonymous"` (see Aphydle's PlantImage.jsx).
+//   - Many of those links point at third-party hosts (e.g.
+//     img.passeportsante.net) that don't send Access-Control-Allow-Origin,
+//     so the browser blocks the load with a CORS error and the puzzle image
+//     never appears.
+//   - PlantSwipe already exposes /api/image-proxy?url=<encoded> with permissive
+//     CORS headers (see plant-swipe/server.js). The previous attempt at fixing
+//     this only rewrote URLs in /api/plants responses, but Aphydle never calls
+//     that endpoint — it queries Supabase directly — so the fix never reached
+//     it.
+//
+// What this does:
+//   - Edits Aphydle's `src/lib/data.js` to make `pickImage()` route every URL
+//     it returns through `/api/image-proxy`, except hosts that already serve
+//     correct CORS (aphylia.app and *.supabase.co).
+//   - Idempotent: re-running on an already-patched file is a no-op.
+//   - Fails loudly if the function shape we depend on isn't present, so an
+//     upstream rename or refactor doesn't silently regress the fix.
+//
+// Invoked from scripts/refresh-aphydle.sh between `git pull` and `bun install`.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import process from "node:process";
+
+const APHYDLE_DIR = process.argv[2] || process.env.APHYDLE_DIR;
+if (!APHYDLE_DIR) {
+  console.error("[aphydle-patch] APHYDLE_DIR not provided (argv[2] or env)");
+  process.exit(2);
+}
+
+const TARGET = resolve(APHYDLE_DIR, "src/lib/data.js");
+const MARKER = "__APHYLIA_IMAGE_PROXY_PATCH__";
+
+let src;
+try {
+  src = readFileSync(TARGET, "utf8");
+} catch (err) {
+  console.error(`[aphydle-patch] cannot read ${TARGET}: ${err.message}`);
+  process.exit(1);
+}
+
+if (src.includes(MARKER)) {
+  console.log(`[aphydle-patch] ${TARGET} already patched — nothing to do`);
+  process.exit(0);
+}
+
+// Match the original pickImage definition. We pin against the exact upstream
+// body so a meaningful rename (e.g. someone changes the use-list ordering)
+// fails this script instead of letting the CORS regression slip through.
+const ORIGINAL = `function pickImage(images) {
+  if (!Array.isArray(images) || images.length === 0) return null;
+  for (const use of ["card", "cover", "hero", "thumbnail"]) {
+    const m = images.find((i) => i?.use === use && i?.link);
+    if (m) return m.link;
+  }
+  return images.find((i) => i?.link)?.link || null;
+}`;
+
+const REPLACEMENT = `function pickImage(images) {
+  // ${MARKER}: route third-party plant_images.link URLs through PlantSwipe's
+  // CORS-enabled /api/image-proxy so <img crossOrigin="anonymous"> succeeds on
+  // hosts that don't send Access-Control-Allow-Origin (e.g. passeportsante).
+  // Hosts that already serve correct CORS pass through untouched.
+  const _aphyliaWrap = (u) => {
+    if (!u || typeof u !== "string") return u;
+    let host;
+    try {
+      const parsed = new URL(u);
+      if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return u;
+      host = parsed.hostname.toLowerCase();
+    } catch {
+      return u;
+    }
+    if (
+      host === "aphylia.app" ||
+      host.endsWith(".aphylia.app") ||
+      host.endsWith(".supabase.co")
+    ) {
+      return u;
+    }
+    const base = (import.meta.env.VITE_APHYLIA_API_URL || "https://aphylia.app").replace(/\\/+$/, "");
+    return base + "/api/image-proxy?url=" + encodeURIComponent(u);
+  };
+  if (!Array.isArray(images) || images.length === 0) return null;
+  for (const use of ["card", "cover", "hero", "thumbnail"]) {
+    const m = images.find((i) => i?.use === use && i?.link);
+    if (m) return _aphyliaWrap(m.link);
+  }
+  return _aphyliaWrap(images.find((i) => i?.link)?.link || null);
+}`;
+
+if (!src.includes(ORIGINAL)) {
+  console.error(
+    `[aphydle-patch] FAILED: pickImage() in ${TARGET} no longer matches the ` +
+      `expected upstream shape. The Aphydle repo has likely changed; update ` +
+      `scripts/aphydle-patch-image-proxy.mjs to match the new function before ` +
+      `running refresh-aphydle.sh again, otherwise plant_images.link URLs will ` +
+      `regress to direct (CORS-blocked) fetches.`,
+  );
+  process.exit(1);
+}
+
+const patched = src.replace(ORIGINAL, REPLACEMENT);
+writeFileSync(TARGET, patched);
+console.log(`[aphydle-patch] patched ${TARGET}`);

--- a/scripts/refresh-aphydle.sh
+++ b/scripts/refresh-aphydle.sh
@@ -164,6 +164,22 @@ PY
   fi
 fi
 
+# ── 3b. patch Aphydle source for image proxy ────────────────────────────────
+# Aphydle queries Supabase directly for plant_images.link and renders the URL
+# into a <canvas> via crossOrigin="anonymous" — third-party hosts that don't
+# send Access-Control-Allow-Origin (e.g. img.passeportsante.net) make every
+# load fail CORS. The patcher rewrites pickImage() to route those URLs through
+# PlantSwipe's /api/image-proxy. Idempotent, fails loudly if upstream changes.
+APHYDLE_PATCHER="$WORK_DIR/scripts/aphydle-patch-image-proxy.mjs"
+if [[ -f "$APHYDLE_PATCHER" && -f "$APHYDLE_DIR/src/lib/data.js" ]]; then
+  log "Patching Aphydle source for image-proxy CORS wrapping…"
+  if [[ "$EUID" -eq 0 ]]; then
+    sudo -u "$REPO_OWNER" -H node "$APHYDLE_PATCHER" "$APHYDLE_DIR"
+  else
+    node "$APHYDLE_PATCHER" "$APHYDLE_DIR"
+  fi
+fi
+
 # ── 4. locate Bun ────────────────────────────────────────────────────────────
 OWNER_HOME="$(getent passwd "$REPO_OWNER" | cut -d: -f6 2>/dev/null || echo "$HOME")"
 OWNER_BUN_DIR="$OWNER_HOME/.bun/bin"
@@ -224,6 +240,31 @@ fi
 if [[ ! -d "$APHYDLE_DIR/dist" ]]; then
   echo "[ERROR] Aphydle build did not produce $APHYDLE_DIR/dist" >&2
   exit 1
+fi
+
+# ── 5b. ensure favicon.ico is present in dist ───────────────────────────────
+# Aphydle's upstream repo ships no favicon, so the browser-issued GET for
+# /favicon.ico 404s (visible in the Aphydle browser console). Reuse the
+# PlantSwipe app icon so the app reports a green console without dragging
+# Aphydle into PlantSwipe-specific deploy assets.
+APHYDLE_FAVICON_DEST="$APHYDLE_DIR/dist/favicon.ico"
+APHYDLE_FAVICON_SRC=""
+for candidate in \
+  "$WORK_DIR/plant-swipe/public/icons/icon-192x192.png" \
+  "$WORK_DIR/plant-swipe/public/favicon.ico"; do
+  if [[ -f "$candidate" ]]; then APHYDLE_FAVICON_SRC="$candidate"; break; fi
+done
+if [[ -n "$APHYDLE_FAVICON_SRC" ]]; then
+  log "Installing favicon.ico into Aphydle dist (from $APHYDLE_FAVICON_SRC)"
+  if [[ "$EUID" -eq 0 ]]; then
+    sudo -u "$REPO_OWNER" -H install -m 0644 "$APHYDLE_FAVICON_SRC" "$APHYDLE_FAVICON_DEST" || \
+      log "[WARN] Failed to install Aphydle favicon"
+  else
+    install -m 0644 "$APHYDLE_FAVICON_SRC" "$APHYDLE_FAVICON_DEST" || \
+      log "[WARN] Failed to install Aphydle favicon"
+  fi
+else
+  log "[WARN] No PlantSwipe favicon source found; Aphydle /favicon.ico will 404."
 fi
 
 # ── 6. ensure /var/www/Aphydle symlink ──────────────────────────────────────

--- a/scripts/refresh-aphydle.sh
+++ b/scripts/refresh-aphydle.sh
@@ -256,41 +256,16 @@ if [[ ! -d "$APHYDLE_DIR/dist" ]]; then
   exit 1
 fi
 
-# ── 5b. install Aphylia branding into dist ──────────────────────────────────
-# Aphydle's upstream repo ships no icons, so:
-#   - the browser-issued GET for /favicon.ico 404s (visible in the console)
-#   - the patched index.html (<link rel="icon" href="/icons/...">) and the
-#     patched MosaicLeaf (<img src="/icons/plant-swipe-icon.svg">) need the
-#     same files reachable on Aphydle's origin (CSS/<img> can't reach across
-#     to aphylia.app without CORS we don't want to manage for icons).
-# Copy PlantSwipe's icons/ directory into dist/icons/ and drop a same-origin
-# /favicon.ico for the browser's automatic request. Idempotent; cp -fL handles
-# repeated refreshes without fuss.
-APHYDLE_ICON_SRC_DIR="$WORK_DIR/plant-swipe/public/icons"
-APHYDLE_ICON_DEST_DIR="$APHYDLE_DIR/dist/icons"
-if [[ -d "$APHYDLE_ICON_SRC_DIR" ]]; then
-  log "Copying Aphylia icons into Aphydle dist ($APHYDLE_ICON_SRC_DIR → $APHYDLE_ICON_DEST_DIR)"
-  if [[ "$EUID" -eq 0 ]]; then
-    sudo -u "$REPO_OWNER" -H mkdir -p "$APHYDLE_ICON_DEST_DIR"
-    sudo -u "$REPO_OWNER" -H cp -fL "$APHYDLE_ICON_SRC_DIR"/* "$APHYDLE_ICON_DEST_DIR/" || \
-      log "[WARN] Failed to copy Aphylia icons into Aphydle dist"
-  else
-    mkdir -p "$APHYDLE_ICON_DEST_DIR"
-    cp -fL "$APHYDLE_ICON_SRC_DIR"/* "$APHYDLE_ICON_DEST_DIR/" || \
-      log "[WARN] Failed to copy Aphylia icons into Aphydle dist"
-  fi
-else
-  log "[WARN] $APHYDLE_ICON_SRC_DIR not found; Aphydle branding icons missing."
-fi
-
+# ── 5b. drop a same-origin favicon.ico for the browser's auto-fetch ─────────
+# Even with `<link rel="icon">` in index.html (injected by aphydle-patch-
+# branding.mjs and hashed by Vite into dist/assets/<hash>.png), some clients
+# still poke /favicon.ico — copy the upstream brand asset there so the
+# console stays clean. The hashed dist asset and the in-app <MosaicLeaf>
+# image don't need any post-build copy: Vite already emits and references
+# them via src/assets/FINAL.png.
 APHYDLE_FAVICON_DEST="$APHYDLE_DIR/dist/favicon.ico"
-APHYDLE_FAVICON_SRC=""
-for candidate in \
-  "$WORK_DIR/plant-swipe/public/icons/icon-192x192.png" \
-  "$WORK_DIR/plant-swipe/public/favicon.ico"; do
-  if [[ -f "$candidate" ]]; then APHYDLE_FAVICON_SRC="$candidate"; break; fi
-done
-if [[ -n "$APHYDLE_FAVICON_SRC" ]]; then
+APHYDLE_FAVICON_SRC="$APHYDLE_DIR/src/assets/FINAL.png"
+if [[ -f "$APHYDLE_FAVICON_SRC" ]]; then
   log "Installing favicon.ico into Aphydle dist (from $APHYDLE_FAVICON_SRC)"
   if [[ "$EUID" -eq 0 ]]; then
     sudo -u "$REPO_OWNER" -H install -m 0644 "$APHYDLE_FAVICON_SRC" "$APHYDLE_FAVICON_DEST" || \
@@ -300,7 +275,7 @@ if [[ -n "$APHYDLE_FAVICON_SRC" ]]; then
       log "[WARN] Failed to install Aphydle favicon"
   fi
 else
-  log "[WARN] No PlantSwipe favicon source found; Aphydle /favicon.ico will 404."
+  log "[WARN] $APHYDLE_FAVICON_SRC not found; Aphydle /favicon.ico will 404."
 fi
 
 # ── 6. ensure /var/www/Aphydle symlink ──────────────────────────────────────

--- a/scripts/refresh-aphydle.sh
+++ b/scripts/refresh-aphydle.sh
@@ -164,7 +164,7 @@ PY
   fi
 fi
 
-# ── 3b. patch Aphydle source for image proxy ────────────────────────────────
+# ── 3b. patch Aphydle source for image proxy + Aphylia branding ────────────
 # Aphydle queries Supabase directly for plant_images.link and renders the URL
 # into a <canvas> via crossOrigin="anonymous" — third-party hosts that don't
 # send Access-Control-Allow-Origin (e.g. img.passeportsante.net) make every
@@ -177,6 +177,20 @@ if [[ -f "$APHYDLE_PATCHER" && -f "$APHYDLE_DIR/src/lib/data.js" ]]; then
     sudo -u "$REPO_OWNER" -H node "$APHYDLE_PATCHER" "$APHYDLE_DIR"
   else
     node "$APHYDLE_PATCHER" "$APHYDLE_DIR"
+  fi
+fi
+
+# Branding: drop in the Aphylia favicon links and replace the procedural
+# MosaicLeaf with the PlantSwipe icon SVG. Aphylia/PlantSwipe icon files are
+# copied into dist/icons/ after build (step 5b below) so the patched paths
+# resolve at runtime.
+APHYDLE_BRANDING_PATCHER="$WORK_DIR/scripts/aphydle-patch-branding.mjs"
+if [[ -f "$APHYDLE_BRANDING_PATCHER" && -f "$APHYDLE_DIR/index.html" ]]; then
+  log "Patching Aphydle source for Aphylia branding (favicon + logo)…"
+  if [[ "$EUID" -eq 0 ]]; then
+    sudo -u "$REPO_OWNER" -H node "$APHYDLE_BRANDING_PATCHER" "$APHYDLE_DIR"
+  else
+    node "$APHYDLE_BRANDING_PATCHER" "$APHYDLE_DIR"
   fi
 fi
 
@@ -242,11 +256,33 @@ if [[ ! -d "$APHYDLE_DIR/dist" ]]; then
   exit 1
 fi
 
-# ── 5b. ensure favicon.ico is present in dist ───────────────────────────────
-# Aphydle's upstream repo ships no favicon, so the browser-issued GET for
-# /favicon.ico 404s (visible in the Aphydle browser console). Reuse the
-# PlantSwipe app icon so the app reports a green console without dragging
-# Aphydle into PlantSwipe-specific deploy assets.
+# ── 5b. install Aphylia branding into dist ──────────────────────────────────
+# Aphydle's upstream repo ships no icons, so:
+#   - the browser-issued GET for /favicon.ico 404s (visible in the console)
+#   - the patched index.html (<link rel="icon" href="/icons/...">) and the
+#     patched MosaicLeaf (<img src="/icons/plant-swipe-icon.svg">) need the
+#     same files reachable on Aphydle's origin (CSS/<img> can't reach across
+#     to aphylia.app without CORS we don't want to manage for icons).
+# Copy PlantSwipe's icons/ directory into dist/icons/ and drop a same-origin
+# /favicon.ico for the browser's automatic request. Idempotent; cp -fL handles
+# repeated refreshes without fuss.
+APHYDLE_ICON_SRC_DIR="$WORK_DIR/plant-swipe/public/icons"
+APHYDLE_ICON_DEST_DIR="$APHYDLE_DIR/dist/icons"
+if [[ -d "$APHYDLE_ICON_SRC_DIR" ]]; then
+  log "Copying Aphylia icons into Aphydle dist ($APHYDLE_ICON_SRC_DIR → $APHYDLE_ICON_DEST_DIR)"
+  if [[ "$EUID" -eq 0 ]]; then
+    sudo -u "$REPO_OWNER" -H mkdir -p "$APHYDLE_ICON_DEST_DIR"
+    sudo -u "$REPO_OWNER" -H cp -fL "$APHYDLE_ICON_SRC_DIR"/* "$APHYDLE_ICON_DEST_DIR/" || \
+      log "[WARN] Failed to copy Aphylia icons into Aphydle dist"
+  else
+    mkdir -p "$APHYDLE_ICON_DEST_DIR"
+    cp -fL "$APHYDLE_ICON_SRC_DIR"/* "$APHYDLE_ICON_DEST_DIR/" || \
+      log "[WARN] Failed to copy Aphylia icons into Aphydle dist"
+  fi
+else
+  log "[WARN] $APHYDLE_ICON_SRC_DIR not found; Aphydle branding icons missing."
+fi
+
 APHYDLE_FAVICON_DEST="$APHYDLE_DIR/dist/favicon.ico"
 APHYDLE_FAVICON_SRC=""
 for candidate in \


### PR DESCRIPTION
## Summary

This PR adds automated patching of the upstream Aphydle clone to integrate it with PlantSwipe's infrastructure. Two new patcher scripts handle CORS-blocked plant images and unified branding across Aphylia surfaces.

## Key Changes

- **Image Proxy Patching** (`aphydle-patch-image-proxy.mjs`): Rewrites Aphydle's `pickImage()` function to route third-party plant image URLs through PlantSwipe's `/api/image-proxy` endpoint, bypassing CORS failures on hosts like `img.passeportsante.net`. Whitelists hosts that already serve correct CORS headers (aphylia.app and Supabase).

- **Branding Patching** (`aphydle-patch-branding.mjs`): 
  - Injects favicon `<link>` tags into Aphydle's `index.html` pointing to the shared brand asset (`src/assets/FINAL.png`)
  - Replaces the procedural `MosaicLeaf` component with an `<img>` rendering of the Aphylia icon, ensuring consistent branding across Aphydle and PlantSwipe

- **Build Integration** (`refresh-aphydle.sh`): 
  - Invokes both patchers after pulling upstream Aphydle changes
  - Copies the brand asset to `dist/favicon.ico` post-build to satisfy browser auto-fetch requests

## Implementation Details

- Both patchers are **idempotent**: they skip if a marker comment is already present, allowing safe re-runs
- **Fail-safe design**: Each patcher validates that expected upstream code signatures exist before patching, preventing silent regressions if Aphydle's structure changes
- **Asset handling**: Uses relative paths so Vite hashes assets during build and emits content-addressed URLs, enabling proper cache-busting
- **CORS whitelist**: The image proxy wrapper intelligently skips wrapping for same-origin and Supabase URLs to avoid unnecessary proxying

https://claude.ai/code/session_01PhQr5kMuPDXQquZZEFhvSK