### PR TITLE
Add Aphydle sister app analytics & cross-promotion

### DIFF
--- a/plant-swipe/public/locales/en/Landing.json
+++ b/plant-swipe/public/locales/en/Landing.json
@@ -263,6 +263,13 @@
     "ctaDownload": "Download Aphylia",
     "ctaDocs": "View docs"
   },
+  "aphydle": {
+    "eyebrow": "From the Aphylia team",
+    "title": "Aphydle",
+    "tagline": "Daily plant guessing game",
+    "description": "A new mystery plant every day. Use progressive botanical clues — foliage, habitat, family — to guess the species before you run out of tries.",
+    "cta": "Play Aphydle"
+  },
   "footer": {
     "about": "About",
     "blog": "Blog",

--- a/plant-swipe/public/locales/en/Landing.json
+++ b/plant-swipe/public/locales/en/Landing.json
@@ -268,7 +268,8 @@
     "title": "Aphydle",
     "tagline": "Daily plant guessing game",
     "description": "A new mystery plant every day. Use progressive botanical clues — foliage, habitat, family — to guess the species before you run out of tries.",
-    "cta": "Play Aphydle"
+    "cta": "Play Aphydle",
+    "tease": "Can you guess what's growing today?"
   },
   "footer": {
     "about": "About",

--- a/plant-swipe/public/locales/fr/Landing.json
+++ b/plant-swipe/public/locales/fr/Landing.json
@@ -263,6 +263,13 @@
     "ctaDocs": "Voir la documentation",
     "socialText": "Connectons-nous ! Nous adorons avoir de vos nouvelles"
   },
+  "aphydle": {
+    "eyebrow": "Par l'équipe Aphylia",
+    "title": "Aphydle",
+    "tagline": "Le jeu de devinette de plantes quotidien",
+    "description": "Une nouvelle plante mystère chaque jour. Utilisez des indices botaniques progressifs — feuillage, habitat, famille — pour deviner l'espèce avant la fin de vos essais.",
+    "cta": "Jouer à Aphydle"
+  },
   "footer": {
     "about": "À propos",
     "blog": "Blog",

--- a/plant-swipe/public/locales/fr/Landing.json
+++ b/plant-swipe/public/locales/fr/Landing.json
@@ -268,7 +268,8 @@
     "title": "Aphydle",
     "tagline": "Le jeu de devinette de plantes quotidien",
     "description": "Une nouvelle plante mystère chaque jour. Utilisez des indices botaniques progressifs — feuillage, habitat, famille — pour deviner l'espèce avant la fin de vos essais.",
-    "cta": "Jouer à Aphydle"
+    "cta": "Jouer à Aphydle",
+    "tease": "Saurez-vous deviner la plante d'aujourd'hui ?"
   },
   "footer": {
     "about": "À propos",

--- a/plant-swipe/scripts/generate-sitemap.js
+++ b/plant-swipe/scripts/generate-sitemap.js
@@ -75,6 +75,8 @@ try {
 }
 const siteUrlWithSlash = siteUrlBase.endsWith('/') ? siteUrlBase : `${siteUrlBase}/`
 
+const aphydleUrlBase = deriveAphydleUrl(siteUrlBase)
+
 const basePath = normalizeBasePath(process.env.VITE_APP_BASE_PATH)
 const defaultLanguage = (process.env.SITEMAP_DEFAULT_LANGUAGE || 'en').trim() || 'en'
 
@@ -173,6 +175,20 @@ async function main() {
     // Then sort by URL
     return a.loc.localeCompare(b.loc)
   })
+
+  // Sister app: Aphydle (daily plant guessing game) on aphydle.<primary>.
+  // Top-priority cross-link so crawlers discover the second property.
+  if (aphydleUrlBase) {
+    const aphydleHref = `${aphydleUrlBase}/`
+    urlEntries.unshift({
+      loc: aphydleHref,
+      changefreq: 'daily',
+      priority: 1.0,
+      lastmod: nowIso,
+      alternates: [{ hreflang: 'x-default', href: aphydleHref }],
+      lang: defaultLanguage,
+    })
+  }
 
   const xml = [
     '<?xml version="1.0" encoding="UTF-8"?>',
@@ -440,6 +456,31 @@ function escapeXml(value) {
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
     .replace(/'/g, '&apos;')
+}
+
+// Derive the Aphydle (sister daily plant guessing game) URL from the primary
+// site URL. Aphydle is served on the `aphydle.<primary>` subdomain (see
+// plant-swipe.conf and setup.sh). An explicit override can be supplied via
+// PLANTSWIPE_APHYDLE_URL or APHYDLE_URL env vars.
+function deriveAphydleUrl(siteUrl) {
+  const override = (process.env.PLANTSWIPE_APHYDLE_URL || process.env.APHYDLE_URL || '').trim()
+  if (override) {
+    try {
+      const parsed = new URL(override)
+      return `${parsed.origin}`
+    } catch {
+      console.warn(`[sitemap] Invalid APHYDLE_URL "${override}" — falling back to derived URL.`)
+    }
+  }
+  try {
+    const parsed = new URL(siteUrl)
+    let host = parsed.hostname
+    if (host.startsWith('www.')) host = host.slice(4)
+    if (!host.startsWith('aphydle.')) host = `aphydle.${host}`
+    return `${parsed.protocol}//${host}`
+  } catch {
+    return null
+  }
 }
 
 async function loadBlogRoutes() {
@@ -913,6 +954,14 @@ async function generateLlmsTxt(counts) {
   lines.push(`- [Terms](${siteUrlBase}/terms): Terms of Service`)
   lines.push(`- [Privacy](${siteUrlBase}/privacy): GDPR-compliant Privacy Policy`)
   lines.push(``)
+
+  // ── Sister Apps ──────────────────────────────────────────────
+  if (aphydleUrlBase) {
+    lines.push(`### Sister Apps`)
+    lines.push(``)
+    lines.push(`- [Aphydle](${aphydleUrlBase}/): Daily plant guessing game from the Aphylia team. A new mystery plant every day — players guess the species using progressive botanical clues (foliage, habitat, family, etc.). Hosted on a dedicated subdomain and shares the Aphylia plant database.`)
+    lines.push(``)
+  }
 
   // ── Optional / Technical ─────────────────────────────────────
   lines.push(`## Optional`)

--- a/plant-swipe/server.js
+++ b/plant-swipe/server.js
@@ -13468,6 +13468,81 @@ app.get('/api/admin/stats', async (req, res) => {
   }
 })
 
+// Admin: Aphydle stats — count of players who attempted today's puzzle and
+// page visits today. Reads aphydle.attempts / aphydle.daily_log directly via
+// the postgres-js client; aphydle.attempts has no SELECT RLS policy so the
+// REST fallback can't be used here.
+app.get('/api/admin/aphydle-stats', async (req, res) => {
+  const uid = await ensureAdmin(req, res)
+  if (!uid) return
+  try {
+    let playersToday = null
+    let visitsToday = null
+    let puzzleNo = null
+    let puzzleDate = null
+
+    if (sql) {
+      // Today's puzzle_no: prefer daily_log (matches what the runtime served),
+      // fall back to date-math against the rotation epoch (2026-04-27, mirrors
+      // PUZZLE_EPOCH_UTC in Aphydle's src/engine/game.js) if no row has been
+      // stamped yet.
+      try {
+        const pnRows = await sql`
+          select coalesce(
+            (select puzzle_no from aphydle.daily_log where puzzle_date = (now() at time zone 'utc')::date),
+            ((now() at time zone 'utc')::date - date '2026-04-27') + 1
+          )::int as puzzle_no,
+          to_char((now() at time zone 'utc')::date, 'YYYY-MM-DD') as puzzle_date
+        `
+        if (Array.isArray(pnRows) && pnRows[0]) {
+          puzzleNo = Number(pnRows[0].puzzle_no)
+          puzzleDate = pnRows[0].puzzle_date || null
+        }
+      } catch (e) {
+        console.warn('[aphydle-stats] puzzle_no lookup failed:', e?.message)
+      }
+
+      if (puzzleNo != null) {
+        // (anon_id, puzzle_no) is unique on aphydle.attempts, so count(*) on
+        // today's puzzle_no is the number of distinct players today.
+        try {
+          const rows = await sql`
+            select count(*)::int as count
+            from aphydle.attempts
+            where puzzle_no = ${puzzleNo}
+          `
+          if (Array.isArray(rows) && rows[0]) playersToday = Number(rows[0].count)
+        } catch (e) {
+          console.warn('[aphydle-stats] players query failed:', e?.message)
+        }
+      }
+
+      try {
+        const rows = await sql`
+          select count(*)::int as count
+          from aphydle.page_visits
+          where visited_at >= (now() at time zone 'utc')::date
+        `
+        if (Array.isArray(rows) && rows[0]) visitsToday = Number(rows[0].count)
+      } catch (e) {
+        console.warn('[aphydle-stats] visits query failed:', e?.message)
+      }
+    }
+
+    res.json({ ok: true, playersToday, visitsToday, puzzleNo, puzzleDate })
+  } catch (e) {
+    res.status(200).json({
+      ok: true,
+      playersToday: null,
+      visitsToday: null,
+      puzzleNo: null,
+      puzzleDate: null,
+      error: e?.message || 'Failed to load aphydle stats',
+      errorCode: 'ADMIN_APHYDLE_STATS_ERROR',
+    })
+  }
+})
+
 // Admin: lookup member by email (returns user, profile, and known IPs)
 app.get('/api/admin/member', async (req, res) => {
   try {

--- a/plant-swipe/server.js
+++ b/plant-swipe/server.js
@@ -13503,12 +13503,17 @@ app.get('/api/admin/aphydle-stats', async (req, res) => {
       }
 
       if (puzzleNo != null) {
-        // (anon_id, puzzle_no) is unique on aphydle.attempts, so count(*) on
-        // today's puzzle_no is the number of distinct players today.
+        // Source from aphydle.puzzle_results — one row per completed game
+        // (submitResult upserts on (puzzle_no, player_id) once at end). This
+        // matches the finalised data in the SQL editor. We avoid
+        // aphydle.attempts here because trackAttempt's per-guess upserts
+        // race against each other (App.jsx fires them un-awaited), so the
+        // final state of an `attempts` row can be a stale loser even after
+        // the player won.
         try {
           const rows = await sql`
             select count(*)::int as count
-            from aphydle.attempts
+            from aphydle.puzzle_results
             where puzzle_no = ${puzzleNo}
           `
           if (Array.isArray(rows) && rows[0]) playersToday = Number(rows[0].count)
@@ -13543,18 +13548,21 @@ app.get('/api/admin/aphydle-stats', async (req, res) => {
   }
 })
 
-// Admin: Aphydle analytics — time series (visits / players / attempts / wins
+// Admin: Aphydle analytics — time series (visits / players / guesses / wins
 // per day) and details for the most recent puzzles, used by the admin
 // dashboard's "Aphydle" tab. Reads aphydle.* directly via the postgres-js
-// client because the schema's RLS policies don't grant SELECT on attempts /
+// client because the schema's RLS policies don't grant SELECT on
 // page_visits to anon/authenticated.
 //
-// Important: queries are deliberately driven by aphydle.attempts.puzzle_no
-// (not aphydle.daily_log) because daily_log only fills in when the cron job
-// fires or someone visits the page; older sessions whose attempts predate
-// the daily_log row would otherwise vanish from the chart. The puzzle_no →
-// puzzle_date mapping is derived from the rotation epoch instead, mirroring
-// PUZZLE_EPOCH_UTC in Aphydle's src/engine/game.js.
+// Source-of-truth: aphydle.puzzle_results, NOT aphydle.attempts. Aphydle's
+// trackAttempt() fires un-awaited upserts keyed on (anon_id, puzzle_no), so
+// when several guesses race the final `attempts` row can land in a stale
+// pre-win state and the daily_distribution view counts a corresponding 0
+// for the win bucket. puzzle_results is written once per finalised game
+// with the real outcome + guess_count, so it gives faithful numbers.
+//
+// puzzle_no → puzzle_date is derived from the rotation epoch (mirrors
+// PUZZLE_EPOCH_UTC = 2026-04-27 in Aphydle's src/engine/game.js).
 app.get('/api/admin/aphydle-analytics', async (req, res) => {
   const uid = await ensureAdmin(req, res)
   if (!uid) return
@@ -13596,50 +13604,50 @@ app.get('/api/admin/aphydle-analytics', async (req, res) => {
       order by 1
     `
 
-    // Players + total guesses + wins per puzzle. Each row in aphydle.attempts
-    // is one player-puzzle pairing (unique constraint), so count(*) is the
-    // number of players for that puzzle and sum(attempt_no) is the total
-    // guess count across them. Bucket by puzzle_no, then map to puzzle_date
-    // in JS via the rotation epoch.
+    // Players + total guesses + wins per puzzle, sourced from
+    // aphydle.puzzle_results. Each row is one finalised game so count(*) is
+    // the number of players and sum(guess_count) is the total guesses.
     const playsRows = await sql`
-      select a.puzzle_no::int as puzzle_no,
+      select pr.puzzle_no::int as puzzle_no,
              count(*)::int as players,
-             coalesce(sum(a.attempt_no), 0)::int as attempts,
-             sum(case when a.is_correct then 1 else 0 end)::int as wins
-      from aphydle.attempts a
-      where a.puzzle_no >= ${cutoffPuzzleNo} and a.puzzle_no <= ${todayPuzzleNo}
-      group by a.puzzle_no
-      order by a.puzzle_no
+             coalesce(sum(pr.guess_count), 0)::int as attempts,
+             sum(case when pr.outcome = 'won' then 1 else 0 end)::int as wins
+      from aphydle.puzzle_results pr
+      where pr.puzzle_no >= ${cutoffPuzzleNo} and pr.puzzle_no <= ${todayPuzzleNo}
+      group by pr.puzzle_no
+      order by pr.puzzle_no
     `
 
-    // Last 5 puzzles by activity (driven by attempts, not daily_log) so the
-    // list never goes empty on a fresh DB where the cron hasn't stamped any
-    // log rows yet. plant_id and the bucket histogram are best-effort joins.
+    // Last 5 puzzles by completion activity (puzzle_results). The bucket
+    // histogram is computed inline from outcome + guess_count rather than
+    // from aphydle.daily_distribution (which sources from the racy
+    // aphydle.attempts table). plant_id is a best-effort join to daily_log.
     const lastPuzzleRows = await sql`
       with recent_puzzles as (
         select distinct puzzle_no
-        from aphydle.attempts
+        from aphydle.puzzle_results
         order by puzzle_no desc
         limit 5
       )
       select rp.puzzle_no::int as puzzle_no,
              dl.plant_id,
-             coalesce(dd.bucket_1,  0)::int as bucket_1,
-             coalesce(dd.bucket_2,  0)::int as bucket_2,
-             coalesce(dd.bucket_3,  0)::int as bucket_3,
-             coalesce(dd.bucket_4,  0)::int as bucket_4,
-             coalesce(dd.bucket_5,  0)::int as bucket_5,
-             coalesce(dd.bucket_6,  0)::int as bucket_6,
-             coalesce(dd.bucket_7,  0)::int as bucket_7,
-             coalesce(dd.bucket_8,  0)::int as bucket_8,
-             coalesce(dd.bucket_9,  0)::int as bucket_9,
-             coalesce(dd.bucket_10, 0)::int as bucket_10,
-             coalesce(dd.bucket_lost, 0)::int as bucket_lost,
-             coalesce(dd.total_played, 0)::int as total_played,
-             (select count(*)::int from aphydle.attempts a where a.puzzle_no = rp.puzzle_no) as players
+             sum(case when pr.outcome = 'won' and pr.guess_count = 1  then 1 else 0 end)::int as bucket_1,
+             sum(case when pr.outcome = 'won' and pr.guess_count = 2  then 1 else 0 end)::int as bucket_2,
+             sum(case when pr.outcome = 'won' and pr.guess_count = 3  then 1 else 0 end)::int as bucket_3,
+             sum(case when pr.outcome = 'won' and pr.guess_count = 4  then 1 else 0 end)::int as bucket_4,
+             sum(case when pr.outcome = 'won' and pr.guess_count = 5  then 1 else 0 end)::int as bucket_5,
+             sum(case when pr.outcome = 'won' and pr.guess_count = 6  then 1 else 0 end)::int as bucket_6,
+             sum(case when pr.outcome = 'won' and pr.guess_count = 7  then 1 else 0 end)::int as bucket_7,
+             sum(case when pr.outcome = 'won' and pr.guess_count = 8  then 1 else 0 end)::int as bucket_8,
+             sum(case when pr.outcome = 'won' and pr.guess_count = 9  then 1 else 0 end)::int as bucket_9,
+             sum(case when pr.outcome = 'won' and pr.guess_count = 10 then 1 else 0 end)::int as bucket_10,
+             sum(case when pr.outcome = 'lost' then 1 else 0 end)::int as bucket_lost,
+             count(pr.id)::int as total_played,
+             count(pr.id)::int as players
       from recent_puzzles rp
       left join aphydle.daily_log dl on dl.puzzle_no = rp.puzzle_no
-      left join aphydle.daily_distribution dd on dd.puzzle_no = rp.puzzle_no
+      left join aphydle.puzzle_results pr on pr.puzzle_no = rp.puzzle_no
+      group by rp.puzzle_no, dl.plant_id
       order by rp.puzzle_no desc
     `
 
@@ -13653,17 +13661,19 @@ app.get('/api/admin/aphydle-analytics', async (req, res) => {
       } catch { /* swallow — names are nice-to-have */ }
     }
 
-    // Totals over the window (same windowing as the per-day series above).
+    // Totals over the window. Plays/guesses/wins from puzzle_results so
+    // they reflect finalised outcomes rather than the racy attempts state.
     const totalsRows = await sql`
       select
         coalesce((select count(*)::int from aphydle.page_visits
                   where visited_at >= ${cutoffISO}::timestamptz), 0) as visits_total,
-        coalesce((select count(*)::int from aphydle.attempts
+        coalesce((select count(*)::int from aphydle.puzzle_results
                   where puzzle_no >= ${cutoffPuzzleNo} and puzzle_no <= ${todayPuzzleNo}), 0) as plays_total,
-        coalesce((select sum(attempt_no)::int from aphydle.attempts
+        coalesce((select sum(guess_count)::int from aphydle.puzzle_results
                   where puzzle_no >= ${cutoffPuzzleNo} and puzzle_no <= ${todayPuzzleNo}), 0) as guesses_total,
-        coalesce((select sum(case when is_correct then 1 else 0 end)::int from aphydle.attempts
-                  where puzzle_no >= ${cutoffPuzzleNo} and puzzle_no <= ${todayPuzzleNo}), 0) as wins_total
+        coalesce((select count(*)::int from aphydle.puzzle_results
+                  where puzzle_no >= ${cutoffPuzzleNo} and puzzle_no <= ${todayPuzzleNo}
+                    and outcome = 'won'), 0) as wins_total
     `
     const tot = totalsRows[0] || {}
 

--- a/plant-swipe/server.js
+++ b/plant-swipe/server.js
@@ -13548,6 +13548,13 @@ app.get('/api/admin/aphydle-stats', async (req, res) => {
 // dashboard's "Aphydle" tab. Reads aphydle.* directly via the postgres-js
 // client because the schema's RLS policies don't grant SELECT on attempts /
 // page_visits to anon/authenticated.
+//
+// Important: queries are deliberately driven by aphydle.attempts.puzzle_no
+// (not aphydle.daily_log) because daily_log only fills in when the cron job
+// fires or someone visits the page; older sessions whose attempts predate
+// the daily_log row would otherwise vanish from the chart. The puzzle_no →
+// puzzle_date mapping is derived from the rotation epoch instead, mirroring
+// PUZZLE_EPOCH_UTC in Aphydle's src/engine/game.js.
 app.get('/api/admin/aphydle-analytics', async (req, res) => {
   const uid = await ensureAdmin(req, res)
   if (!uid) return
@@ -13562,58 +13569,78 @@ app.get('/api/admin/aphydle-analytics', async (req, res) => {
       lastPuzzles: [],
     })
   }
+
+  // Compute the window in JS so SQL never has to do parameterised date
+  // arithmetic (postgres-js mishandles "${n}::int - 1" in some setups).
+  const APHYDLE_EPOCH_UTC_MS = Date.UTC(2026, 3, 27) // April 27 2026, month is 0-indexed
+  const DAY_MS = 24 * 3600 * 1000
+  const todayUtcMs = Math.floor(Date.now() / DAY_MS) * DAY_MS
+  const todayPuzzleNo = Math.floor((todayUtcMs - APHYDLE_EPOCH_UTC_MS) / DAY_MS) + 1
+  const cutoffPuzzleNo = todayPuzzleNo - (days - 1)
+  const cutoffUtcMs = todayUtcMs - (days - 1) * DAY_MS
+  const cutoffISO = new Date(cutoffUtcMs).toISOString() // "YYYY-MM-DDT00:00:00.000Z"
+  const epochISODate = '2026-04-27' // mirrors APHYDLE_EPOCH_UTC_MS, used as a Postgres date literal
+
+  // Helper: puzzle_no → "YYYY-MM-DD" in UTC, used to densify the time series
+  // and to label the lastPuzzles cards on the client.
+  const puzzleDateOf = (n) => new Date(APHYDLE_EPOCH_UTC_MS + (n - 1) * DAY_MS).toISOString().slice(0, 10)
+
   try {
-    // Visits per UTC day (count of page_visits rows). Bucketed in UTC to match
-    // the puzzle_date convention in aphydle.daily_log.
+    // Visits per UTC day. No daily_log dependency.
     const visitsRows = await sql`
       select to_char(date_trunc('day', visited_at at time zone 'utc'), 'YYYY-MM-DD') as date,
              count(*)::int as visits
       from aphydle.page_visits
-      where visited_at >= (now() at time zone 'utc')::date - (${days}::int - 1)
+      where visited_at >= ${cutoffISO}::timestamptz
       group by 1
       order by 1
     `
 
-    // Players + total guesses + wins per day. Each row in aphydle.attempts is
-    // one player-puzzle pairing (unique constraint), so count(*) gives the
-    // number of players on that day's puzzle and sum(attempt_no) is the total
-    // guess count across all those players.
+    // Players + total guesses + wins per puzzle. Each row in aphydle.attempts
+    // is one player-puzzle pairing (unique constraint), so count(*) is the
+    // number of players for that puzzle and sum(attempt_no) is the total
+    // guess count across them. Bucket by puzzle_no, then map to puzzle_date
+    // in JS via the rotation epoch.
     const playsRows = await sql`
-      select to_char(dl.puzzle_date, 'YYYY-MM-DD') as date,
+      select a.puzzle_no::int as puzzle_no,
              count(*)::int as players,
              coalesce(sum(a.attempt_no), 0)::int as attempts,
              sum(case when a.is_correct then 1 else 0 end)::int as wins
       from aphydle.attempts a
-      join aphydle.daily_log dl on dl.puzzle_no = a.puzzle_no
-      where dl.puzzle_date >= (now() at time zone 'utc')::date - (${days}::int - 1)
-      group by 1
-      order by 1
+      where a.puzzle_no >= ${cutoffPuzzleNo} and a.puzzle_no <= ${todayPuzzleNo}
+      group by a.puzzle_no
+      order by a.puzzle_no
     `
 
-    // Last 5 puzzles with their distribution buckets. Joins the existing
-    // aphydle.daily_distribution view (bucket_1..10 + bucket_lost +
-    // total_played) to avoid duplicating the histogram aggregation here.
+    // Last 5 puzzles by activity (driven by attempts, not daily_log) so the
+    // list never goes empty on a fresh DB where the cron hasn't stamped any
+    // log rows yet. plant_id and the bucket histogram are best-effort joins.
     const lastPuzzleRows = await sql`
-      select dl.puzzle_no,
-             to_char(dl.puzzle_date, 'YYYY-MM-DD') as puzzle_date,
+      with recent_puzzles as (
+        select distinct puzzle_no
+        from aphydle.attempts
+        order by puzzle_no desc
+        limit 5
+      )
+      select rp.puzzle_no::int as puzzle_no,
              dl.plant_id,
-             coalesce(dd.bucket_1, 0)::int as bucket_1,
-             coalesce(dd.bucket_2, 0)::int as bucket_2,
-             coalesce(dd.bucket_3, 0)::int as bucket_3,
-             coalesce(dd.bucket_4, 0)::int as bucket_4,
-             coalesce(dd.bucket_5, 0)::int as bucket_5,
-             coalesce(dd.bucket_6, 0)::int as bucket_6,
-             coalesce(dd.bucket_7, 0)::int as bucket_7,
-             coalesce(dd.bucket_8, 0)::int as bucket_8,
-             coalesce(dd.bucket_9, 0)::int as bucket_9,
+             coalesce(dd.bucket_1,  0)::int as bucket_1,
+             coalesce(dd.bucket_2,  0)::int as bucket_2,
+             coalesce(dd.bucket_3,  0)::int as bucket_3,
+             coalesce(dd.bucket_4,  0)::int as bucket_4,
+             coalesce(dd.bucket_5,  0)::int as bucket_5,
+             coalesce(dd.bucket_6,  0)::int as bucket_6,
+             coalesce(dd.bucket_7,  0)::int as bucket_7,
+             coalesce(dd.bucket_8,  0)::int as bucket_8,
+             coalesce(dd.bucket_9,  0)::int as bucket_9,
              coalesce(dd.bucket_10, 0)::int as bucket_10,
              coalesce(dd.bucket_lost, 0)::int as bucket_lost,
              coalesce(dd.total_played, 0)::int as total_played,
-             (select count(*)::int from aphydle.attempts a where a.puzzle_no = dl.puzzle_no) as players
-      from aphydle.daily_log dl
-      left join aphydle.daily_distribution dd on dd.puzzle_no = dl.puzzle_no
-      order by dl.puzzle_no desc
-      limit 5
+             (select count(*)::int from aphydle.attempts a where a.puzzle_no = rp.puzzle_no) as players
+      from recent_puzzles rp
+      left join aphydle.daily_log dl on dl.puzzle_no = rp.puzzle_no
+      left join aphydle.daily_distribution dd on dd.puzzle_no = rp.puzzle_no
+      order by rp.puzzle_no desc
     `
 
     // Resolve plant common names (best-effort; ignored on failure).
@@ -13626,33 +13653,24 @@ app.get('/api/admin/aphydle-analytics', async (req, res) => {
       } catch { /* swallow — names are nice-to-have */ }
     }
 
-    // Totals over the window
+    // Totals over the window (same windowing as the per-day series above).
     const totalsRows = await sql`
       select
         coalesce((select count(*)::int from aphydle.page_visits
-                  where visited_at >= (now() at time zone 'utc')::date - (${days}::int - 1)), 0) as visits_total,
-        coalesce((select count(*)::int from aphydle.attempts a
-                  join aphydle.daily_log dl on dl.puzzle_no = a.puzzle_no
-                  where dl.puzzle_date >= (now() at time zone 'utc')::date - (${days}::int - 1)), 0) as plays_total,
-        coalesce((select sum(a.attempt_no)::int from aphydle.attempts a
-                  join aphydle.daily_log dl on dl.puzzle_no = a.puzzle_no
-                  where dl.puzzle_date >= (now() at time zone 'utc')::date - (${days}::int - 1)), 0) as guesses_total,
-        coalesce((select sum(case when a.is_correct then 1 else 0 end)::int from aphydle.attempts a
-                  join aphydle.daily_log dl on dl.puzzle_no = a.puzzle_no
-                  where dl.puzzle_date >= (now() at time zone 'utc')::date - (${days}::int - 1)), 0) as wins_total
+                  where visited_at >= ${cutoffISO}::timestamptz), 0) as visits_total,
+        coalesce((select count(*)::int from aphydle.attempts
+                  where puzzle_no >= ${cutoffPuzzleNo} and puzzle_no <= ${todayPuzzleNo}), 0) as plays_total,
+        coalesce((select sum(attempt_no)::int from aphydle.attempts
+                  where puzzle_no >= ${cutoffPuzzleNo} and puzzle_no <= ${todayPuzzleNo}), 0) as guesses_total,
+        coalesce((select sum(case when is_correct then 1 else 0 end)::int from aphydle.attempts
+                  where puzzle_no >= ${cutoffPuzzleNo} and puzzle_no <= ${todayPuzzleNo}), 0) as wins_total
     `
     const tot = totalsRows[0] || {}
 
-    // Densify the time series — make sure every UTC day in the window has a
-    // row so the chart doesn't have gaps. Visits-only days, play-only days,
-    // and quiet days (zeros) all share the same row.
-    const todayUtc = new Date()
-    const startUtc = new Date(Date.UTC(todayUtc.getUTCFullYear(), todayUtc.getUTCMonth(), todayUtc.getUTCDate()))
-    startUtc.setUTCDate(startUtc.getUTCDate() - (days - 1))
+    // Densify the time series so every UTC day in the window has a row.
     const seriesByDate = {}
     for (let i = 0; i < days; i++) {
-      const d = new Date(startUtc)
-      d.setUTCDate(startUtc.getUTCDate() + i)
+      const d = new Date(cutoffUtcMs + i * DAY_MS)
       const key = d.toISOString().slice(0, 10)
       seriesByDate[key] = { date: key, visits: 0, players: 0, attempts: 0, wins: 0 }
     }
@@ -13660,10 +13678,11 @@ app.get('/api/admin/aphydle-analytics', async (req, res) => {
       if (seriesByDate[r.date]) seriesByDate[r.date].visits = Number(r.visits) || 0
     }
     for (const r of playsRows) {
-      if (seriesByDate[r.date]) {
-        seriesByDate[r.date].players = Number(r.players) || 0
-        seriesByDate[r.date].attempts = Number(r.attempts) || 0
-        seriesByDate[r.date].wins = Number(r.wins) || 0
+      const key = puzzleDateOf(Number(r.puzzle_no))
+      if (seriesByDate[key]) {
+        seriesByDate[key].players = Number(r.players) || 0
+        seriesByDate[key].attempts = Number(r.attempts) || 0
+        seriesByDate[key].wins = Number(r.wins) || 0
       }
     }
     const timeSeries = Object.values(seriesByDate).sort((a, b) => a.date.localeCompare(b.date))
@@ -13671,6 +13690,8 @@ app.get('/api/admin/aphydle-analytics', async (req, res) => {
     res.json({
       ok: true,
       days,
+      epoch: epochISODate,
+      todayPuzzleNo,
       totals: {
         visits: Number(tot.visits_total) || 0,
         plays: Number(tot.plays_total) || 0,
@@ -13680,7 +13701,7 @@ app.get('/api/admin/aphydle-analytics', async (req, res) => {
       timeSeries,
       lastPuzzles: lastPuzzleRows.map(r => ({
         puzzleNo: Number(r.puzzle_no),
-        puzzleDate: r.puzzle_date,
+        puzzleDate: puzzleDateOf(Number(r.puzzle_no)),
         plantId: r.plant_id || null,
         plantName: r.plant_id ? (plantNamesById[String(r.plant_id)] || null) : null,
         players: Number(r.players) || 0,

--- a/plant-swipe/server.js
+++ b/plant-swipe/server.js
@@ -30983,6 +30983,25 @@ function scheduleNotificationWorker() {
   notificationWorkerTimer = setTimeout(tick, 2000)
 }
 
+// Derive the Aphydle (sister daily plant guessing game) origin from the primary
+// site URL. Aphydle is served on `aphydle.<primary>` per plant-swipe.conf /
+// setup.sh. PLANTSWIPE_APHYDLE_URL or APHYDLE_URL can override the default.
+function deriveAphydleOrigin(siteUrl) {
+  const override = (process.env.PLANTSWIPE_APHYDLE_URL || process.env.APHYDLE_URL || '').trim()
+  if (override) {
+    try { return new URL(override).origin } catch { /* fall through */ }
+  }
+  try {
+    const parsed = new URL(siteUrl)
+    let host = parsed.hostname
+    if (host.startsWith('www.')) host = host.slice(4)
+    if (!host.startsWith('aphydle.')) host = `aphydle.${host}`
+    return `${parsed.protocol}//${host}`
+  } catch {
+    return null
+  }
+}
+
 // Dynamic sitemap.xml generator
 // Static pages: NO lastmod (tells Google these are evergreen, don't show dates)
 // Dynamic pages: WITH lastmod (blog posts, plants get proper date indexing)
@@ -31024,6 +31043,20 @@ app.get('/sitemap.xml', async (req, res) => {
 
   // Build sitemap XML - generate URLs for each language
   let urls = ''
+
+  // Sister app: Aphydle (daily plant guessing game) hosted on aphydle.<primary>.
+  // Top priority cross-link so crawlers discover the second property.
+  const aphydleOrigin = deriveAphydleOrigin(siteUrl)
+  if (aphydleOrigin) {
+    const aphydleHref = `${aphydleOrigin}/`
+    urls += `  <url>
+    <loc>${aphydleHref}</loc>
+    <changefreq>daily</changefreq>
+    <priority>1.0</priority>
+    <xhtml:link rel="alternate" hreflang="x-default" href="${aphydleHref}" />
+  </url>\n`
+  }
+
   for (const lang of languages) {
     urls += staticPages.map(page => `  <url>
     <loc>${langUrl(page.loc, lang)}</loc>
@@ -31282,6 +31315,7 @@ ${urls}
 // Analogous to sitemap.xml but optimized for LLM consumption.
 app.get('/llms-full.txt', async (req, res) => {
   const siteUrl = (process.env.PLANTSWIPE_SITE_URL || process.env.SITE_URL || 'https://aphylia.app').replace(/\/+$/, '')
+  const aphydleOrigin = deriveAphydleOrigin(siteUrl)
   const now = new Date().toISOString()
   const db = supabaseServiceClient || supabaseServer
 
@@ -31291,6 +31325,9 @@ app.get('/llms-full.txt', async (req, res) => {
   lines.push(`# Website: ${siteUrl}`)
   lines.push(`# Sitemap: ${siteUrl}/sitemap.xml`)
   lines.push(`# LLM instructions: ${siteUrl}/llms.txt`)
+  if (aphydleOrigin) {
+    lines.push(`# Sister app — Aphydle (daily plant guessing game): ${aphydleOrigin}/`)
+  }
   lines.push('')
   lines.push('> This file is dynamically generated from the Aphylia database.')
   lines.push('> It lists every plant with key care data, all blog posts, public gardens, public profiles, and public bookmark collections.')
@@ -31588,6 +31625,9 @@ app.get('/llms-full.txt', async (req, res) => {
   lines.push(`Website: ${siteUrl}`)
   lines.push(`Sitemap: ${siteUrl}/sitemap.xml`)
   lines.push(`LLM instructions: ${siteUrl}/llms.txt`)
+  if (aphydleOrigin) {
+    lines.push(`Sister app — Aphydle: ${aphydleOrigin}/`)
+  }
   lines.push(`Contact: ${siteUrl}/contact`)
 
   res.setHeader('Content-Type', 'text/plain; charset=utf-8')

--- a/plant-swipe/server.js
+++ b/plant-swipe/server.js
@@ -13468,10 +13468,10 @@ app.get('/api/admin/stats', async (req, res) => {
   }
 })
 
-// Admin: Aphydle stats — count of players who attempted today's puzzle and
-// page visits today. Reads aphydle.attempts / aphydle.daily_log directly via
-// the postgres-js client; aphydle.attempts has no SELECT RLS policy so the
-// REST fallback can't be used here.
+// Admin: Aphydle stats — count of players who finished today's puzzle and
+// page visits today. Reads aphydle.puzzle_results / aphydle.page_visits /
+// aphydle.daily_log directly via the postgres-js client; page_visits has
+// no SELECT RLS policy for anon, so REST can't be used as a fallback here.
 app.get('/api/admin/aphydle-stats', async (req, res) => {
   const uid = await ensureAdmin(req, res)
   if (!uid) return
@@ -13503,13 +13503,9 @@ app.get('/api/admin/aphydle-stats', async (req, res) => {
       }
 
       if (puzzleNo != null) {
-        // Source from aphydle.puzzle_results — one row per completed game
-        // (submitResult upserts on (puzzle_no, player_id) once at end). This
-        // matches the finalised data in the SQL editor. We avoid
-        // aphydle.attempts here because trackAttempt's per-guess upserts
-        // race against each other (App.jsx fires them un-awaited), so the
-        // final state of an `attempts` row can be a stale loser even after
-        // the player won.
+        // Source from aphydle.puzzle_results — one row per finalised game
+        // (submitResult upserts on (puzzle_no, player_id) at end of game).
+        // This is the authoritative table for outcomes.
         try {
           const rows = await sql`
             select count(*)::int as count
@@ -13551,16 +13547,10 @@ app.get('/api/admin/aphydle-stats', async (req, res) => {
 // Admin: Aphydle analytics — time series (visits / players / guesses / wins
 // per day) and details for the most recent puzzles, used by the admin
 // dashboard's "Aphydle" tab. Reads aphydle.* directly via the postgres-js
-// client because the schema's RLS policies don't grant SELECT on
-// page_visits to anon/authenticated.
+// client because page_visits has no SELECT RLS policy for anon.
 //
-// Source-of-truth: aphydle.puzzle_results, NOT aphydle.attempts. Aphydle's
-// trackAttempt() fires un-awaited upserts keyed on (anon_id, puzzle_no), so
-// when several guesses race the final `attempts` row can land in a stale
-// pre-win state and the daily_distribution view counts a corresponding 0
-// for the win bucket. puzzle_results is written once per finalised game
-// with the real outcome + guess_count, so it gives faithful numbers.
-//
+// Source-of-truth for outcomes is aphydle.puzzle_results — submitResult
+// writes one row per finalised game with the real outcome + guess_count.
 // puzzle_no → puzzle_date is derived from the rotation epoch (mirrors
 // PUZZLE_EPOCH_UTC = 2026-04-27 in Aphydle's src/engine/game.js).
 app.get('/api/admin/aphydle-analytics', async (req, res) => {
@@ -13619,9 +13609,8 @@ app.get('/api/admin/aphydle-analytics', async (req, res) => {
     `
 
     // Last 5 puzzles by completion activity (puzzle_results). The bucket
-    // histogram is computed inline from outcome + guess_count rather than
-    // from aphydle.daily_distribution (which sources from the racy
-    // aphydle.attempts table). plant_id is a best-effort join to daily_log.
+    // histogram is computed inline from outcome + guess_count.
+    // plant_id is a best-effort join to daily_log.
     const lastPuzzleRows = await sql`
       with recent_puzzles as (
         select distinct puzzle_no

--- a/plant-swipe/server.js
+++ b/plant-swipe/server.js
@@ -13543,6 +13543,174 @@ app.get('/api/admin/aphydle-stats', async (req, res) => {
   }
 })
 
+// Admin: Aphydle analytics — time series (visits / players / attempts / wins
+// per day) and details for the most recent puzzles, used by the admin
+// dashboard's "Aphydle" tab. Reads aphydle.* directly via the postgres-js
+// client because the schema's RLS policies don't grant SELECT on attempts /
+// page_visits to anon/authenticated.
+app.get('/api/admin/aphydle-analytics', async (req, res) => {
+  const uid = await ensureAdmin(req, res)
+  if (!uid) return
+  const days = Math.max(1, Math.min(90, Number.parseInt(req.query.days, 10) || 30))
+  if (!sql) {
+    return res.json({
+      ok: false,
+      error: 'Database connection not available',
+      days,
+      totals: { visits: 0, plays: 0, guesses: 0, wins: 0 },
+      timeSeries: [],
+      lastPuzzles: [],
+    })
+  }
+  try {
+    // Visits per UTC day (count of page_visits rows). Bucketed in UTC to match
+    // the puzzle_date convention in aphydle.daily_log.
+    const visitsRows = await sql`
+      select to_char(date_trunc('day', visited_at at time zone 'utc'), 'YYYY-MM-DD') as date,
+             count(*)::int as visits
+      from aphydle.page_visits
+      where visited_at >= (now() at time zone 'utc')::date - (${days}::int - 1)
+      group by 1
+      order by 1
+    `
+
+    // Players + total guesses + wins per day. Each row in aphydle.attempts is
+    // one player-puzzle pairing (unique constraint), so count(*) gives the
+    // number of players on that day's puzzle and sum(attempt_no) is the total
+    // guess count across all those players.
+    const playsRows = await sql`
+      select to_char(dl.puzzle_date, 'YYYY-MM-DD') as date,
+             count(*)::int as players,
+             coalesce(sum(a.attempt_no), 0)::int as attempts,
+             sum(case when a.is_correct then 1 else 0 end)::int as wins
+      from aphydle.attempts a
+      join aphydle.daily_log dl on dl.puzzle_no = a.puzzle_no
+      where dl.puzzle_date >= (now() at time zone 'utc')::date - (${days}::int - 1)
+      group by 1
+      order by 1
+    `
+
+    // Last 5 puzzles with their distribution buckets. Joins the existing
+    // aphydle.daily_distribution view (bucket_1..10 + bucket_lost +
+    // total_played) to avoid duplicating the histogram aggregation here.
+    const lastPuzzleRows = await sql`
+      select dl.puzzle_no,
+             to_char(dl.puzzle_date, 'YYYY-MM-DD') as puzzle_date,
+             dl.plant_id,
+             coalesce(dd.bucket_1, 0)::int as bucket_1,
+             coalesce(dd.bucket_2, 0)::int as bucket_2,
+             coalesce(dd.bucket_3, 0)::int as bucket_3,
+             coalesce(dd.bucket_4, 0)::int as bucket_4,
+             coalesce(dd.bucket_5, 0)::int as bucket_5,
+             coalesce(dd.bucket_6, 0)::int as bucket_6,
+             coalesce(dd.bucket_7, 0)::int as bucket_7,
+             coalesce(dd.bucket_8, 0)::int as bucket_8,
+             coalesce(dd.bucket_9, 0)::int as bucket_9,
+             coalesce(dd.bucket_10, 0)::int as bucket_10,
+             coalesce(dd.bucket_lost, 0)::int as bucket_lost,
+             coalesce(dd.total_played, 0)::int as total_played,
+             (select count(*)::int from aphydle.attempts a where a.puzzle_no = dl.puzzle_no) as players
+      from aphydle.daily_log dl
+      left join aphydle.daily_distribution dd on dd.puzzle_no = dl.puzzle_no
+      order by dl.puzzle_no desc
+      limit 5
+    `
+
+    // Resolve plant common names (best-effort; ignored on failure).
+    const plantIds = Array.from(new Set(lastPuzzleRows.map(r => r.plant_id).filter(Boolean).map(String)))
+    const plantNamesById = {}
+    if (plantIds.length) {
+      try {
+        const plantRows = await sql`select id::text as id, name from public.plants where id::text = any(${plantIds})`
+        for (const p of plantRows) plantNamesById[p.id] = p.name
+      } catch { /* swallow — names are nice-to-have */ }
+    }
+
+    // Totals over the window
+    const totalsRows = await sql`
+      select
+        coalesce((select count(*)::int from aphydle.page_visits
+                  where visited_at >= (now() at time zone 'utc')::date - (${days}::int - 1)), 0) as visits_total,
+        coalesce((select count(*)::int from aphydle.attempts a
+                  join aphydle.daily_log dl on dl.puzzle_no = a.puzzle_no
+                  where dl.puzzle_date >= (now() at time zone 'utc')::date - (${days}::int - 1)), 0) as plays_total,
+        coalesce((select sum(a.attempt_no)::int from aphydle.attempts a
+                  join aphydle.daily_log dl on dl.puzzle_no = a.puzzle_no
+                  where dl.puzzle_date >= (now() at time zone 'utc')::date - (${days}::int - 1)), 0) as guesses_total,
+        coalesce((select sum(case when a.is_correct then 1 else 0 end)::int from aphydle.attempts a
+                  join aphydle.daily_log dl on dl.puzzle_no = a.puzzle_no
+                  where dl.puzzle_date >= (now() at time zone 'utc')::date - (${days}::int - 1)), 0) as wins_total
+    `
+    const tot = totalsRows[0] || {}
+
+    // Densify the time series — make sure every UTC day in the window has a
+    // row so the chart doesn't have gaps. Visits-only days, play-only days,
+    // and quiet days (zeros) all share the same row.
+    const todayUtc = new Date()
+    const startUtc = new Date(Date.UTC(todayUtc.getUTCFullYear(), todayUtc.getUTCMonth(), todayUtc.getUTCDate()))
+    startUtc.setUTCDate(startUtc.getUTCDate() - (days - 1))
+    const seriesByDate = {}
+    for (let i = 0; i < days; i++) {
+      const d = new Date(startUtc)
+      d.setUTCDate(startUtc.getUTCDate() + i)
+      const key = d.toISOString().slice(0, 10)
+      seriesByDate[key] = { date: key, visits: 0, players: 0, attempts: 0, wins: 0 }
+    }
+    for (const r of visitsRows) {
+      if (seriesByDate[r.date]) seriesByDate[r.date].visits = Number(r.visits) || 0
+    }
+    for (const r of playsRows) {
+      if (seriesByDate[r.date]) {
+        seriesByDate[r.date].players = Number(r.players) || 0
+        seriesByDate[r.date].attempts = Number(r.attempts) || 0
+        seriesByDate[r.date].wins = Number(r.wins) || 0
+      }
+    }
+    const timeSeries = Object.values(seriesByDate).sort((a, b) => a.date.localeCompare(b.date))
+
+    res.json({
+      ok: true,
+      days,
+      totals: {
+        visits: Number(tot.visits_total) || 0,
+        plays: Number(tot.plays_total) || 0,
+        guesses: Number(tot.guesses_total) || 0,
+        wins: Number(tot.wins_total) || 0,
+      },
+      timeSeries,
+      lastPuzzles: lastPuzzleRows.map(r => ({
+        puzzleNo: Number(r.puzzle_no),
+        puzzleDate: r.puzzle_date,
+        plantId: r.plant_id || null,
+        plantName: r.plant_id ? (plantNamesById[String(r.plant_id)] || null) : null,
+        players: Number(r.players) || 0,
+        wins: Number(r.bucket_1) + Number(r.bucket_2) + Number(r.bucket_3) + Number(r.bucket_4) +
+              Number(r.bucket_5) + Number(r.bucket_6) + Number(r.bucket_7) + Number(r.bucket_8) +
+              Number(r.bucket_9) + Number(r.bucket_10),
+        losses: Number(r.bucket_lost) || 0,
+        totalPlayed: Number(r.total_played) || 0,
+        buckets: [
+          Number(r.bucket_1) || 0, Number(r.bucket_2) || 0, Number(r.bucket_3) || 0,
+          Number(r.bucket_4) || 0, Number(r.bucket_5) || 0, Number(r.bucket_6) || 0,
+          Number(r.bucket_7) || 0, Number(r.bucket_8) || 0, Number(r.bucket_9) || 0,
+          Number(r.bucket_10) || 0,
+        ],
+      })),
+    })
+  } catch (e) {
+    console.error('[aphydle-analytics] failed:', e?.message)
+    res.status(200).json({
+      ok: false,
+      error: e?.message || 'Failed to load aphydle analytics',
+      errorCode: 'ADMIN_APHYDLE_ANALYTICS_ERROR',
+      days,
+      totals: { visits: 0, plays: 0, guesses: 0, wins: 0 },
+      timeSeries: [],
+      lastPuzzles: [],
+    })
+  }
+})
+
 // Admin: lookup member by email (returns user, profile, and known IPs)
 app.get('/api/admin/member', async (req, res) => {
   try {

--- a/plant-swipe/src/pages/AdminPage.tsx
+++ b/plant-swipe/src/pages/AdminPage.tsx
@@ -1926,8 +1926,6 @@ export const AdminPage: React.FC = () => {
     );
     // Aphydle (sister daily plant guessing game) — players for today's puzzle
     const [aphydlePlayersToday, setAphydlePlayersToday] = React.useState<number | null>(null);
-    const [aphydleVisitsToday, setAphydleVisitsToday] = React.useState<number | null>(null);
-    const [aphydlePuzzleNo, setAphydlePuzzleNo] = React.useState<number | null>(null);
     const [aphydleStatsLoading, setAphydleStatsLoading] = React.useState<boolean>(true);
     const [aphydleStatsRefreshing, setAphydleStatsRefreshing] = React.useState<boolean>(false);
     const [aphydleStatsUpdatedAt, setAphydleStatsUpdatedAt] = React.useState<number | null>(null);
@@ -5350,8 +5348,6 @@ export const AdminPage: React.FC = () => {
         if (resp && resp.ok) {
           const data = await safeJson(resp);
           if (typeof data?.playersToday === "number") setAphydlePlayersToday(data.playersToday);
-          if (typeof data?.visitsToday === "number") setAphydleVisitsToday(data.visitsToday);
-          if (typeof data?.puzzleNo === "number") setAphydlePuzzleNo(data.puzzleNo);
           setAphydleStatsUpdatedAt(Date.now());
         }
       } catch (e) {
@@ -7349,8 +7345,12 @@ export const AdminPage: React.FC = () => {
                         </div>
                       </div>
 
-                      {/* Quick Stats Cards */}
-                      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+                      {/* Quick Stats Cards
+                          Layout: 3 equal-width main cards + a compact Aphydle
+                          card on the right at lg+. The custom grid template
+                          keeps the 3 originals at their original width instead
+                          of squashing them to fit a 4-equal-column layout. */}
+                      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-[repeat(3,minmax(0,1fr))_auto] gap-3">
                         {/* Currently Online Card — powered by GA Realtime */}
                         <div className="group relative rounded-2xl border border-emerald-200/70 dark:border-emerald-800/40 bg-gradient-to-br from-emerald-50/80 to-teal-50/50 dark:from-emerald-950/30 dark:to-teal-950/20 p-4 shadow-sm hover:shadow-md hover:shadow-emerald-500/8 transition-all duration-200 overflow-hidden">
                           <div className="flex items-center justify-between mb-3">
@@ -7471,21 +7471,16 @@ export const AdminPage: React.FC = () => {
                           </div>
                         </div>
 
-                        {/* Aphydle Players Today Card — sister daily plant guessing game */}
-                        <div className="group relative rounded-2xl border border-fuchsia-200/70 dark:border-fuchsia-800/40 bg-gradient-to-br from-fuchsia-50/80 to-violet-50/50 dark:from-fuchsia-950/30 dark:to-violet-950/20 p-4 shadow-sm hover:shadow-md hover:shadow-fuchsia-500/8 transition-all duration-200 overflow-hidden">
-                          <div className="flex items-center justify-between mb-3">
-                            <div className="flex items-center gap-2.5">
-                              <div className="w-9 h-9 rounded-lg bg-gradient-to-br from-fuchsia-500 to-violet-500 flex items-center justify-center shadow-sm shadow-fuchsia-500/20">
-                                <Gamepad2 className="h-4.5 w-4.5 text-white" />
+                        {/* Aphydle Card — sister daily plant guessing game.
+                            Compact: fixed width on lg so it doesn't stretch
+                            the three main cards next to it. */}
+                        <div className="group relative rounded-2xl border border-fuchsia-200/70 dark:border-fuchsia-800/40 bg-gradient-to-br from-fuchsia-50/80 to-violet-50/50 dark:from-fuchsia-950/30 dark:to-violet-950/20 p-3 shadow-sm hover:shadow-md hover:shadow-fuchsia-500/8 transition-all duration-200 overflow-hidden lg:w-44">
+                          <div className="flex items-center justify-between mb-2">
+                            <div className="flex items-center gap-2">
+                              <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-fuchsia-500 to-violet-500 flex items-center justify-center shadow-sm shadow-fuchsia-500/20">
+                                <Gamepad2 className="h-4 w-4 text-white" />
                               </div>
-                              <div>
-                                <div className="text-xs font-semibold text-fuchsia-900 dark:text-fuchsia-100">Aphydle Players</div>
-                                <div className="text-[10px] text-fuchsia-600/60 dark:text-fuchsia-400/60">
-                                  {aphydlePuzzleNo != null
-                                    ? `Puzzle #${aphydlePuzzleNo} · ${aphydleStatsUpdatedAt ? formatTimeAgo(aphydleStatsUpdatedAt) : "Updating..."}`
-                                    : aphydleStatsUpdatedAt ? formatTimeAgo(aphydleStatsUpdatedAt) : "Updating..."}
-                                </div>
-                              </div>
+                              <div className="text-xs font-semibold text-fuchsia-900 dark:text-fuchsia-100">Aphydle</div>
                             </div>
                             <Button
                               variant="ghost"
@@ -7493,24 +7488,19 @@ export const AdminPage: React.FC = () => {
                               aria-label="Refresh aphydle players"
                               onClick={() => loadAphydleStats({ initial: false })}
                               disabled={aphydleStatsLoading || aphydleStatsRefreshing}
-                              className="h-7 w-7 rounded-lg text-fuchsia-600 dark:text-fuchsia-400"
+                              className="h-6 w-6 rounded-lg text-fuchsia-600 dark:text-fuchsia-400"
                             >
-                              <RefreshCw className={`h-3.5 w-3.5 ${aphydleStatsLoading || aphydleStatsRefreshing ? "animate-spin" : ""}`} />
+                              <RefreshCw className={`h-3 w-3 ${aphydleStatsLoading || aphydleStatsRefreshing ? "animate-spin" : ""}`} />
                             </Button>
                           </div>
                           <div className="flex items-baseline gap-1.5">
-                            <div className="text-3xl font-bold tabular-nums text-fuchsia-700 dark:text-fuchsia-300">
+                            <div className="text-2xl font-bold tabular-nums text-fuchsia-700 dark:text-fuchsia-300 leading-none">
                               {aphydleStatsLoading ? (
-                                <span className="inline-block w-10 h-8 bg-fuchsia-200/50 dark:bg-fuchsia-800/30 rounded-lg animate-pulse" />
+                                <span className="inline-block w-8 h-6 bg-fuchsia-200/50 dark:bg-fuchsia-800/30 rounded-lg animate-pulse" />
                               ) : aphydleStatsUpdatedAt !== null ? (aphydlePlayersToday ?? "-") : "-"}
                             </div>
-                            <span className="text-xs font-medium text-fuchsia-500 dark:text-fuchsia-400">today</span>
+                            <span className="text-[11px] font-medium text-fuchsia-500 dark:text-fuchsia-400">players today</span>
                           </div>
-                          {aphydleVisitsToday != null && aphydleVisitsToday > 0 && (
-                            <div className="mt-1.5 text-[10px] text-fuchsia-600/60 dark:text-fuchsia-400/60">
-                              {aphydleVisitsToday.toLocaleString()} visit{aphydleVisitsToday === 1 ? "" : "s"} today
-                            </div>
-                          )}
                         </div>
                       </div>
 

--- a/plant-swipe/src/pages/AdminPage.tsx
+++ b/plant-swipe/src/pages/AdminPage.tsx
@@ -121,6 +121,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { SearchInput } from "@/components/ui/search-input";
 import { SearchItem, type SearchItemOption } from "@/components/ui/search-item";
+import { PillTabs } from "@/components/ui/pill-tabs";
 import { supabase } from "@/lib/supabaseClient";
 import { cn } from "@/lib/utils";
 import { setUserThreatLevel, getReportCounts } from "@/lib/moderation";
@@ -1930,6 +1931,32 @@ export const AdminPage: React.FC = () => {
     const [aphydleStatsLoading, setAphydleStatsLoading] = React.useState<boolean>(true);
     const [aphydleStatsRefreshing, setAphydleStatsRefreshing] = React.useState<boolean>(false);
     const [aphydleStatsUpdatedAt, setAphydleStatsUpdatedAt] = React.useState<number | null>(null);
+
+    // Aphydle full analytics (time series + last puzzles + totals) for the
+    // analytics tab in the GA section. Only fetched when the user switches to
+    // the "Aphydle" pill so we don't waste round-trips on the default view.
+    type AphydleSeriesPoint = { date: string; visits: number; players: number; attempts: number; wins: number };
+    type AphydlePuzzleRow = {
+      puzzleNo: number;
+      puzzleDate: string;
+      plantId: string | null;
+      plantName: string | null;
+      players: number;
+      wins: number;
+      losses: number;
+      totalPlayed: number;
+      buckets: number[];
+    };
+    type AphydleAnalytics = {
+      totals: { visits: number; plays: number; guesses: number; wins: number };
+      timeSeries: AphydleSeriesPoint[];
+      lastPuzzles: AphydlePuzzleRow[];
+    };
+    const [analyticsTab, setAnalyticsTab] = React.useState<"aphylia" | "aphydle">("aphylia");
+    const [aphydleAnalytics, setAphydleAnalytics] = React.useState<AphydleAnalytics | null>(null);
+    const [aphydleAnalyticsLoading, setAphydleAnalyticsLoading] = React.useState<boolean>(false);
+    const [aphydleAnalyticsError, setAphydleAnalyticsError] = React.useState<string | null>(null);
+    const [aphydleAnalyticsUpdatedAt, setAphydleAnalyticsUpdatedAt] = React.useState<number | null>(null);
   // Distinct, high-contrast palette for readability
   const countryColors = [
     "#10b981",
@@ -5376,6 +5403,57 @@ export const AdminPage: React.FC = () => {
     return () => clearInterval(id);
   }, [loadAphydleStats]);
 
+  // Aphydle full analytics loader — pulls /api/admin/aphydle-analytics for
+  // the chosen window. Lazy: only invoked once the user lands on the Aphydle
+  // analytics pill, then re-runs whenever gaDays changes.
+  const loadAphydleAnalytics = React.useCallback(
+    async (days: number) => {
+      setAphydleAnalyticsLoading(true);
+      setAphydleAnalyticsError(null);
+      try {
+        const session = (await supabase.auth.getSession()).data.session;
+        const token = session?.access_token;
+        const headers: Record<string, string> = { Accept: "application/json" };
+        if (token) headers["Authorization"] = `Bearer ${token}`;
+        try {
+          const adminToken = (globalThis as EnvWithAdminToken)?.__ENV__
+            ?.VITE_ADMIN_STATIC_TOKEN;
+          if (adminToken) headers["X-Admin-Token"] = String(adminToken);
+        } catch {}
+        const resp = await fetchWithRetry(
+          `/api/admin/aphydle-analytics?days=${encodeURIComponent(String(days))}`,
+          { headers, credentials: "same-origin" },
+        ).catch(() => null);
+        if (!resp || !resp.ok) {
+          setAphydleAnalyticsError("Failed to load Aphydle analytics");
+          return;
+        }
+        const data = await safeJson(resp);
+        if (data?.ok === false) {
+          setAphydleAnalyticsError(data?.error || "Failed to load Aphydle analytics");
+          return;
+        }
+        setAphydleAnalytics({
+          totals: data?.totals ?? { visits: 0, plays: 0, guesses: 0, wins: 0 },
+          timeSeries: Array.isArray(data?.timeSeries) ? data.timeSeries : [],
+          lastPuzzles: Array.isArray(data?.lastPuzzles) ? data.lastPuzzles : [],
+        });
+        setAphydleAnalyticsUpdatedAt(Date.now());
+      } catch (e) {
+        console.error("[AdminPage] Failed to load aphydle analytics:", e);
+        setAphydleAnalyticsError(e instanceof Error ? e.message : String(e));
+      } finally {
+        setAphydleAnalyticsLoading(false);
+      }
+    },
+    [safeJson, fetchWithRetry],
+  );
+
+  React.useEffect(() => {
+    if (analyticsTab !== "aphydle") return;
+    loadAphydleAnalytics(gaDays);
+  }, [analyticsTab, gaDays, loadAphydleAnalytics]);
+
 
   // Loader for list of connected IPs (unique IPs past N minutes; default 60)
   const loadEnrichedIps = React.useCallback(
@@ -8054,9 +8132,11 @@ export const AdminPage: React.FC = () => {
                                 <Activity className="h-5 w-5 text-orange-600 dark:text-orange-400" />
                               </div>
                               <div className="text-left">
-                                <div className="text-sm font-semibold">Google Analytics</div>
+                                <div className="text-sm font-semibold">Analytics</div>
                                 <div className="text-xs text-stone-500 dark:text-stone-400">
-                                  {gaConfigured === null ? "Checking..." : gaConfigured ? "GA4 Data API connected" : "Not configured"}
+                                  {analyticsTab === "aphydle"
+                                    ? "Aphydle · sister daily plant guessing game"
+                                    : (gaConfigured === null ? "Checking..." : gaConfigured ? "Aphylia · GA4 Data API connected" : "Not configured")}
                                 </div>
                               </div>
                             </div>
@@ -8079,6 +8159,18 @@ export const AdminPage: React.FC = () => {
 
                           {gaOpen && gaConfigured === true && (
                             <div className="mt-4 space-y-4">
+                              {/* Pill toggle: Aphylia (GA) ↔ Aphydle (sister daily plant guessing game) */}
+                              <PillTabs
+                                activeKey={analyticsTab}
+                                onTabChange={(k) => setAnalyticsTab(k)}
+                                tabs={[
+                                  { key: "aphylia", label: "Aphylia" },
+                                  { key: "aphydle", label: "Aphydle" },
+                                ]}
+                                className="!justify-start"
+                              />
+
+                              {analyticsTab === "aphylia" && (<>
                               {/* Period selector + refresh */}
                               <div className="flex items-center justify-between">
                                 <div className="flex items-center gap-1">
@@ -8651,6 +8743,294 @@ export const AdminPage: React.FC = () => {
                                 <div className="flex items-center gap-2 text-sm opacity-60 py-4 justify-center">
                                   <Loader2 className="h-4 w-4 animate-spin" />
                                   <span>Loading Google Analytics data...</span>
+                                </div>
+                              )}
+                              </>)}
+
+                              {/* ─── Aphydle analytics tab ─── */}
+                              {analyticsTab === "aphydle" && (
+                                <div className="space-y-4">
+                                  {/* Period selector + refresh — reuses gaDays so the toggle sticks across tabs */}
+                                  <div className="flex items-center justify-between">
+                                    <div className="flex items-center gap-1">
+                                      {([7, 14, 30] as const).map((d) => (
+                                        <button
+                                          key={d}
+                                          type="button"
+                                          className={`text-xs px-2.5 py-1 rounded-lg border transition-colors ${gaDays === d ? "bg-black dark:bg-white text-white dark:text-black border-black dark:border-white" : "bg-white dark:bg-[#2d2d30] border-stone-200 dark:border-[#3e3e42] hover:bg-stone-50 dark:hover:bg-[#3e3e42]"}`}
+                                          onClick={() => setGaDays(d)}
+                                          aria-pressed={gaDays === d}
+                                        >
+                                          {d}d
+                                        </button>
+                                      ))}
+                                    </div>
+                                    <div className="flex items-center gap-2">
+                                      {aphydleAnalyticsUpdatedAt && (
+                                        <span className="text-[10px] opacity-50">{formatTimeAgo(aphydleAnalyticsUpdatedAt)}</span>
+                                      )}
+                                      <Button
+                                        variant="outline"
+                                        size="icon"
+                                        aria-label="Refresh Aphydle analytics"
+                                        onClick={() => loadAphydleAnalytics(gaDays)}
+                                        disabled={aphydleAnalyticsLoading}
+                                        className="h-7 w-7 rounded-lg"
+                                      >
+                                        <RefreshCw className={`h-3.5 w-3.5 ${aphydleAnalyticsLoading ? "animate-spin" : ""}`} />
+                                      </Button>
+                                    </div>
+                                  </div>
+
+                                  {aphydleAnalyticsError && (
+                                    <div className="text-xs text-amber-600 dark:text-amber-400 p-2 rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800/40">
+                                      {aphydleAnalyticsError}
+                                    </div>
+                                  )}
+
+                                  {/* Summary stats: Visits / Plays / Guesses / Win rate.
+                                      Tailwind JIT can't see classes built via template strings,
+                                      so each colour ships its full set of explicit class names. */}
+                                  {aphydleAnalytics && (() => {
+                                    const t = aphydleAnalytics.totals;
+                                    const winRate = t.plays > 0 ? Math.round((t.wins / t.plays) * 1000) / 10 : 0;
+                                    const avgGuessesAcross = t.plays > 0 ? Math.round((t.guesses / t.plays) * 10) / 10 : 0;
+                                    const cards = [
+                                      {
+                                        label: "Visits", value: t.visits.toLocaleString(), icon: Eye,
+                                        wrap: "bg-blue-50/40 dark:bg-blue-950/20 border-blue-200/50 dark:border-blue-800/40",
+                                        iconCls: "text-blue-600 dark:text-blue-400",
+                                        valueCls: "text-blue-700 dark:text-blue-300",
+                                      },
+                                      {
+                                        label: "Plays", value: t.plays.toLocaleString(), icon: Gamepad2,
+                                        wrap: "bg-fuchsia-50/40 dark:bg-fuchsia-950/20 border-fuchsia-200/50 dark:border-fuchsia-800/40",
+                                        iconCls: "text-fuchsia-600 dark:text-fuchsia-400",
+                                        valueCls: "text-fuchsia-700 dark:text-fuchsia-300",
+                                      },
+                                      {
+                                        label: "Total Guesses", value: t.guesses.toLocaleString(), icon: MousePointer,
+                                        wrap: "bg-violet-50/40 dark:bg-violet-950/20 border-violet-200/50 dark:border-violet-800/40",
+                                        iconCls: "text-violet-600 dark:text-violet-400",
+                                        valueCls: "text-violet-700 dark:text-violet-300",
+                                      },
+                                      {
+                                        label: "Win Rate", value: `${winRate}%`, icon: Trophy,
+                                        wrap: "bg-emerald-50/40 dark:bg-emerald-950/20 border-emerald-200/50 dark:border-emerald-800/40",
+                                        iconCls: "text-emerald-600 dark:text-emerald-400",
+                                        valueCls: "text-emerald-700 dark:text-emerald-300",
+                                      },
+                                    ] as const;
+                                    return (
+                                      <>
+                                        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+                                          {cards.map(({ label, value, icon: Icon, wrap, iconCls, valueCls }) => (
+                                            <div key={label} className={`rounded-xl border p-3 ${wrap}`}>
+                                              <div className="flex items-center gap-2 mb-1.5">
+                                                <Icon className={`h-3.5 w-3.5 ${iconCls}`} />
+                                                <span className="text-[10px] font-semibold uppercase tracking-wider opacity-60">{label}</span>
+                                              </div>
+                                              <div className={`text-2xl font-bold tabular-nums ${valueCls}`}>{value}</div>
+                                            </div>
+                                          ))}
+                                        </div>
+                                        {t.plays > 0 && (
+                                          <div className="text-[11px] text-stone-500 dark:text-stone-400">
+                                            Average <span className="font-bold tabular-nums">{avgGuessesAcross}</span> guesses per play across the last {aphydleAnalytics.timeSeries.length} day{aphydleAnalytics.timeSeries.length === 1 ? "" : "s"}.
+                                          </div>
+                                        )}
+                                      </>
+                                    );
+                                  })()}
+
+                                  {/* Visits over time */}
+                                  {aphydleAnalytics && aphydleAnalytics.timeSeries.length > 0 && (
+                                    <div className="rounded-xl border p-3">
+                                      <div className="flex items-center justify-between mb-2">
+                                        <div className="text-sm font-medium">Daily visits — last {gaDays} days</div>
+                                        <span className="text-[10px] opacity-50">page_visits</span>
+                                      </div>
+                                      <div className="h-44 w-full">
+                                        <ChartSuspense fallback={<div className="h-full flex items-center justify-center text-sm text-gray-400">Loading chart...</div>}>
+                                          <ResponsiveContainer width="100%" height="100%">
+                                            <ComposedChart data={aphydleAnalytics.timeSeries} margin={{ top: 8, right: 8, bottom: 8, left: 8 }}>
+                                              <defs>
+                                                <linearGradient id="aphydleVisitsGrad" x1="0" y1="0" x2="0" y2="1">
+                                                  <stop offset="0%" stopColor="#3b82f6" stopOpacity={0.3} />
+                                                  <stop offset="100%" stopColor="#3b82f6" stopOpacity={0.05} />
+                                                </linearGradient>
+                                              </defs>
+                                              <CartesianGrid strokeDasharray="3 3" stroke="rgba(0,0,0,0.06)" />
+                                              <XAxis
+                                                dataKey="date"
+                                                tickFormatter={(d: string) => {
+                                                  try {
+                                                    const dt = new Date(d + "T00:00:00Z");
+                                                    return gaDays <= 14 ? ["Sun","Mon","Tue","Wed","Thu","Fri","Sat"][dt.getUTCDay()] : `${dt.getUTCMonth()+1}/${dt.getUTCDate()}`;
+                                                  } catch { return d; }
+                                                }}
+                                                tick={{ fontSize: 10 }}
+                                                axisLine={false}
+                                                tickLine={false}
+                                                interval={gaDays > 14 ? Math.floor(gaDays / 7) - 1 : 0}
+                                              />
+                                              <YAxis tick={{ fontSize: 10 }} axisLine={false} tickLine={false} width={32} allowDecimals={false} />
+                                              <Tooltip
+                                                content={({ active: tActive, payload, label }: { active?: boolean; payload?: Array<{ dataKey?: string; value?: number; color?: string }>; label?: string }) => {
+                                                  if (!tActive || !payload?.length) return null;
+                                                  return (
+                                                    <div className="rounded-xl border bg-white/95 dark:bg-[#252526] backdrop-blur p-2.5 shadow-lg text-xs">
+                                                      <div className="font-medium opacity-70 mb-1">{label}</div>
+                                                      {payload.map((p) => (
+                                                        <div key={p.dataKey} className="flex items-center gap-2">
+                                                          <span className="w-2 h-2 rounded-full" style={{ background: p.color }} />
+                                                          <span className="capitalize">{p.dataKey}</span>
+                                                          <span className="font-bold tabular-nums ml-auto">{p.value?.toLocaleString()}</span>
+                                                        </div>
+                                                      ))}
+                                                    </div>
+                                                  );
+                                                }}
+                                              />
+                                              <Area type="monotone" dataKey="visits" fill="url(#aphydleVisitsGrad)" stroke="none" />
+                                              <Line type="monotone" dataKey="visits" stroke="#3b82f6" strokeWidth={2} dot={false} />
+                                            </ComposedChart>
+                                          </ResponsiveContainer>
+                                        </ChartSuspense>
+                                      </div>
+                                    </div>
+                                  )}
+
+                                  {/* Plays + guesses + wins over time */}
+                                  {aphydleAnalytics && aphydleAnalytics.timeSeries.length > 0 && (
+                                    <div className="rounded-xl border p-3">
+                                      <div className="flex items-center justify-between mb-2">
+                                        <div className="text-sm font-medium">Plays, guesses &amp; wins — last {gaDays} days</div>
+                                        <div className="flex items-center gap-3 text-[10px]">
+                                          <span className="flex items-center gap-1"><span className="w-2 h-2 rounded-full bg-fuchsia-500" /> Plays</span>
+                                          <span className="flex items-center gap-1"><span className="w-2 h-2 rounded-full bg-violet-500" /> Guesses</span>
+                                          <span className="flex items-center gap-1"><span className="w-2 h-2 rounded-full bg-emerald-500" /> Wins</span>
+                                        </div>
+                                      </div>
+                                      <div className="h-56 w-full">
+                                        <ChartSuspense fallback={<div className="h-full flex items-center justify-center text-sm text-gray-400">Loading chart...</div>}>
+                                          <ResponsiveContainer width="100%" height="100%">
+                                            <ComposedChart data={aphydleAnalytics.timeSeries} margin={{ top: 8, right: 8, bottom: 8, left: 8 }}>
+                                              <CartesianGrid strokeDasharray="3 3" stroke="rgba(0,0,0,0.06)" />
+                                              <XAxis
+                                                dataKey="date"
+                                                tickFormatter={(d: string) => {
+                                                  try {
+                                                    const dt = new Date(d + "T00:00:00Z");
+                                                    return gaDays <= 14 ? ["Sun","Mon","Tue","Wed","Thu","Fri","Sat"][dt.getUTCDay()] : `${dt.getUTCMonth()+1}/${dt.getUTCDate()}`;
+                                                  } catch { return d; }
+                                                }}
+                                                tick={{ fontSize: 10 }}
+                                                axisLine={false}
+                                                tickLine={false}
+                                                interval={gaDays > 14 ? Math.floor(gaDays / 7) - 1 : 0}
+                                              />
+                                              <YAxis tick={{ fontSize: 10 }} axisLine={false} tickLine={false} width={32} allowDecimals={false} />
+                                              <Tooltip
+                                                content={({ active: tActive, payload, label }: { active?: boolean; payload?: Array<{ dataKey?: string; value?: number; color?: string }>; label?: string }) => {
+                                                  if (!tActive || !payload?.length) return null;
+                                                  return (
+                                                    <div className="rounded-xl border bg-white/95 dark:bg-[#252526] backdrop-blur p-2.5 shadow-lg text-xs">
+                                                      <div className="font-medium opacity-70 mb-1">{label}</div>
+                                                      {payload.map((p) => (
+                                                        <div key={p.dataKey} className="flex items-center gap-2">
+                                                          <span className="w-2 h-2 rounded-full" style={{ background: p.color }} />
+                                                          <span className="capitalize">{p.dataKey === "players" ? "plays" : p.dataKey === "attempts" ? "guesses" : p.dataKey}</span>
+                                                          <span className="font-bold tabular-nums ml-auto">{p.value?.toLocaleString()}</span>
+                                                        </div>
+                                                      ))}
+                                                    </div>
+                                                  );
+                                                }}
+                                              />
+                                              <Line type="monotone" dataKey="players" stroke="#d946ef" strokeWidth={2} dot={false} />
+                                              <Line type="monotone" dataKey="attempts" stroke="#8b5cf6" strokeWidth={2} dot={false} />
+                                              <Line type="monotone" dataKey="wins" stroke="#10b981" strokeWidth={2} dot={false} />
+                                            </ComposedChart>
+                                          </ResponsiveContainer>
+                                        </ChartSuspense>
+                                      </div>
+                                    </div>
+                                  )}
+
+                                  {/* Last 5 puzzles — one card each with a mini histogram */}
+                                  {aphydleAnalytics && aphydleAnalytics.lastPuzzles.length > 0 && (
+                                    <div>
+                                      <div className="text-sm font-medium mb-2">Last {aphydleAnalytics.lastPuzzles.length} puzzles</div>
+                                      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-3">
+                                        {aphydleAnalytics.lastPuzzles.map((p) => {
+                                          const peak = Math.max(1, ...p.buckets, p.losses);
+                                          const winRatePuzzle = p.players > 0 ? Math.round((p.wins / p.players) * 100) : 0;
+                                          // Avg guesses on a winning play: weighted average of bucket index (1..10) by bucket count
+                                          const winningGuessSum = p.buckets.reduce((s, c, i) => s + c * (i + 1), 0);
+                                          const avgWinGuesses = p.wins > 0 ? Math.round((winningGuessSum / p.wins) * 10) / 10 : null;
+                                          return (
+                                            <div key={p.puzzleNo} className="rounded-xl border p-3 bg-fuchsia-50/30 dark:bg-fuchsia-950/15 border-fuchsia-200/40 dark:border-fuchsia-800/30">
+                                              <div className="flex items-baseline justify-between mb-1">
+                                                <div className="text-xs font-semibold">#{p.puzzleNo}</div>
+                                                <div className="text-[10px] opacity-50">{p.puzzleDate}</div>
+                                              </div>
+                                              {p.plantName && (
+                                                <div className="text-[11px] text-fuchsia-700 dark:text-fuchsia-300 truncate" title={p.plantName}>{p.plantName}</div>
+                                              )}
+                                              <div className="mt-2 flex items-baseline gap-1">
+                                                <span className="text-2xl font-bold tabular-nums text-fuchsia-700 dark:text-fuchsia-300">{p.players}</span>
+                                                <span className="text-[10px] text-stone-500 dark:text-stone-400">plays</span>
+                                              </div>
+                                              <div className="text-[10px] text-stone-500 dark:text-stone-400">
+                                                {p.wins} win{p.wins === 1 ? "" : "s"} · {p.losses} loss{p.losses === 1 ? "" : "es"}
+                                                {p.players > 0 && ` · ${winRatePuzzle}%`}
+                                              </div>
+                                              {avgWinGuesses != null && (
+                                                <div className="text-[10px] text-stone-500 dark:text-stone-400">avg {avgWinGuesses} guesses to win</div>
+                                              )}
+                                              {/* Mini histogram: 1..10 wins + losses bar */}
+                                              <div className="mt-2 flex items-end gap-0.5 h-12" aria-hidden="true">
+                                                {p.buckets.map((c, i) => (
+                                                  <div
+                                                    key={i}
+                                                    className="flex-1 rounded-sm bg-emerald-400/80 dark:bg-emerald-500/70"
+                                                    style={{ height: `${(c / peak) * 100}%`, minHeight: c > 0 ? 2 : 0 }}
+                                                    title={`${i + 1} guess${i === 0 ? "" : "es"}: ${c}`}
+                                                  />
+                                                ))}
+                                                <div
+                                                  className="flex-1 rounded-sm bg-rose-400/80 dark:bg-rose-500/70"
+                                                  style={{ height: `${(p.losses / peak) * 100}%`, minHeight: p.losses > 0 ? 2 : 0 }}
+                                                  title={`Lost: ${p.losses}`}
+                                                />
+                                              </div>
+                                              <div className="mt-0.5 flex justify-between text-[9px] opacity-50">
+                                                <span>1</span>
+                                                <span>10</span>
+                                                <span>X</span>
+                                              </div>
+                                            </div>
+                                          );
+                                        })}
+                                      </div>
+                                    </div>
+                                  )}
+
+                                  {/* Loading state */}
+                                  {aphydleAnalyticsLoading && !aphydleAnalytics && (
+                                    <div className="flex items-center gap-2 text-sm opacity-60 py-4 justify-center">
+                                      <Loader2 className="h-4 w-4 animate-spin" />
+                                      <span>Loading Aphydle analytics...</span>
+                                    </div>
+                                  )}
+
+                                  {/* Empty state */}
+                                  {!aphydleAnalyticsLoading && !aphydleAnalyticsError && aphydleAnalytics && aphydleAnalytics.timeSeries.every((p) => p.visits === 0 && p.players === 0) && (
+                                    <div className="text-xs text-stone-500 dark:text-stone-400 py-4 text-center">
+                                      No Aphydle activity recorded in the last {gaDays} days.
+                                    </div>
+                                  )}
                                 </div>
                               )}
                             </div>

--- a/plant-swipe/src/pages/AdminPage.tsx
+++ b/plant-swipe/src/pages/AdminPage.tsx
@@ -7480,7 +7480,12 @@ export const AdminPage: React.FC = () => {
                               <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-fuchsia-500 to-violet-500 flex items-center justify-center shadow-sm shadow-fuchsia-500/20">
                                 <Gamepad2 className="h-4 w-4 text-white" />
                               </div>
-                              <div className="text-xs font-semibold text-fuchsia-900 dark:text-fuchsia-100">Aphydle</div>
+                              <div>
+                                <div className="text-xs font-semibold text-fuchsia-900 dark:text-fuchsia-100">Aphydle</div>
+                                <div className="text-[10px] text-fuchsia-600/60 dark:text-fuchsia-400/60">
+                                  {aphydleStatsUpdatedAt ? formatTimeAgo(aphydleStatsUpdatedAt) : "Updating..."}
+                                </div>
+                              </div>
                             </div>
                             <Button
                               variant="ghost"

--- a/plant-swipe/src/pages/AdminPage.tsx
+++ b/plant-swipe/src/pages/AdminPage.tsx
@@ -7472,13 +7472,16 @@ export const AdminPage: React.FC = () => {
                         </div>
 
                         {/* Aphydle Card — sister daily plant guessing game.
-                            Compact: fixed width on lg so it doesn't stretch
-                            the three main cards next to it. */}
-                        <div className="group relative rounded-2xl border border-fuchsia-200/70 dark:border-fuchsia-800/40 bg-gradient-to-br from-fuchsia-50/80 to-violet-50/50 dark:from-fuchsia-950/30 dark:to-violet-950/20 p-3 shadow-sm hover:shadow-md hover:shadow-fuchsia-500/8 transition-all duration-200 overflow-hidden lg:w-44">
-                          <div className="flex items-center justify-between mb-2">
-                            <div className="flex items-center gap-2">
-                              <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-fuchsia-500 to-violet-500 flex items-center justify-center shadow-sm shadow-fuchsia-500/20">
-                                <Gamepad2 className="h-4 w-4 text-white" />
+                            Matches the Registered / Plants cards' internal
+                            dimensions (p-4, w-9 logo, text-3xl number) so all
+                            four cards align; the grid template above gives it
+                            its own auto-sized column so it doesn't squash the
+                            three main cards. */}
+                        <div className="group relative rounded-2xl border border-fuchsia-200/70 dark:border-fuchsia-800/40 bg-gradient-to-br from-fuchsia-50/80 to-violet-50/50 dark:from-fuchsia-950/30 dark:to-violet-950/20 p-4 shadow-sm hover:shadow-md hover:shadow-fuchsia-500/8 transition-all duration-200 overflow-hidden lg:w-52">
+                          <div className="flex items-center justify-between mb-3">
+                            <div className="flex items-center gap-2.5">
+                              <div className="w-9 h-9 rounded-lg bg-gradient-to-br from-fuchsia-500 to-violet-500 flex items-center justify-center shadow-sm shadow-fuchsia-500/20">
+                                <Gamepad2 className="h-4.5 w-4.5 text-white" />
                               </div>
                               <div>
                                 <div className="text-xs font-semibold text-fuchsia-900 dark:text-fuchsia-100">Aphydle</div>
@@ -7493,18 +7496,18 @@ export const AdminPage: React.FC = () => {
                               aria-label="Refresh aphydle players"
                               onClick={() => loadAphydleStats({ initial: false })}
                               disabled={aphydleStatsLoading || aphydleStatsRefreshing}
-                              className="h-6 w-6 rounded-lg text-fuchsia-600 dark:text-fuchsia-400"
+                              className="h-7 w-7 rounded-lg text-fuchsia-600 dark:text-fuchsia-400"
                             >
-                              <RefreshCw className={`h-3 w-3 ${aphydleStatsLoading || aphydleStatsRefreshing ? "animate-spin" : ""}`} />
+                              <RefreshCw className={`h-3.5 w-3.5 ${aphydleStatsLoading || aphydleStatsRefreshing ? "animate-spin" : ""}`} />
                             </Button>
                           </div>
                           <div className="flex items-baseline gap-1.5">
-                            <div className="text-2xl font-bold tabular-nums text-fuchsia-700 dark:text-fuchsia-300 leading-none">
+                            <div className="text-3xl font-bold tabular-nums text-fuchsia-700 dark:text-fuchsia-300">
                               {aphydleStatsLoading ? (
-                                <span className="inline-block w-8 h-6 bg-fuchsia-200/50 dark:bg-fuchsia-800/30 rounded-lg animate-pulse" />
+                                <span className="inline-block w-10 h-8 bg-fuchsia-200/50 dark:bg-fuchsia-800/30 rounded-lg animate-pulse" />
                               ) : aphydleStatsUpdatedAt !== null ? (aphydlePlayersToday ?? "-") : "-"}
                             </div>
-                            <span className="text-[11px] font-medium text-fuchsia-500 dark:text-fuchsia-400">players today</span>
+                            <span className="text-xs font-medium text-fuchsia-500 dark:text-fuchsia-400">today</span>
                           </div>
                         </div>
                       </div>

--- a/plant-swipe/src/pages/AdminPage.tsx
+++ b/plant-swipe/src/pages/AdminPage.tsx
@@ -1926,6 +1926,7 @@ export const AdminPage: React.FC = () => {
     );
     // Aphydle (sister daily plant guessing game) — players for today's puzzle
     const [aphydlePlayersToday, setAphydlePlayersToday] = React.useState<number | null>(null);
+    const [aphydleVisitsToday, setAphydleVisitsToday] = React.useState<number | null>(null);
     const [aphydleStatsLoading, setAphydleStatsLoading] = React.useState<boolean>(true);
     const [aphydleStatsRefreshing, setAphydleStatsRefreshing] = React.useState<boolean>(false);
     const [aphydleStatsUpdatedAt, setAphydleStatsUpdatedAt] = React.useState<number | null>(null);
@@ -5348,6 +5349,7 @@ export const AdminPage: React.FC = () => {
         if (resp && resp.ok) {
           const data = await safeJson(resp);
           if (typeof data?.playersToday === "number") setAphydlePlayersToday(data.playersToday);
+          if (typeof data?.visitsToday === "number") setAphydleVisitsToday(data.visitsToday);
           setAphydleStatsUpdatedAt(Date.now());
         }
       } catch (e) {
@@ -7507,8 +7509,13 @@ export const AdminPage: React.FC = () => {
                                 <span className="inline-block w-10 h-8 bg-fuchsia-200/50 dark:bg-fuchsia-800/30 rounded-lg animate-pulse" />
                               ) : aphydleStatsUpdatedAt !== null ? (aphydlePlayersToday ?? "-") : "-"}
                             </div>
-                            <span className="text-xs font-medium text-fuchsia-500 dark:text-fuchsia-400">today</span>
+                            <span className="text-xs font-medium text-fuchsia-500 dark:text-fuchsia-400">players</span>
                           </div>
+                          {aphydleVisitsToday != null && (
+                            <div className="mt-1 text-[10px] text-fuchsia-600/60 dark:text-fuchsia-400/60 tabular-nums">
+                              {aphydleVisitsToday.toLocaleString()} visit{aphydleVisitsToday === 1 ? "" : "s"} today
+                            </div>
+                          )}
                         </div>
                       </div>
 

--- a/plant-swipe/src/pages/AdminPage.tsx
+++ b/plant-swipe/src/pages/AdminPage.tsx
@@ -104,6 +104,7 @@ import {
   Eye,
   MousePointer,
   ArrowDownRight,
+  Gamepad2,
 } from "lucide-react";
 import {
   DropdownMenu,
@@ -1923,6 +1924,13 @@ export const AdminPage: React.FC = () => {
     const [plantsUpdatedAt, setPlantsUpdatedAt] = React.useState<number | null>(
       null,
     );
+    // Aphydle (sister daily plant guessing game) — players for today's puzzle
+    const [aphydlePlayersToday, setAphydlePlayersToday] = React.useState<number | null>(null);
+    const [aphydleVisitsToday, setAphydleVisitsToday] = React.useState<number | null>(null);
+    const [aphydlePuzzleNo, setAphydlePuzzleNo] = React.useState<number | null>(null);
+    const [aphydleStatsLoading, setAphydleStatsLoading] = React.useState<boolean>(true);
+    const [aphydleStatsRefreshing, setAphydleStatsRefreshing] = React.useState<boolean>(false);
+    const [aphydleStatsUpdatedAt, setAphydleStatsUpdatedAt] = React.useState<number | null>(null);
   // Distinct, high-contrast palette for readability
   const countryColors = [
     "#10b981",
@@ -5319,6 +5327,57 @@ export const AdminPage: React.FC = () => {
     return () => clearInterval(id);
   }, [loadRegisteredCount]);
 
+  // Loader for Aphydle (sister daily plant guessing game) stats
+  const loadAphydleStats = React.useCallback(
+    async (opts?: { initial?: boolean }) => {
+      const isInitial = !!opts?.initial;
+      if (isInitial) setAphydleStatsLoading(true);
+      else setAphydleStatsRefreshing(true);
+      try {
+        const session = (await supabase.auth.getSession()).data.session;
+        const token = session?.access_token;
+        const headers: Record<string, string> = { Accept: "application/json" };
+        if (token) headers["Authorization"] = `Bearer ${token}`;
+        try {
+          const adminToken = (globalThis as EnvWithAdminToken)?.__ENV__
+            ?.VITE_ADMIN_STATIC_TOKEN;
+          if (adminToken) headers["X-Admin-Token"] = String(adminToken);
+        } catch {}
+        const resp = await fetchWithRetry("/api/admin/aphydle-stats", {
+          headers,
+          credentials: "same-origin",
+        }).catch(() => null);
+        if (resp && resp.ok) {
+          const data = await safeJson(resp);
+          if (typeof data?.playersToday === "number") setAphydlePlayersToday(data.playersToday);
+          if (typeof data?.visitsToday === "number") setAphydleVisitsToday(data.visitsToday);
+          if (typeof data?.puzzleNo === "number") setAphydlePuzzleNo(data.puzzleNo);
+          setAphydleStatsUpdatedAt(Date.now());
+        }
+      } catch (e) {
+        console.error("[AdminPage] Failed to load aphydle stats:", e);
+      } finally {
+        if (isInitial) setAphydleStatsLoading(false);
+        else setAphydleStatsRefreshing(false);
+      }
+    },
+    [safeJson, fetchWithRetry],
+  );
+
+  React.useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      loadAphydleStats({ initial: true });
+    }, 400);
+    return () => clearTimeout(timeoutId);
+  }, [loadAphydleStats]);
+
+  React.useEffect(() => {
+    const id = setInterval(() => {
+      loadAphydleStats({ initial: false });
+    }, 60_000);
+    return () => clearInterval(id);
+  }, [loadAphydleStats]);
+
 
   // Loader for list of connected IPs (unique IPs past N minutes; default 60)
   const loadEnrichedIps = React.useCallback(
@@ -7291,7 +7350,7 @@ export const AdminPage: React.FC = () => {
                       </div>
 
                       {/* Quick Stats Cards */}
-                      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+                      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
                         {/* Currently Online Card — powered by GA Realtime */}
                         <div className="group relative rounded-2xl border border-emerald-200/70 dark:border-emerald-800/40 bg-gradient-to-br from-emerald-50/80 to-teal-50/50 dark:from-emerald-950/30 dark:to-teal-950/20 p-4 shadow-sm hover:shadow-md hover:shadow-emerald-500/8 transition-all duration-200 overflow-hidden">
                           <div className="flex items-center justify-between mb-3">
@@ -7410,6 +7469,48 @@ export const AdminPage: React.FC = () => {
                             </div>
                             <span className="text-xs font-medium text-amber-500 dark:text-amber-400">plants</span>
                           </div>
+                        </div>
+
+                        {/* Aphydle Players Today Card — sister daily plant guessing game */}
+                        <div className="group relative rounded-2xl border border-fuchsia-200/70 dark:border-fuchsia-800/40 bg-gradient-to-br from-fuchsia-50/80 to-violet-50/50 dark:from-fuchsia-950/30 dark:to-violet-950/20 p-4 shadow-sm hover:shadow-md hover:shadow-fuchsia-500/8 transition-all duration-200 overflow-hidden">
+                          <div className="flex items-center justify-between mb-3">
+                            <div className="flex items-center gap-2.5">
+                              <div className="w-9 h-9 rounded-lg bg-gradient-to-br from-fuchsia-500 to-violet-500 flex items-center justify-center shadow-sm shadow-fuchsia-500/20">
+                                <Gamepad2 className="h-4.5 w-4.5 text-white" />
+                              </div>
+                              <div>
+                                <div className="text-xs font-semibold text-fuchsia-900 dark:text-fuchsia-100">Aphydle Players</div>
+                                <div className="text-[10px] text-fuchsia-600/60 dark:text-fuchsia-400/60">
+                                  {aphydlePuzzleNo != null
+                                    ? `Puzzle #${aphydlePuzzleNo} · ${aphydleStatsUpdatedAt ? formatTimeAgo(aphydleStatsUpdatedAt) : "Updating..."}`
+                                    : aphydleStatsUpdatedAt ? formatTimeAgo(aphydleStatsUpdatedAt) : "Updating..."}
+                                </div>
+                              </div>
+                            </div>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              aria-label="Refresh aphydle players"
+                              onClick={() => loadAphydleStats({ initial: false })}
+                              disabled={aphydleStatsLoading || aphydleStatsRefreshing}
+                              className="h-7 w-7 rounded-lg text-fuchsia-600 dark:text-fuchsia-400"
+                            >
+                              <RefreshCw className={`h-3.5 w-3.5 ${aphydleStatsLoading || aphydleStatsRefreshing ? "animate-spin" : ""}`} />
+                            </Button>
+                          </div>
+                          <div className="flex items-baseline gap-1.5">
+                            <div className="text-3xl font-bold tabular-nums text-fuchsia-700 dark:text-fuchsia-300">
+                              {aphydleStatsLoading ? (
+                                <span className="inline-block w-10 h-8 bg-fuchsia-200/50 dark:bg-fuchsia-800/30 rounded-lg animate-pulse" />
+                              ) : aphydleStatsUpdatedAt !== null ? (aphydlePlayersToday ?? "-") : "-"}
+                            </div>
+                            <span className="text-xs font-medium text-fuchsia-500 dark:text-fuchsia-400">today</span>
+                          </div>
+                          {aphydleVisitsToday != null && aphydleVisitsToday > 0 && (
+                            <div className="mt-1.5 text-[10px] text-fuchsia-600/60 dark:text-fuchsia-400/60">
+                              {aphydleVisitsToday.toLocaleString()} visit{aphydleVisitsToday === 1 ? "" : "s"} today
+                            </div>
+                          )}
                         </div>
                       </div>
 

--- a/plant-swipe/src/pages/LandingPage.css
+++ b/plant-swipe/src/pages/LandingPage.css
@@ -90,6 +90,31 @@
   background: rgba(30, 30, 30, 0.7);
 }
 
+/* Aphydle tease-strip pixel sprites: gentle staggered bobbing on group hover.
+   Idle they sit still so the card stays calm; on hover they wiggle to invite
+   a click. The mystery sprite is rendered as a dark silhouette so users can't
+   tell which plant it is — same shape as the others, but unreadable. */
+@keyframes aphydle-sprite-bob {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-4px); }
+}
+.aphydle-tease-sprite {
+  transition: transform 0.25s ease-out;
+}
+.group:hover .aphydle-tease-sprite {
+  animation: aphydle-sprite-bob 1.4s ease-in-out infinite;
+}
+.group:hover .aphydle-tease-sprite:nth-child(2) { animation-delay: 0.1s; }
+.group:hover .aphydle-tease-sprite:nth-child(3) { animation-delay: 0.2s; }
+.group:hover .aphydle-tease-sprite:nth-child(4) { animation-delay: 0.3s; }
+.group:hover .aphydle-tease-sprite:nth-child(5) { animation-delay: 0.4s; }
+.aphydle-tease-mystery {
+  filter: brightness(0) saturate(100%) opacity(0.55);
+}
+.dark .aphydle-tease-mystery {
+  filter: brightness(0) saturate(100%) invert(15%) opacity(0.7);
+}
+
 /* Pause animations when section is not visible (controlled via JS) */
 .landing-section-hidden .animate-float,
 .landing-section-hidden .animate-float-slow,

--- a/plant-swipe/src/pages/LandingPage.tsx
+++ b/plant-swipe/src/pages/LandingPage.tsx
@@ -12,6 +12,7 @@ import { useLanguageNavigate, usePathWithoutLanguage } from "@/lib/i18nRouting"
 import { supabase } from "@/lib/supabaseClient"
 import i18n from "@/lib/i18n"
 import { DitheringShader } from "@/components/ui/dithering-shader"
+import { PixelSprite } from "@/components/ui/pixel-sprite"
 import "./LandingPage.css"
 
 // Intersection Observer hook: defers rendering of below-fold sections until they approach the viewport.
@@ -2102,6 +2103,23 @@ const AphydleSection: React.FC = React.memo(() => {
       "A new mystery plant every day. Use progressive botanical clues — foliage, habitat, family — to guess the species before you run out of tries.",
   })
   const cta = t("aphydle.cta", { defaultValue: "Play Aphydle" })
+  const tease = t("aphydle.tease", { defaultValue: "Can you guess what's growing today?" })
+
+  // Show the URL as it appears in the browser address bar (host only, no scheme)
+  // so the favicon-flanked tab preview reads naturally.
+  const aphydleHostLabel = React.useMemo(() => {
+    try { return new URL(aphydleUrl).host } catch { return "aphydle" }
+  }, [aphydleUrl])
+
+  // Decorative pixel-plant strip — five plants in a procession of growth stages
+  // mixed across the three available sprite sheets. The last slot is left as
+  // "???" to tease that today's plant could be anything.
+  const teaseSprites: Array<{ name: "Growing_Plant_00" | "Growing_Plant_01" | "Growing_Plant_03"; state: number }> = [
+    { name: "Growing_Plant_00", state: 0 },
+    { name: "Growing_Plant_01", state: 1 },
+    { name: "Growing_Plant_00", state: 2 },
+    { name: "Growing_Plant_03", state: 3 },
+  ]
 
   return (
     <section className="py-12 lg:py-16 px-4 sm:px-6 lg:px-8">
@@ -2119,47 +2137,94 @@ const AphydleSection: React.FC = React.memo(() => {
             <div className="pointer-events-none absolute -top-16 -right-10 w-64 h-64 bg-violet-500/10 rounded-full blur-3xl" />
             <div className="pointer-events-none absolute -bottom-16 -left-10 w-64 h-64 bg-emerald-500/10 rounded-full blur-3xl" />
 
-            <div className="relative flex flex-col sm:flex-row items-center gap-6 p-6 sm:p-8">
-              {/* Logo block */}
-              <div className="relative shrink-0">
-                <div className="absolute inset-0 bg-gradient-to-br from-violet-500/30 to-emerald-500/30 rounded-2xl blur-lg group-hover:from-violet-500/40 group-hover:to-emerald-500/40 transition-colors" />
-                <div className="relative h-20 w-20 rounded-2xl bg-white dark:bg-stone-950 border border-stone-200 dark:border-stone-800 flex items-center justify-center shadow-sm">
-                  <img
-                    src="/icons/plant-swipe-icon.svg"
-                    alt=""
-                    className="h-12 w-12 plant-icon-theme"
-                    draggable="false"
-                    aria-hidden="true"
-                  />
-                  <span className="absolute -bottom-2 -right-2 h-7 w-7 rounded-full bg-gradient-to-br from-violet-500 to-emerald-500 flex items-center justify-center shadow-md ring-2 ring-white dark:ring-stone-950">
-                    <Gamepad2 className="h-3.5 w-3.5 text-white" />
-                  </span>
+            <div className="relative p-6 sm:p-8">
+              {/* Top row: logo + text + CTA */}
+              <div className="flex flex-col sm:flex-row items-center gap-6">
+                {/* Logo block — Aphydle's favicon (shared with Aphylia) */}
+                <div className="relative shrink-0">
+                  <div className="absolute inset-0 bg-gradient-to-br from-violet-500/30 to-emerald-500/30 rounded-2xl blur-lg group-hover:from-violet-500/40 group-hover:to-emerald-500/40 transition-colors" />
+                  <div className="relative h-20 w-20 rounded-2xl bg-white dark:bg-stone-950 border border-stone-200 dark:border-stone-800 flex items-center justify-center shadow-sm">
+                    <img
+                      src="/icons/plant-swipe-icon.svg"
+                      alt=""
+                      className="h-12 w-12 plant-icon-theme"
+                      draggable="false"
+                      aria-hidden="true"
+                    />
+                    <span className="absolute -bottom-2 -right-2 h-7 w-7 rounded-full bg-gradient-to-br from-violet-500 to-emerald-500 flex items-center justify-center shadow-md ring-2 ring-white dark:ring-stone-950">
+                      <Gamepad2 className="h-3.5 w-3.5 text-white" />
+                    </span>
+                  </div>
+                </div>
+
+                {/* Text + browser-tab style URL preview (favicon flanks the host) */}
+                <div className="flex-1 min-w-0 text-center sm:text-left">
+                  <div className="inline-flex items-center gap-1.5 text-xs font-medium uppercase tracking-wider text-violet-600 dark:text-violet-400">
+                    <Sparkles className="h-3.5 w-3.5" />
+                    {eyebrow}
+                  </div>
+                  <div className="mt-1.5 flex items-baseline gap-2 justify-center sm:justify-start flex-wrap">
+                    <span className="font-brand text-2xl sm:text-3xl font-bold tracking-tight text-stone-900 dark:text-white">
+                      {title}
+                    </span>
+                    <span className="text-sm text-stone-500 dark:text-stone-400">
+                      · {tagline}
+                    </span>
+                  </div>
+                  <p className="mt-2 text-sm sm:text-base text-stone-600 dark:text-stone-300 leading-relaxed">
+                    {description}
+                  </p>
+                  {/* Browser-tab style URL chip — favicon next to the host */}
+                  <div className="mt-3 inline-flex items-center gap-2 px-2.5 py-1 rounded-md bg-stone-100 dark:bg-stone-800/70 border border-stone-200/70 dark:border-stone-700/70 text-xs text-stone-600 dark:text-stone-300 font-mono">
+                    <img
+                      src="/icons/plant-swipe-icon.svg"
+                      alt=""
+                      className="h-3.5 w-3.5 plant-icon-theme"
+                      draggable="false"
+                      aria-hidden="true"
+                    />
+                    <span className="truncate">{aphydleHostLabel}</span>
+                  </div>
+                </div>
+
+                {/* CTA */}
+                <div className="shrink-0 inline-flex items-center gap-2 px-5 py-3 rounded-xl bg-stone-900 text-white dark:bg-white dark:text-stone-900 text-sm font-semibold shadow-sm group-hover:bg-stone-800 dark:group-hover:bg-stone-100 transition-colors">
+                  {cta}
+                  <ExternalLink className="h-4 w-4 opacity-80 group-hover:translate-x-0.5 transition-transform" />
                 </div>
               </div>
 
-              {/* Text + CTA */}
-              <div className="flex-1 min-w-0 text-center sm:text-left">
-                <div className="inline-flex items-center gap-1.5 text-xs font-medium uppercase tracking-wider text-violet-600 dark:text-violet-400">
-                  <Sparkles className="h-3.5 w-3.5" />
-                  {eyebrow}
+              {/* Pixel-plant tease strip — growth-stage procession + a hidden "today's plant" */}
+              <div className="mt-6 pt-5 border-t border-stone-200/70 dark:border-stone-800/70 flex items-center gap-4 sm:gap-6 justify-center sm:justify-start">
+                <div
+                  className="flex items-end gap-3 sm:gap-4"
+                  aria-hidden="true"
+                >
+                  {teaseSprites.map((s, i) => (
+                    <PixelSprite
+                      key={`${s.name}-${i}`}
+                      name={s.name}
+                      state={s.state}
+                      scale={3}
+                      className="aphydle-tease-sprite"
+                    />
+                  ))}
+                  {/* Mystery plant: a real sprite turned into a silhouette with a "?" overlay */}
+                  <div className="relative inline-flex items-end justify-center">
+                    <PixelSprite
+                      name="Growing_Plant_03"
+                      state={3}
+                      scale={3}
+                      className="aphydle-tease-sprite aphydle-tease-mystery"
+                    />
+                    <span className="absolute inset-0 flex items-center justify-center text-xl font-bold text-white drop-shadow">
+                      ?
+                    </span>
+                  </div>
                 </div>
-                <div className="mt-1.5 flex items-baseline gap-2 justify-center sm:justify-start flex-wrap">
-                  <span className="font-brand text-2xl sm:text-3xl font-bold tracking-tight text-stone-900 dark:text-white">
-                    {title}
-                  </span>
-                  <span className="text-sm text-stone-500 dark:text-stone-400">
-                    · {tagline}
-                  </span>
-                </div>
-                <p className="mt-2 text-sm sm:text-base text-stone-600 dark:text-stone-300 leading-relaxed">
-                  {description}
-                </p>
-              </div>
-
-              {/* CTA arrow / button */}
-              <div className="shrink-0 inline-flex items-center gap-2 px-5 py-3 rounded-xl bg-stone-900 text-white dark:bg-white dark:text-stone-900 text-sm font-semibold shadow-sm group-hover:bg-stone-800 dark:group-hover:bg-stone-100 transition-colors">
-                {cta}
-                <ExternalLink className="h-4 w-4 opacity-80 group-hover:translate-x-0.5 transition-transform" />
+                <span className="text-sm text-stone-500 dark:text-stone-400 italic">
+                  {tease}
+                </span>
               </div>
             </div>
           </div>

--- a/plant-swipe/src/pages/LandingPage.tsx
+++ b/plant-swipe/src/pages/LandingPage.tsx
@@ -76,7 +76,33 @@ import {
   Flame,
   Calendar,
   PawPrint,
+  Gamepad2,
+  ExternalLink,
 } from "lucide-react"
+
+// Aphydle (sister daily plant guessing game) is served on `aphydle.<primary>`
+// per plant-swipe.conf / setup.sh. Derive the URL from the current host (or
+// VITE_SITE_URL when SSRing) so each environment links to its own subdomain.
+// VITE_APHYDLE_URL overrides everything for special builds.
+const getAphydleUrl = (): string => {
+  const override = (import.meta.env.VITE_APHYDLE_URL as string | undefined)?.trim()
+  if (override) {
+    try { return new URL(override).origin + "/" } catch { /* fall through */ }
+  }
+  const candidate =
+    (typeof window !== "undefined" && window.location?.origin) ||
+    (import.meta.env.VITE_SITE_URL as string | undefined) ||
+    "https://aphylia.app"
+  try {
+    const parsed = new URL(candidate)
+    let host = parsed.hostname
+    if (host.startsWith("www.")) host = host.slice(4)
+    if (!host.startsWith("aphydle.")) host = `aphydle.${host}`
+    return `${parsed.protocol}//${host}/`
+  } catch {
+    return "https://aphydle.aphylia.app/"
+  }
+}
 
 // Types for database data
 type HeroCard = {
@@ -529,6 +555,10 @@ const LandingPage: React.FC = () => {
         {(landingData.settings?.show_final_cta_section ?? true) && (
           <LazySection minHeight="300px"><FinalCTASection /></LazySection>
         )}
+
+        {/* Sister-app card: Aphydle (daily plant guessing game). Placed near the
+            bottom because it's a side project, not the main product. */}
+        <LazySection minHeight="180px"><AphydleSection /></LazySection>
 
         {/* Footer */}
         <Footer />
@@ -2051,6 +2081,89 @@ const FAQSection: React.FC = React.memo(() => {
             </div>
           </div>
         </div>
+      </div>
+    </section>
+  )
+})
+
+/* ═══════════════════════════════════════════════════════════════════════════════
+   APHYDLE SISTER-APP CARD - compact cross-link to the daily plant guessing game
+   Sized intentionally smaller than the main CTAs since Aphydle is a side project.
+   ═══════════════════════════════════════════════════════════════════════════════ */
+const AphydleSection: React.FC = React.memo(() => {
+  const { t } = useTranslation("Landing")
+  const aphydleUrl = React.useMemo(() => getAphydleUrl(), [])
+
+  const eyebrow = t("aphydle.eyebrow", { defaultValue: "From the Aphylia team" })
+  const title = t("aphydle.title", { defaultValue: "Aphydle" })
+  const tagline = t("aphydle.tagline", { defaultValue: "Daily plant guessing game" })
+  const description = t("aphydle.description", {
+    defaultValue:
+      "A new mystery plant every day. Use progressive botanical clues — foliage, habitat, family — to guess the species before you run out of tries.",
+  })
+  const cta = t("aphydle.cta", { defaultValue: "Play Aphydle" })
+
+  return (
+    <section className="py-12 lg:py-16 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-4xl mx-auto">
+        <a
+          href={aphydleUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="group block no-underline"
+          aria-label={`${title} — ${tagline}`}
+        >
+          <div className="relative overflow-hidden rounded-3xl border border-stone-200/70 dark:border-stone-800/70 bg-white/70 dark:bg-stone-900/60 backdrop-blur-sm shadow-sm hover:shadow-lg hover:-translate-y-0.5 transition-all">
+            {/* Subtle accent gradient (violet/emerald) to set Aphydle apart from the main palette */}
+            <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-violet-500/[0.05] via-transparent to-emerald-500/[0.06]" />
+            <div className="pointer-events-none absolute -top-16 -right-10 w-64 h-64 bg-violet-500/10 rounded-full blur-3xl" />
+            <div className="pointer-events-none absolute -bottom-16 -left-10 w-64 h-64 bg-emerald-500/10 rounded-full blur-3xl" />
+
+            <div className="relative flex flex-col sm:flex-row items-center gap-6 p-6 sm:p-8">
+              {/* Logo block */}
+              <div className="relative shrink-0">
+                <div className="absolute inset-0 bg-gradient-to-br from-violet-500/30 to-emerald-500/30 rounded-2xl blur-lg group-hover:from-violet-500/40 group-hover:to-emerald-500/40 transition-colors" />
+                <div className="relative h-20 w-20 rounded-2xl bg-white dark:bg-stone-950 border border-stone-200 dark:border-stone-800 flex items-center justify-center shadow-sm">
+                  <img
+                    src="/icons/plant-swipe-icon.svg"
+                    alt=""
+                    className="h-12 w-12 plant-icon-theme"
+                    draggable="false"
+                    aria-hidden="true"
+                  />
+                  <span className="absolute -bottom-2 -right-2 h-7 w-7 rounded-full bg-gradient-to-br from-violet-500 to-emerald-500 flex items-center justify-center shadow-md ring-2 ring-white dark:ring-stone-950">
+                    <Gamepad2 className="h-3.5 w-3.5 text-white" />
+                  </span>
+                </div>
+              </div>
+
+              {/* Text + CTA */}
+              <div className="flex-1 min-w-0 text-center sm:text-left">
+                <div className="inline-flex items-center gap-1.5 text-xs font-medium uppercase tracking-wider text-violet-600 dark:text-violet-400">
+                  <Sparkles className="h-3.5 w-3.5" />
+                  {eyebrow}
+                </div>
+                <div className="mt-1.5 flex items-baseline gap-2 justify-center sm:justify-start flex-wrap">
+                  <span className="font-brand text-2xl sm:text-3xl font-bold tracking-tight text-stone-900 dark:text-white">
+                    {title}
+                  </span>
+                  <span className="text-sm text-stone-500 dark:text-stone-400">
+                    · {tagline}
+                  </span>
+                </div>
+                <p className="mt-2 text-sm sm:text-base text-stone-600 dark:text-stone-300 leading-relaxed">
+                  {description}
+                </p>
+              </div>
+
+              {/* CTA arrow / button */}
+              <div className="shrink-0 inline-flex items-center gap-2 px-5 py-3 rounded-xl bg-stone-900 text-white dark:bg-white dark:text-stone-900 text-sm font-semibold shadow-sm group-hover:bg-stone-800 dark:group-hover:bg-stone-100 transition-colors">
+                {cta}
+                <ExternalLink className="h-4 w-4 opacity-80 group-hover:translate-x-0.5 transition-transform" />
+              </div>
+            </div>
+          </div>
+        </a>
       </div>
     </section>
   )

--- a/plant-swipe/src/pages/LandingPage.tsx
+++ b/plant-swipe/src/pages/LandingPage.tsx
@@ -2145,16 +2145,16 @@ const AphydleSection: React.FC = React.memo(() => {
                 {/* Logo block — official Aphydle brand mark */}
                 <div className="relative shrink-0">
                   <div className="absolute inset-0 bg-gradient-to-br from-violet-500/30 to-emerald-500/30 rounded-2xl blur-lg group-hover:from-violet-500/40 group-hover:to-emerald-500/40 transition-colors" />
-                  <div className="relative h-20 w-20 rounded-2xl bg-white dark:bg-stone-950 border border-stone-200 dark:border-stone-800 flex items-center justify-center shadow-sm overflow-hidden">
+                  <div className="relative h-20 w-20 rounded-2xl bg-white dark:bg-stone-950 border border-stone-200 dark:border-stone-800 flex items-center justify-center shadow-sm">
                     <img
                       src={APHYDLE_LOGO_URL}
                       alt="Aphydle"
-                      className="h-16 w-16 object-contain"
+                      className="h-16 w-16 object-contain rounded-xl"
                       loading="lazy"
                       decoding="async"
                       draggable="false"
                     />
-                    <span className="absolute -bottom-2 -right-2 h-7 w-7 rounded-full bg-gradient-to-br from-violet-500 to-emerald-500 flex items-center justify-center shadow-md ring-2 ring-white dark:ring-stone-950">
+                    <span className="absolute -top-2 -right-2 h-7 w-7 rounded-full bg-gradient-to-br from-violet-500 to-emerald-500 flex items-center justify-center shadow-md ring-2 ring-white dark:ring-stone-950">
                       <Gamepad2 className="h-3.5 w-3.5 text-white" />
                     </span>
                   </div>

--- a/plant-swipe/src/pages/LandingPage.tsx
+++ b/plant-swipe/src/pages/LandingPage.tsx
@@ -85,6 +85,8 @@ import {
 // per plant-swipe.conf / setup.sh. Derive the URL from the current host (or
 // VITE_SITE_URL when SSRing) so each environment links to its own subdomain.
 // VITE_APHYDLE_URL overrides everything for special builds.
+const APHYDLE_LOGO_URL =
+  "https://media.aphylia.app/UTILITY/admin/aphydle/webp/final-c031f1aa-619f-440e-b748-291f29c8987b.webp"
 const getAphydleUrl = (): string => {
   const override = (import.meta.env.VITE_APHYDLE_URL as string | undefined)?.trim()
   if (override) {
@@ -2140,16 +2142,17 @@ const AphydleSection: React.FC = React.memo(() => {
             <div className="relative p-6 sm:p-8">
               {/* Top row: logo + text + CTA */}
               <div className="flex flex-col sm:flex-row items-center gap-6">
-                {/* Logo block — Aphydle's favicon (shared with Aphylia) */}
+                {/* Logo block — official Aphydle brand mark */}
                 <div className="relative shrink-0">
                   <div className="absolute inset-0 bg-gradient-to-br from-violet-500/30 to-emerald-500/30 rounded-2xl blur-lg group-hover:from-violet-500/40 group-hover:to-emerald-500/40 transition-colors" />
-                  <div className="relative h-20 w-20 rounded-2xl bg-white dark:bg-stone-950 border border-stone-200 dark:border-stone-800 flex items-center justify-center shadow-sm">
+                  <div className="relative h-20 w-20 rounded-2xl bg-white dark:bg-stone-950 border border-stone-200 dark:border-stone-800 flex items-center justify-center shadow-sm overflow-hidden">
                     <img
-                      src="/icons/plant-swipe-icon.svg"
-                      alt=""
-                      className="h-12 w-12 plant-icon-theme"
+                      src={APHYDLE_LOGO_URL}
+                      alt="Aphydle"
+                      className="h-16 w-16 object-contain"
+                      loading="lazy"
+                      decoding="async"
                       draggable="false"
-                      aria-hidden="true"
                     />
                     <span className="absolute -bottom-2 -right-2 h-7 w-7 rounded-full bg-gradient-to-br from-violet-500 to-emerald-500 flex items-center justify-center shadow-md ring-2 ring-white dark:ring-stone-950">
                       <Gamepad2 className="h-3.5 w-3.5 text-white" />
@@ -2174,12 +2177,14 @@ const AphydleSection: React.FC = React.memo(() => {
                   <p className="mt-2 text-sm sm:text-base text-stone-600 dark:text-stone-300 leading-relaxed">
                     {description}
                   </p>
-                  {/* Browser-tab style URL chip — favicon next to the host */}
+                  {/* Browser-tab style URL chip — Aphydle favicon next to the host */}
                   <div className="mt-3 inline-flex items-center gap-2 px-2.5 py-1 rounded-md bg-stone-100 dark:bg-stone-800/70 border border-stone-200/70 dark:border-stone-700/70 text-xs text-stone-600 dark:text-stone-300 font-mono">
                     <img
-                      src="/icons/plant-swipe-icon.svg"
+                      src={APHYDLE_LOGO_URL}
                       alt=""
-                      className="h-3.5 w-3.5 plant-icon-theme"
+                      className="h-3.5 w-3.5 object-contain"
+                      loading="lazy"
+                      decoding="async"
                       draggable="false"
                       aria-hidden="true"
                     />

--- a/plant-swipe/src/vite-env.d.ts
+++ b/plant-swipe/src/vite-env.d.ts
@@ -9,6 +9,8 @@ interface ImportMetaEnv {
   readonly VITE_API_ORIGIN?: string
   /** Canonical public site URL. */
   readonly VITE_SITE_URL?: string
+  /** Override for the Aphydle (sister daily plant guessing game) origin. */
+  readonly VITE_APHYDLE_URL?: string
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
Integrates Aphydle (a sister daily plant guessing game) into the Aphylia ecosystem by adding admin analytics dashboards, real-time stats tracking, and landing page cross-promotion.

## Key Changes

### Admin Dashboard
- **Aphydle stats card**: Displays today's player count and page visits with auto-refresh every 60 seconds
- **Aphydle analytics tab**: Full time-series analytics (visits, plays, guesses, win rate) with configurable 7/14/30-day windows
- **Analytics UI**: Summary cards, daily visit charts, and detailed puzzle performance breakdowns with guess distribution histograms
- **PillTabs component**: Toggle between Aphylia (GA4) and Aphydle analytics within the same section

### Backend APIs
- **`/api/admin/aphydle-stats`**: Real-time endpoint returning today's player count and page visits from `aphydle.puzzle_results` and `aphydle.page_visits` tables
- **`/api/admin/aphydle-analytics`**: Comprehensive analytics endpoint with:
  - Time-series data (visits, players, attempts, wins per day)
  - Last 5 puzzles with plant details and guess distribution buckets
  - Aggregate totals (visits, plays, guesses, wins)
  - Configurable lookback window (1–90 days)

### Landing Page
- **Aphydle cross-promotion card**: Compact section near footer with official branding, description, and CTA
- **Pixel sprite tease strip**: Animated decorative plants with staggered hover effects and mystery plant silhouette
- **Dynamic URL derivation**: Automatically links to `aphydle.<primary-domain>` subdomain with environment variable overrides

### SEO & Sitemap
- **Sitemap integration**: Aphydle homepage added as top-priority (1.0) daily-changing entry
- **URL derivation helpers**: Consistent logic across server, client, and build scripts to resolve Aphydle origin from primary site URL

### Localization
- **English & French translations**: Added Aphydle section strings (eyebrow, title, tagline, description, CTA, tease)

### Styling & UX
- **Aphydle card design**: Violet/emerald gradient accents to differentiate from main Aphylia palette
- **Sprite animations**: CSS keyframes for gentle bobbing on hover with staggered delays
- **Responsive grid**: Admin stats cards use custom grid template to preserve original 3-column layout while accommodating the 4th Aphydle card

## Implementation Details
- Puzzle numbering uses epoch-based calculation (2026-04-27) matching Aphydle's game engine
- Analytics queries source from `aphydle.puzzle_results` (authoritative outcomes) rather than racy attempts state
- Plant name resolution is best-effort; failures don't block analytics display
- All Aphydle URLs support environment variable overrides (`VITE_APHYDLE_URL`, `PLANTSWIPE_APHYDLE_URL`) for custom deployments
- Admin endpoints require authentication (ensureAdmin check) and support both session tokens and static admin tokens

https://claude.ai/code/session_01Tsz464YBkmAHeWBpDVm7yd