### PR TITLE
Add Aphydle export button and fix SEO configuration

### DIFF
--- a/plant-swipe/src/pages/AdminPage.tsx
+++ b/plant-swipe/src/pages/AdminPage.tsx
@@ -7562,6 +7562,28 @@ export const AdminPage: React.FC = () => {
                                 {refreshingAphydle ? "Refreshing..." : "Refresh Aphydle"}
                               </Button>
 
+                              {/* Open Aphydle Export — Aphydle's /export route renders the
+                                  share-card archive picker. Derive the host from the current
+                                  domain (e.g. dev01.aphylia.app → aphydle.dev01.aphylia.app)
+                                  so this Just Works on every deploy that registers the
+                                  Aphydle subdomain in domain.json. */}
+                              <Button
+                                variant="outline"
+                                className="w-full rounded-xl justify-start gap-2"
+                                onClick={() => {
+                                  const host = window.location.hostname;
+                                  const isLocal = host === "localhost" || host === "127.0.0.1" || host.endsWith(".local");
+                                  const url = isLocal
+                                    ? `${window.location.protocol}//${host}:4173/export`
+                                    : `https://aphydle.${host}/export`;
+                                  window.open(url, "_blank", "noopener,noreferrer");
+                                }}
+                                title="Open Aphydle's admin export archive in a new tab"
+                              >
+                                <ExternalLink className="h-4 w-4" />
+                                Open Aphydle Export
+                              </Button>
+
                               {/* Clear Memory Button */}
                               <Button
                                 variant="outline"

--- a/setup.sh
+++ b/setup.sh
@@ -1655,9 +1655,17 @@ setup_aphydle() {
     _primary_for_env="$(get_primary_domain_from_domain_json "$REPO_DIR/domain.json")"
     if [[ -n "$_primary_for_env" && "$_primary_for_env" != "__PRIMARY_DOMAIN__" ]]; then
       local _host_url="https://$_primary_for_env"
-      log "Injecting VITE_APHYLIA_HOST_URL=$_host_url into Aphydle .env"
-      $SUDO sed -i '/^VITE_APHYLIA_HOST_URL=/d; /^VITE_APHYLIA_API_URL=/d' "$aphydle_env"
-      $SUDO bash -c "printf 'VITE_APHYLIA_HOST_URL=%s\nVITE_APHYLIA_API_URL=%s\n' '$_host_url' '$_host_url' >> '$aphydle_env'"
+      local _aphydle_site_url="https://aphydle.$_primary_for_env"
+      # VITE_APP_SITE_URL is read by Aphydle's vite.config.js seoArtifactsPlugin
+      # at build time. Without it Vite falls back to the hardcoded
+      # https://aphydle.aphylia.com default, which produces a sitemap.xml,
+      # robots.txt, canonical <link>, OG/Twitter tags, and JSON-LD that all
+      # point at the wrong host on every non-canonical deploy. Derive it
+      # from domain.json's primary so dev01/staging/prod each get a
+      # self-consistent SEO bundle.
+      log "Injecting VITE_APHYLIA_HOST_URL=$_host_url and VITE_APP_SITE_URL=$_aphydle_site_url into Aphydle .env"
+      $SUDO sed -i '/^VITE_APHYLIA_HOST_URL=/d; /^VITE_APHYLIA_API_URL=/d; /^VITE_APP_SITE_URL=/d' "$aphydle_env"
+      $SUDO bash -c "printf 'VITE_APHYLIA_HOST_URL=%s\nVITE_APHYLIA_API_URL=%s\nVITE_APP_SITE_URL=%s\n' '$_host_url' '$_host_url' '$_aphydle_site_url' >> '$aphydle_env'"
       $SUDO chown "$SERVICE_USER:$SERVICE_USER" "$aphydle_env"
     fi
   fi


### PR DESCRIPTION
## Summary
This PR adds an admin interface button to open Aphydle's export feature and fixes SEO artifact generation for non-canonical deployments by properly configuring the Aphydle site URL during setup.

## Key Changes

- **AdminPage.tsx**: Added "Open Aphydle Export" button that intelligently routes to the correct Aphydle instance based on the current deployment environment (localhost:4173 for local development, aphydle subdomain for deployed environments)

- **setup.sh**: Enhanced Aphydle environment configuration to inject `VITE_APP_SITE_URL` alongside existing host URL variables. This ensures Vite's SEO artifacts plugin generates correct sitemap.xml, robots.txt, canonical links, and OG/Twitter tags for each deployment environment (dev01, staging, prod) instead of defaulting to the hardcoded production domain

## Implementation Details

The export button uses the current hostname to determine the target URL:
- Local environments (localhost, 127.0.0.1, .local domains) → `http://localhost:4173/export`
- Deployed environments → `https://aphydle.{primary_domain}/export`

The setup script now derives `VITE_APP_SITE_URL` from domain.json's primary domain, ensuring each deployment generates self-consistent SEO artifacts that point to the correct host rather than the canonical production domain.

https://claude.ai/code/session_01MPYBtR9Q73Ui6demDMLgXH