### PR TITLE
Patch Aphydle image-proxy CORS during setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1681,6 +1681,21 @@ setup_aphydle() {
     fi
   fi
 
+  # Patch Aphydle source for image-proxy CORS wrapping. Mirrors the same step
+  # in scripts/refresh-aphydle.sh so a fresh `setup.sh` run produces an
+  # already-patched build — without this, the build embedded the unmodified
+  # upstream src/lib/data.js and operators had to re-run refresh-aphydle.sh
+  # afterward to get a working image proxy. The patcher is idempotent and
+  # fails loudly if the upstream function shape changes.
+  local aphydle_patcher="$REPO_DIR/scripts/aphydle-patch-image-proxy.mjs"
+  if [[ -f "$aphydle_patcher" && -f "$APHYDLE_DIR/src/lib/data.js" ]]; then
+    log "Patching Aphydle source for image-proxy CORS wrapping…"
+    if ! sudo -u "$SERVICE_USER" -H node "$aphydle_patcher" "$APHYDLE_DIR" 2>&1; then
+      log "[ERROR] Aphydle image-proxy patcher failed; aborting Aphydle setup to avoid shipping a broken build."
+      return 1
+    fi
+  fi
+
   # Locate Bun for the service user (matches plant-swipe convention)
   local owner_home owner_bun_dir owner_bun_bin
   owner_home="$(getent passwd "$SERVICE_USER" | cut -d: -f6 2>/dev/null || echo /var/www)"


### PR DESCRIPTION
## Summary
Add automatic patching of Aphydle's image-proxy CORS configuration during the initial `setup.sh` run, eliminating the need for operators to manually run `refresh-aphydle.sh` after setup.

## Changes
- Added image-proxy CORS patching step to `setup_aphydle()` function in `setup.sh`
- Invokes `scripts/aphydle-patch-image-proxy.mjs` to patch `src/lib/data.js` before the build is embedded
- Patcher runs as the service user with proper error handling and validation
- Includes idempotent patcher design that fails loudly if upstream function shape changes
- Mirrors the same patching logic already present in `scripts/refresh-aphydle.sh`

## Implementation Details
- Patcher is only invoked if both the patcher script and target `data.js` file exist
- Runs under the service user context using `sudo -u` to maintain proper permissions
- Returns error code 1 and aborts setup if patching fails, preventing deployment of broken builds
- Includes informative logging for both success and failure cases

https://claude.ai/code/session_01BQ67MHQM6ETsguJRWPQzrr