### PR TITLE
Replace git pull with fetch + hard reset to handle local modifications

### DIFF
--- a/scripts/refresh-aphydle.sh
+++ b/scripts/refresh-aphydle.sh
@@ -115,13 +115,29 @@ if [[ ! -d "$APHYDLE_DIR/.git" ]]; then
   fi
 fi
 
-# ── 2. git pull ──────────────────────────────────────────────────────────────
+# ── 2. git fetch + hard reset ────────────────────────────────────────────────
+# Fetch+reset (not pull --ff-only): the patchers below modify tracked files
+# (src/lib/data.js, index.html). Those edits are idempotent and re-applied
+# every run, so discarding them before pulling is safe — and avoids the
+# "local changes would be overwritten by merge" abort that would otherwise
+# leave the checkout stuck on an old commit missing newly-committed assets
+# (e.g. src/assets/FINAL.png).
 if [[ "$SKIP_PULL" != "true" ]]; then
   log "Pulling latest Aphydle…"
   if [[ "$EUID" -eq 0 ]]; then
-    sudo -u "$REPO_OWNER" -H git -C "$APHYDLE_DIR" pull --ff-only || log "[WARN] git pull failed; continuing with current checkout."
+    APHYDLE_BRANCH="$(sudo -u "$REPO_OWNER" -H git -C "$APHYDLE_DIR" symbolic-ref --short HEAD 2>/dev/null || true)"
   else
-    git -C "$APHYDLE_DIR" pull --ff-only || log "[WARN] git pull failed; continuing with current checkout."
+    APHYDLE_BRANCH="$(git -C "$APHYDLE_DIR" symbolic-ref --short HEAD 2>/dev/null || true)"
+  fi
+  [[ -n "$APHYDLE_BRANCH" && "$APHYDLE_BRANCH" != "HEAD" ]] || APHYDLE_BRANCH="main"
+  if [[ "$EUID" -eq 0 ]]; then
+    sudo -u "$REPO_OWNER" -H git -C "$APHYDLE_DIR" fetch origin "$APHYDLE_BRANCH" \
+      && sudo -u "$REPO_OWNER" -H git -C "$APHYDLE_DIR" reset --hard "origin/$APHYDLE_BRANCH" \
+      || log "[WARN] git fetch/reset failed; continuing with current checkout."
+  else
+    git -C "$APHYDLE_DIR" fetch origin "$APHYDLE_BRANCH" \
+      && git -C "$APHYDLE_DIR" reset --hard "origin/$APHYDLE_BRANCH" \
+      || log "[WARN] git fetch/reset failed; continuing with current checkout."
   fi
 else
   log "Skipping git pull (--skip-pull)"


### PR DESCRIPTION
## Summary
Changed the git update strategy in the refresh script from `git pull --ff-only` to `git fetch` followed by `git reset --hard`. This allows the script to safely discard local modifications to tracked files before updating, preventing merge conflicts that would leave the repository in a stale state.

## Key Changes
- Replaced `git pull --ff-only` with a two-step process: `git fetch origin <branch>` followed by `git reset --hard origin/<branch>`
- Added logic to detect the current branch name using `git symbolic-ref --short HEAD`, defaulting to "main" if detection fails
- Updated error handling to report "git fetch/reset failed" instead of "git pull failed"
- Added detailed comments explaining why this approach is necessary: the patchers below modify tracked files (src/lib/data.js, index.html) with idempotent changes that are re-applied every run, so discarding them is safe and prevents the checkout from getting stuck on old commits missing newly-committed assets

## Implementation Details
- Branch detection is wrapped in error suppression (`2>/dev/null || true`) to gracefully handle detached HEAD states
- The fetch and reset operations are chained with `&&` so reset only runs if fetch succeeds
- Both root (sudo) and non-root execution paths are updated consistently
- The approach maintains backward compatibility with the `--skip-pull` flag

https://claude.ai/code/session_01WZXQdN7DPMcjq19LK5vgHW