### PR TITLE
Fix Aphydle setup to handle dirty tracked files during updates

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1614,11 +1614,22 @@ setup_aphydle() {
 
   log "Setting up Aphydle (daily plant guessing game)…"
 
-  # Clone or update Aphydle repo
+  # Clone or update Aphydle repo. Use fetch + reset --hard (not pull --ff-only)
+  # because scripts/refresh-aphydle.sh's image-proxy patcher dirties tracked
+  # files (src/lib/data.js); pull --ff-only would abort with "local changes
+  # would be overwritten by merge" and silently leave the build stale.
   if [[ -d "$APHYDLE_DIR/.git" ]]; then
-    log "Aphydle repo present at $APHYDLE_DIR — pulling latest…"
-    if ! sudo -u "$SERVICE_USER" -H git -C "$APHYDLE_DIR" pull --ff-only 2>&1; then
-      log "[WARN] git pull failed for Aphydle; continuing with existing checkout."
+    log "Aphydle repo present at $APHYDLE_DIR — fetching latest…"
+    local aphydle_branch
+    aphydle_branch="$(sudo -u "$SERVICE_USER" -H git -C "$APHYDLE_DIR" symbolic-ref --short HEAD 2>/dev/null || true)"
+    [[ -n "$aphydle_branch" && "$aphydle_branch" != "HEAD" ]] || aphydle_branch="main"
+    if ! sudo -u "$SERVICE_USER" -H git -C "$APHYDLE_DIR" fetch origin "$aphydle_branch" 2>&1; then
+      log "[ERROR] git fetch failed for Aphydle (branch $aphydle_branch); aborting Aphydle setup to avoid shipping a stale build."
+      return 1
+    fi
+    if ! sudo -u "$SERVICE_USER" -H git -C "$APHYDLE_DIR" reset --hard "origin/$aphydle_branch" 2>&1; then
+      log "[ERROR] git reset --hard origin/$aphydle_branch failed for Aphydle; aborting Aphydle setup to avoid shipping a stale build."
+      return 1
     fi
   else
     log "Cloning Aphydle from $APHYDLE_REPO_URL → $APHYDLE_DIR"


### PR DESCRIPTION
## Summary
Changed the Aphydle repository update strategy from `git pull --ff-only` to `git fetch` + `git reset --hard` to properly handle cases where tracked files are modified by post-clone scripts.

## Key Changes
- Replaced `git pull --ff-only` with separate `git fetch` and `git reset --hard` commands
- Added logic to detect the current branch and fetch/reset to the correct remote tracking branch (defaults to `main`)
- Changed error handling to abort setup (return 1) instead of continuing with potentially stale builds
- Updated log messages to reflect the new fetch-based approach and provide more context on failures

## Implementation Details
The previous approach using `git pull --ff-only` would fail silently when the image-proxy patcher in `scripts/refresh-aphydle.sh` modified tracked files (specifically `src/lib/data.js`), leaving the build stale. The new approach:
- Fetches the latest changes from the remote without modifying the working directory
- Explicitly resets the working directory to match the remote branch, overwriting any local modifications
- Properly detects the current branch using `git symbolic-ref --short HEAD` to ensure the correct branch is updated
- Treats fetch/reset failures as critical errors that should abort setup rather than silently continuing with outdated code

https://claude.ai/code/session_01H1LJozAEbCuqMGWix3MHxd