### PR TITLE
docs(db-audit): weekly DB governance audit — 2026-04-28

### DIFF
--- a/docs/db-audit/2026-04-28.md
+++ b/docs/db-audit/2026-04-28.md
@@ -1,0 +1,96 @@
+# Weekly DB Governance Audit — 2026-04-28
+
+## Summary
+- PRs reviewed: 14 merged into `main` between 2026-04-21 and 2026-04-28
+- Commits reviewed: 44 non-merge commits on `main`
+- DB-related PRs: 1 (#1448 `claude/add-plant-history-tracking-LKdvy`, with several follow-up commits on `main`)
+- New or changed DB surfaces: 4 (`plant_history`, `plant_admin_notes`, `plant_contributors` restructure, `plants.admin_commentary` drop)
+- Critical issues: 0
+- Warnings: 2 (Supabase CLI not available in audit env; `is_admin` bypass policy on `plant_admin_notes` allows any admin/editor to edit/delete *any* note — by design but worth restating)
+
+## Scope walked
+Files in scope checked across the last 7 days on `main`:
+
+- `plant-swipe/supabase/sync_parts/03_plants_and_colors.sql` (modified)
+- `plant-swipe/supabase/sync_parts/01_extensions_and_setup.sql` (`allowed_tables` updated)
+- `plant-swipe/supabase/DATABASE_SCHEMA.md` (modified)
+- `plant-swipe/supabase/migrations/20260422000000_migrate_admin_commentary_to_notes.sql` (new)
+- `plant-swipe/supabase/migrations/20260422100000_backfill_plant_contributor_ids.sql` (new)
+- `plant-swipe/server.js` (GDPR data-export queries no longer project `plants.admin_commentary`; `plant-reports` approval credits the reporter as a contributor by profile id)
+- `plant-swipe/src/**` (typed model + UI changes; no new persisted surfaces beyond what the SQL above covers)
+
+No DB-touching changes detected this week in `admin_api/**`, `EXTERNAL_APIS.md`, `plant-swipe/SECURITY_AUDIT_REPORT.md`, `AGENTS.md`, or `plant-swipe/README.md`.
+
+The remaining merged PRs (#1436, #1437, #1438, #1439, #1440, #1441, #1442, #1443, #1444, #1445, #1446, #1447, #1449) touched UI / mobile layout, scan upload UX, CI / release housekeeping, GDPR weekly audit doc + resolutions, or one-line refactors — none altered persisted DB shape, RLS, or storage policy.
+
+---
+
+## Repo Sync Health
+
+### Correct
+- `plant_history` table created in `sync_parts/03_plants_and_colors.sql:2219` with the right shape (`plant_id text` FK to `plants(id)` ON DELETE CASCADE — fix `5e71a2f` corrected the initial UUID typo).
+- `plant_admin_notes` table created in `sync_parts/03_plants_and_colors.sql:2273` with matching `plant_id text` FK.
+- Both new tables are listed in `allowed_tables` (`sync_parts/01_extensions_and_setup.sql:97-98`), so the public-schema cleanup loop will not drop them.
+- `plant_contributors` rebuilt to id-only schema (`sync_parts/03_plants_and_colors.sql:1635-1703`):
+  - `contributor_id uuid NOT NULL` with `ON DELETE CASCADE`.
+  - `contributor_name` and the legacy `id-or-name` check constraint removed via an idempotent cleanup block (line 1641-1657).
+  - Single unique `(plant_id, contributor_id)` replaces the two prior partial uniques.
+- `plants.admin_commentary` is dropped in three locations (CREATE TABLE definition removed at line 287, Phase-1 add-if-missing whitelist updated, Phase-4 explicit `drop column if exists` at the matching block).
+- `plant_history.old_value` / `new_value` are dropped via `alter table ... drop column if exists` at `03_plants_and_colors.sql:2233-2234` so already-deployed environments converge.
+- Supplemental migration files `20260422000000_migrate_admin_commentary_to_notes.sql` (one note per newline, idempotent per plant) and `20260422100000_backfill_plant_contributor_ids.sql` (case-insensitive name → profile id) match the sync model and are both idempotent.
+
+### Missing / stale
+- None for surfaces merged to `main` this week. No new table introduced via migration that is missing from `sync_parts`. No new column on a production migration that is missing from `sync_parts`.
+
+---
+
+## Documentation Health
+
+### Up to date
+- `DATABASE_SCHEMA.md:1069-1083` — `plant_history` documented (table shape, RLS, immutability, no-snapshot rationale).
+- `DATABASE_SCHEMA.md:1085-1098` — `plant_admin_notes` documented (CRUD by admins, mirrored into `plant_history`).
+- `DATABASE_SCHEMA.md:984-996` — `plant_contributors` rewritten to reflect the id-only shape and the join used to resolve display names.
+- `DATABASE_SCHEMA.md:101-104` — Plant catalog table-listing rows added/updated for the two new tables.
+- `DATABASE_SCHEMA.md:34-36` — Recent Updates entries added for the three Apr 22 / Apr 23 schema changes.
+- `DATABASE_SCHEMA.md:835` — `admin_commentary` column noted as removed in the `plants` CREATE example.
+
+### Missing / stale
+- None on `main`. (Note: `plant-swipe/SECURITY_AUDIT_REPORT.md` was not modified; the new admin-only tables don't change the security posture summarized there because they reuse the existing admin/editor RLS pattern, but a future refresh could mention them explicitly.)
+
+---
+
+## Supabase Health
+- `migration list --linked`: **NOT RUN** — the Supabase CLI is not installed in this audit environment. Manually re-run from a workstation with `SUPABASE_ACCESS_TOKEN` configured before the next deploy.
+- `db lint`: **NOT RUN** — same reason. Static review of the new SQL did not flag any obvious lint issues (FKs, indexes, RLS, and policies are well-formed; helper functions `public.is_admin_user` and `public.has_any_role` exist in `sync_parts/02_profiles_and_purge.sql`).
+- `db diff --linked --schema public,storage,auth`: **NOT RUN** — same reason.
+- Migration ordering on `main`: the two new files use distinct timestamps (`20260422000000_migrate_admin_commentary_to_notes.sql`, `20260422100000_backfill_plant_contributor_ids.sql`), so no duplicate-timestamp collision against what is currently merged.
+  - Heads-up for the next merge window: the working branch (`claude/nifty-hawking-ZH4vD`) carries an unmerged migration `20260422000000_prevent_self_admin_escalation.sql` whose timestamp **collides** with `20260422000000_migrate_admin_commentary_to_notes.sql` already on `main`. Whoever merges that branch must rename the new migration (e.g. `20260422000003_*`) to avoid `MIGRATION_HISTORY_MISMATCH`.
+
+---
+
+## Security / Policy Audit
+
+### Good
+- **`plant_history`** — RLS enabled (`03_plants_and_colors.sql:2238`). Policies scoped to `is_admin = true` OR `has_any_role(...,['admin','editor'])`. Only `select` and `insert` policies exist; no `update`/`delete` policy means rows are **immutable from authenticated callers** (matches the documented "history is insert-only" intent).
+- **`plant_admin_notes`** — RLS enabled (`03_plants_and_colors.sql:2287`). Four policies (select/insert/update/delete), each gated on the same admin-or-editor check, with `WITH CHECK` mirroring `USING` on update/insert.
+- **`plant_contributors`** — RLS enabled. SELECT is open to `authenticated, anon` (intended: contributor lists are public on plant pages). Write policy is admin/editor only with `WITH CHECK` matching the read predicate.
+- **No `auth.uid()`-bypassing functions** introduced this week. No new `SECURITY DEFINER` function. No new `GRANT` statements for `anon`/`authenticated` beyond what the existing pattern provides.
+- **Ownership/purge path** — both new tables FK-cascade off `plants(id)`, so plant deletion cleans up history and notes automatically. `author_id` uses `ON DELETE SET NULL`, so a profile deletion preserves the audit row but with `author_id = NULL`; the UI renders these as "Unknown". This is consistent with the existing GDPR purge flow (see `02_profiles_and_purge.sql`).
+- **Plant deletion → contributor cascade** — `plant_contributors.contributor_id` is now `ON DELETE CASCADE` on both sides (plant + profile), so a profile deletion no longer leaves orphan rows. Acceptable trade-off given the snapshot column was removed.
+
+### Review
+- **`plant_admin_notes` "edit/delete any note"** — by product spec, any admin/editor can edit or delete any other admin's note. No tamper-evident per-note ownership check. The mirroring into `plant_history` (`note_edit` / `note_delete`) is the only audit trail. This is acceptable for a small editorial team, but flagging so it shows up in the next access-control review if the editor pool grows.
+- **`plant_history` immutability is enforced only at the policy level**. A future `SECURITY DEFINER` helper that touches `plant_history` would bypass RLS — keep an eye on it.
+
+### Problems
+- None.
+
+---
+
+## Action Required
+- Run `supabase migration list --linked`, `supabase db lint`, and `supabase db diff --linked --schema public,storage,auth` from a workstation with the Supabase access token before the next production deploy and attach the output to the next weekly audit. This audit could not execute them locally.
+- When rebasing/merging the `claude/nifty-hawking-ZH4vD` branch (or any branch carrying `20260422000000_prevent_self_admin_escalation.sql`), rename that migration to a unique timestamp (e.g. `20260422000003_*`) before merge to avoid a `MIGRATION_HISTORY_MISMATCH` against `main`.
+
+## Human Review Needed
+- Confirm the "any admin/editor can edit/delete any note" rule on `plant_admin_notes` is still the desired product behaviour. If editorial volume grows, consider tightening to author-only updates with a separate `admin` override.
+- Confirm that `plant_contributors.contributor_id ON DELETE CASCADE` is the intended GDPR-purge behaviour for a plant's contributor list (deleting a profile silently removes the contribution credit). The previous `SET NULL` + name snapshot preserved attribution as "Unknown"; the new model removes the row entirely.


### PR DESCRIPTION
## Summary
Weekly DB governance audit covering merges to `main` between 2026-04-21 and 2026-04-28.

DB-related work merged this week (PR #1448 + follow-ups):
- New `plant_history` table (insert-only admin/editor change log).
- New `plant_admin_notes` table (chat-style editorial notes; replaces `plants.admin_commentary`).
- `plant_contributors` rebuilt to id-only (`contributor_id NOT NULL`, `ON DELETE CASCADE`); legacy `contributor_name` and `id-or-name` constraint dropped.
- `plants.admin_commentary` dropped; `plant_history.old_value` / `new_value` dropped (compaction).
- Two new migrations: `20260422000000_migrate_admin_commentary_to_notes.sql`, `20260422100000_backfill_plant_contributor_ids.sql`.

## Findings
- Critical issues: 0
- Warnings: 2
  - Supabase CLI is unavailable in the audit environment, so `migration list --linked`, `db lint`, and `db diff --linked` were **not** executed. Re-run from a workstation before the next deploy.
  - Heads-up: an unmerged sibling branch (`claude/nifty-hawking-ZH4vD` itself, in fact) carries `20260422000000_prevent_self_admin_escalation.sql` whose timestamp **collides** with `20260422000000_migrate_admin_commentary_to_notes.sql` already on `main`. That migration must be renamed (e.g. `20260422000003_*`) before merge to avoid `MIGRATION_HISTORY_MISMATCH`.

Sync (`sync_parts/01_extensions_and_setup.sql:97-98`), docs (`DATABASE_SCHEMA.md:1069-1098`, `:984-996`, `:34-36`, `:101-104`), RLS (admin/editor scoped on both new tables; `plant_history` immutable from authenticated callers), and FK cascade behaviour all check out.

## Test plan
- [x] `git log main --since="2026-04-21" -- plant-swipe/supabase/` reviewed
- [x] `plant_history` / `plant_admin_notes` definitions inspected (`sync_parts/03_plants_and_colors.sql:2219`, `:2273`)
- [x] `allowed_tables` checked for both new tables (`sync_parts/01_extensions_and_setup.sql:97-98`)
- [x] `DATABASE_SCHEMA.md` checked for both new tables and the `plant_contributors` rewrite
- [x] RLS policies for `plant_history`, `plant_admin_notes`, `plant_contributors` reviewed
- [ ] `supabase migration list --linked` — run from a workstation
- [ ] `supabase db lint` — run from a workstation
- [ ] `supabase db diff --linked --schema public,storage,auth` — run from a workstation

https://claude.ai/code/session_01SbCxGjbpduhNQ16qhojX98

---
_Generated by [Claude Code](https://claude.ai/code/session_01SbCxGjbpduhNQ16qhojX98)_