### PR TITLE
Add export page for plant images

### DIFF
--- a/plant-swipe/server.js
+++ b/plant-swipe/server.js
@@ -5337,6 +5337,7 @@ app.post('/api/admin/ai/plant-export-content', async (req, res) => {
     const plantName = typeof body.plantName === 'string' ? body.plantName.trim() : ''
     const scientificName = typeof body.scientificName === 'string' ? body.scientificName.trim() : ''
     const family = typeof body.family === 'string' ? body.family.trim() : ''
+    const variety = typeof body.variety === 'string' ? body.variety.trim() : ''
     if (!plantName) {
       res.status(400).json({ error: 'Plant name is required' })
       return
@@ -5356,20 +5357,34 @@ app.post('/api/admin/ai/plant-export-content', async (req, res) => {
 }
 
 historicalFact (max ${factMax} chars):
-- ONE verified, share-worthy fact prioritising:
-  1. documented strange or unexpected historical use (folk medicine, ritual, dye, weapon, poison, embalming, perfumery)
-  2. discovery / explorer / craze / smuggling story
-  3. attested macabre or dark folklore (witch trials, funeral rites, gallows associations, graveyard symbolism)
-  4. surprising biology only if it has a story attached
-- ONLY attested history. NEVER hedge ("some say", "legend has it"). NEVER invent dates/names/events.
+- ONE verified, share-worthy fact. Walk down this priority ladder and pick the first tier with a real, attested story for THIS plant. Do NOT skip ahead — exhaust each tier before falling back.
+
+  TIER 1 — Documented historical use or event:
+    a. strange / unexpected use in history (folk medicine, ritual, dye, weapon, poison, embalming, perfumery, currency, food preservation)
+    b. discovery / explorer / craze / smuggling / botanical-trade story
+    c. attested macabre or dark folklore (witch trials, funeral rites, gallows associations, graveyard symbolism)
+    d. surprising biology only if it has a documented historical story attached
+
+  TIER 2 — Belief, mythology, symbolism (use only if Tier 1 has nothing):
+    a. role in a documented mythology (Greek, Roman, Norse, Hindu, Buddhist, Indigenous, etc.) — name the source
+    b. attested cultural symbolism / "language of flowers" / heraldry / national or regional emblem
+    c. astrology, zodiac, planetary correspondence, moon-cycle gardening tradition (only if it appears in a recognised tradition or text — name it)
+    d. religious or ceremonial significance recorded in literature
+
+  TIER 3 — Etymology + naming (last resort, only if Tiers 1 & 2 have nothing):
+    a. origin of the common name — what language, what it literally translates to, who named it and why
+    b. origin of the genus / species epithet — Latin / Greek root, which botanist coined it, what it commemorates
+    c. interesting nomenclatural story (renaming, mistaken identity, dispute, dedication to a person)
+
+- ONLY attested content with a real source basis. NEVER hedge ("some say", "legend has it" without a tradition named). NEVER invent dates, names, persons, or events.
 - One self-contained sentence (max two short sentences).
 - Plain prose, no markdown, no leading filler ("Did you know"), no quotes around the whole thing.
-- If you don't have a verified strange fact, return an empty string and set factConfidence to "low".
+- If even Tier 3 has nothing verifiable, return an empty string and set factConfidence to "low".
 
 factConfidence:
-- "high" if the fact is widely attested in mainstream botanical / historical sources.
-- "medium" if it's documented but less mainstream.
-- "low" if you reached for it — caller will discard low-confidence outputs.
+- "high" if the fact is widely attested in mainstream botanical / historical / mythological sources.
+- "medium" if it's documented but less mainstream, OR if you fell back to Tier 2 / Tier 3.
+- "low" only if you genuinely reached for something unverified — caller will discard.
 
 gardenerTip (HARD MAX ${tipMax} characters, including spaces and punctuation):
 - LENGTH IS A HARD LIMIT. Count characters before returning. If your tip is over ${tipMax} characters, rewrite it shorter — do NOT exceed the budget. Truncated tips will be discarded.
@@ -5392,9 +5407,19 @@ postDescription (max ${captionMax} chars):
 
 Return ONLY the JSON object. No commentary before or after.`
 
-    const promptParts = [`Plant: ${plantName}`]
+    // The variety / cultivar disambiguates same-named plants (Tomato vs
+    // Tomato 'Cherry' vs Tomato 'San Marzano'); the AI needs it so the
+    // historical fact and gardener tip target the actual subject of the
+    // card — without it, generic content for the species sneaks through.
+    const promptParts = [`Plant common name: ${plantName}`]
+    if (variety) promptParts.push(`Variety / cultivar: ${variety}`)
     if (scientificName) promptParts.push(`Scientific name: ${scientificName}`)
     if (family) promptParts.push(`Family: ${family}`)
+    if (variety) {
+      promptParts.push(
+        `IMPORTANT: this card is about "${plantName} '${variety}'" specifically. Where the variety has its own documented history, mythology, or naming origin distinct from the species, write about THE VARIETY. Where it doesn't, write about the species.`,
+      )
+    }
     promptParts.push('Generate the JSON object now.')
     const prompt = promptParts.join('\n')
 

--- a/plant-swipe/src/components/admin/AdminExportPanel.tsx
+++ b/plant-swipe/src/components/admin/AdminExportPanel.tsx
@@ -181,6 +181,7 @@ type IconSet = {
   scroll: HTMLImageElement | null;
   scrollGold: HTMLImageElement | null;
   chevDown: HTMLImageElement | null;
+  chevDownInk: HTMLImageElement | null;
   sunCream: HTMLImageElement | null;
 };
 
@@ -766,22 +767,44 @@ function drawCardCover(
   ctx.fillText(name, padX, titleBaseline);
   ctx.letterSpacing = "0px";
 
-  // Variety / sci-name subtitle
+  // Variety — own prominent line under the name. Same plant `name` can have
+  // many varieties (Tomato → Cherry / Beefsteak / Roma); without it the card
+  // is ambiguous. Rendered in mint accent at ~half the title size so it
+  // reads as a clearly tied second-line cultivar.
   const variantTextRaw = variety && variety.trim() ? variety.trim() : "";
+  let cursorBaseline = titleBaseline;
+  if (variantTextRaw) {
+    const variantUpper = variantTextRaw.toUpperCase();
+    const varietySize = fitText(
+      ctx,
+      variantUpper,
+      CARD_W - 128,
+      Math.round(titleSize * 0.55),
+      28,
+      "600",
+      FONT_MONO,
+    );
+    ctx.font = `600 ${varietySize}px ${FONT_MONO}`;
+    ctx.fillStyle = C.mint;
+    ctx.letterSpacing = "4px";
+    cursorBaseline = titleBaseline + Math.round(titleSize * 0.7);
+    ctx.fillText(variantUpper, padX, cursorBaseline);
+    ctx.letterSpacing = "0px";
+  }
+
+  // Scientific-name subtitle — third row, lighter so it doesn't compete
+  // with the variety.
   const sci = String(plant.scientific_name_species || "").trim();
-  const sub = variantTextRaw
-    ? `'${variantTextRaw}' · ${sci}`
-    : sci;
-  if (sub) {
+  if (sci) {
     ctx.font = `400 26px ${FONT_MONO}`;
     ctx.fillStyle = "rgba(245,239,226,0.85)";
-    ctx.fillText(sub, padX, titleBaseline + 50);
+    ctx.fillText(sci, padX, cursorBaseline + 44);
   }
 
   // Family + plant_type chips on a single row.
   const family = tidy(plant.family || "");
   const plantType = tidy(plant.plant_type || "");
-  const chipsRowY = titleBaseline + 80;
+  const chipsRowY = cursorBaseline + 78;
   let cursorX = padX;
   if (family) {
     const sz = drawChip(ctx, cursorX, chipsRowY, family.toUpperCase(), {
@@ -869,6 +892,7 @@ function drawCardIdentity(
   hero: HTMLImageElement | null,
   colors: ColorRow[],
   commonNames: string[],
+  variety: string,
   gardenerTip: string,
   icons: IconSet | null,
   logoBlack: HTMLImageElement | null,
@@ -936,8 +960,34 @@ function drawCardIdentity(
   ctx.fillText(name, 64, 230 + nameSize);
   ctx.letterSpacing = "0px";
 
+  // Variety — prominent second tier in the title stack. The plant `name`
+  // alone (e.g. "Tomato") collides with every other tomato variety; the
+  // cultivar is what disambiguates the card.
+  let nextY = 230 + nameSize + 14;
+  const variantTextRaw = variety && variety.trim() ? variety.trim() : "";
+  if (variantTextRaw) {
+    const variantUpper = variantTextRaw.toUpperCase();
+    const varietySize = fitText(
+      ctx,
+      variantUpper,
+      600,
+      Math.round(nameSize * 0.55),
+      18,
+      "600",
+      FONT_MONO,
+    );
+    ctx.font = `600 ${varietySize}px ${FONT_MONO}`;
+    ctx.fillStyle = C.mintDim;
+    ctx.letterSpacing = "3px";
+    nextY += varietySize;
+    ctx.fillText(variantUpper, 64, nextY);
+    ctx.letterSpacing = "0px";
+    nextY += 22;
+  } else {
+    nextY += 36;
+  }
+
   const sci = String(plant.scientific_name_species || "").trim();
-  let nextY = 230 + nameSize + 50;
   if (sci) {
     ctx.font = `400 22px ${FONT_MONO}`;
     ctx.fillStyle = C.inkDim;
@@ -1664,6 +1714,7 @@ function drawCardWild(
   ctx: CanvasRenderingContext2D,
   plant: PlantRow,
   images: HTMLImageElement[],
+  variety: string,
   icons: IconSet | null,
   logoWhite: HTMLImageElement | null,
 ) {
@@ -1692,12 +1743,21 @@ function drawCardWild(
     ctx.clip();
     drawCoverImage(ctx, hero, 0, 0, CARD_W, heroH);
 
-    // Emerald-tinted gradient overlay at the bottom of the hero so the
-    // headline stays readable without dimming the whole photo.
-    const overlay = ctx.createLinearGradient(0, heroH * 0.45, 0, heroH);
+    // Top scrim — guarantees the brand header reads cleanly even on a
+    // busy/light foliage photo. Stronger than before; was too subtle and
+    // brand text was getting lost.
+    const topScrim = ctx.createLinearGradient(0, 0, 0, 180);
+    topScrim.addColorStop(0, "rgba(15,31,31,0.78)");
+    topScrim.addColorStop(1, "rgba(15,31,31,0)");
+    ctx.fillStyle = topScrim;
+    ctx.fillRect(0, 0, CARD_W, 180);
+
+    // Bottom scrim — stronger so the headline is fully legible against
+    // any photo, not just dark ones.
+    const overlay = ctx.createLinearGradient(0, heroH * 0.35, 0, heroH);
     overlay.addColorStop(0, "rgba(15,31,31,0)");
-    overlay.addColorStop(0.55, "rgba(15,31,31,0.55)");
-    overlay.addColorStop(1, "rgba(15,31,31,0.92)");
+    overlay.addColorStop(0.45, "rgba(15,31,31,0.65)");
+    overlay.addColorStop(1, "rgba(15,31,31,0.96)");
     ctx.fillStyle = overlay;
     ctx.fillRect(0, 0, CARD_W, heroH);
 
@@ -1710,7 +1770,7 @@ function drawCardWild(
       heroH * 0.25,
       CARD_W * 0.6,
     );
-    glow.addColorStop(0, "rgba(16,185,129,0.35)");
+    glow.addColorStop(0, "rgba(16,185,129,0.30)");
     glow.addColorStop(1, "rgba(16,185,129,0)");
     ctx.fillStyle = glow;
     ctx.fillRect(0, 0, CARD_W, heroH);
@@ -1758,14 +1818,15 @@ function drawCardWild(
   ctx.letterSpacing = "0px";
 
   // — Cream content panel below the hero ------------------------------
-  // Three concrete reasons to visit the app — anything less specific reads
-  // as marketing fluff. Pulls from what the app actually offers.
+  // Honest descriptors only — no fabricated numbers ("10K+", "DAILY") that
+  // we can't substantiate. Three short truthful pillars of what the site
+  // actually is, with emerald check discs.
   const reasonsTop = heroH + 60;
 
   ctx.fillStyle = APP_EMERALD_DEEPER;
   ctx.font = `700 12px ${FONT_MONO}`;
   ctx.letterSpacing = "8px";
-  ctx.fillText("WHAT YOU'LL FIND", 64, reasonsTop);
+  ctx.fillText("WHY APHYLIA", 64, reasonsTop);
   ctx.letterSpacing = "0px";
 
   ctx.strokeStyle = APP_EMERALD;
@@ -1775,16 +1836,17 @@ function drawCardWild(
   ctx.lineTo(120, reasonsTop + 12);
   ctx.stroke();
 
-  type Reason = { stat: string; label: string };
-  const reasons: Reason[] = [
-    { stat: "10K+", label: "PLANTS, ALL CURATED" },
-    { stat: "DAILY", label: "NEW DISCOVERIES" },
-    { stat: "REAL", label: "GROWERS' ADVICE" },
+  // Single label per row — no fake stats, no superlatives. Each line is a
+  // direct, defensible statement about what the site offers.
+  const reasons: string[] = [
+    "CURATED PLANT CARDS",
+    "STRAIGHTFORWARD CARE GUIDES",
+    "FREE TO BROWSE, NO ACCOUNT NEEDED",
   ];
   const reasonY = reasonsTop + 50;
-  const reasonRowH = 70;
+  const reasonRowH = 64;
   for (let i = 0; i < reasons.length; i++) {
-    const r = reasons[i];
+    const label = reasons[i];
     const ry = reasonY + i * reasonRowH;
 
     // Emerald check disc
@@ -1805,19 +1867,14 @@ function drawCardWild(
     ctx.lineTo(cx + 8, cy - 6);
     ctx.stroke();
 
-    // Stat in big emerald
-    ctx.fillStyle = APP_EMERALD_DARK;
-    ctx.font = `700 28px ${FONT_MONO}`;
+    // Single-tier label — fitText so longer copy still fits the line.
+    ctx.fillStyle = APP_INK;
     ctx.textAlign = "left";
     ctx.textBaseline = "alphabetic";
-    ctx.fillText(r.stat, 116, ry + 28);
-
-    // Label after stat
-    const statW = ctx.measureText(r.stat).width;
-    ctx.fillStyle = APP_INK;
-    ctx.font = `600 17px ${FONT_MONO}`;
+    const sz = fitText(ctx, label, CARD_W - 64 - 116, 19, 13, "700", FONT_MONO);
+    ctx.font = `700 ${sz}px ${FONT_MONO}`;
     ctx.letterSpacing = "3px";
-    ctx.fillText(r.label, 116 + statW + 16, ry + 28);
+    ctx.fillText(label, 116, ry + 28);
     ctx.letterSpacing = "0px";
   }
 
@@ -1884,7 +1941,11 @@ function drawCardWild(
   ctx.textAlign = "center";
   ctx.textBaseline = "alphabetic";
   const nameForLine = tidy(plant.name || "this plant").toUpperCase();
-  const personalLine = `STARTED WITH ${nameForLine} · KEEP EXPLORING`;
+  const variantForLine = variety && variety.trim() ? variety.trim().toUpperCase() : "";
+  const fullName = variantForLine
+    ? `${nameForLine} · ${variantForLine}`
+    : nameForLine;
+  const personalLine = `STARTED WITH ${fullName} · KEEP EXPLORING`;
   const personalY = ctaY + ctaH + 40;
   ctx.letterSpacing = "4px";
   ctx.fillText(personalLine, CARD_W / 2, personalY);
@@ -1900,16 +1961,16 @@ function drawCardWild(
   ctx.fillText("READ THE FULL POST BELOW", CARD_W / 2, cueTop);
   ctx.letterSpacing = "0px";
 
-  if (icons?.chevDown) {
+  if (icons?.chevDownInk) {
     const sizes = [
-      { y: cueTop + 14, op: 0.85, sz: 36 },
-      { y: cueTop + 38, op: 0.5, sz: 30 },
+      { y: cueTop + 14, op: 0.9, sz: 36 },
+      { y: cueTop + 38, op: 0.55, sz: 30 },
     ];
     for (const s of sizes) {
       ctx.save();
       ctx.globalAlpha = s.op;
       ctx.drawImage(
-        icons.chevDown,
+        icons.chevDownInk,
         CARD_W / 2 - s.sz / 2,
         s.y,
         s.sz,
@@ -2018,6 +2079,7 @@ async function renderCardCanvas(
         pickImage(b.images, 1),
         b.colors,
         b.commonNames,
+        b.variety,
         b.gardenerTip,
         b.icons,
         b.logoBlack,
@@ -2037,7 +2099,7 @@ async function renderCardCanvas(
       break;
     case 3:
       // Wild card rotates through every available image in the orb collage.
-      drawCardWild(ctx, b.plant, b.images, b.icons, b.logoWhite);
+      drawCardWild(ctx, b.plant, b.images, b.variety, b.icons, b.logoWhite);
       break;
   }
   return c;
@@ -2187,6 +2249,7 @@ export function AdminExportPanel() {
         scroll,
         scrollGold,
         chevDown,
+        chevDownInk,
         sunCream,
       ] = await Promise.all([
         lucideImage(Sun, C.gold, 64, 2.4),
@@ -2206,6 +2269,9 @@ export function AdminExportPanel() {
         lucideImage(ScrollText, C.cream, 64, 2),
         lucideImage(ScrollText, C.gold, 96, 2.2),
         lucideImage(ChevronsDown, C.cream, 96, 2.5),
+        // Emerald-dark chevron for Card 4's cream surface — using the
+        // cream-tinted version on the light bg made the cue invisible.
+        lucideImage(ChevronsDown, "#059669", 96, 2.5),
         lucideImage(Sun, C.cream, 64, 2.2),
       ]);
       if (cancelled) return;
@@ -2227,6 +2293,7 @@ export function AdminExportPanel() {
         scroll,
         scrollGold,
         chevDown,
+        chevDownInk,
         sunCream,
       });
     })();
@@ -2254,29 +2321,52 @@ export function AdminExportPanel() {
         return [];
       }
       const ids = (data as PlantRow[]).map((p) => p.id as string);
-      const { data: imgs } = await supabase
-        .from("plant_images")
-        .select("plant_id,link")
-        .in("plant_id", ids)
-        .eq("use", "primary");
-      const map = new Map(
-        ((imgs as { plant_id: string; link: string }[]) || []).map((i) => [
-          i.plant_id,
-          i.link,
-        ]),
+      // Fetch primary image AND English variety in parallel — variety is the
+      // common "Cherry" / "Beefsteak" suffix that disambiguates two rows
+      // sharing the same `name` (Tomato + Tomato), so the picker has to show
+      // it inline. Without it, two cards with identical labels are
+      // indistinguishable.
+      const [imgsRes, transRes] = await Promise.all([
+        supabase
+          .from("plant_images")
+          .select("plant_id,link")
+          .in("plant_id", ids)
+          .eq("use", "primary"),
+        supabase
+          .from("plant_translations")
+          .select("plant_id,language,variety")
+          .in("plant_id", ids)
+          .eq("language", "en"),
+      ]);
+      const imgMap = new Map(
+        ((imgsRes.data as { plant_id: string; link: string }[]) || []).map(
+          (i) => [i.plant_id, i.link],
+        ),
       );
-      const rows: SearchItemOption[] = (data as PlantRow[]).map((p) => ({
-        id: p.id as string,
-        label: (p.name as string) || "Unknown",
-        description: (p.scientific_name_species as string) || "",
-        icon: map.get(p.id as string) ? (
-          <img
-            src={map.get(p.id as string) as string}
-            className="h-9 w-9 rounded object-cover"
-            alt=""
-          />
-        ) : undefined,
-      }));
+      const varMap = new Map(
+        ((transRes.data as { plant_id: string; variety: string | null }[]) ||
+          []).map((t) => [t.plant_id, (t.variety || "").trim()]),
+      );
+      const rows: SearchItemOption[] = (data as PlantRow[]).map((p) => {
+        const id = p.id as string;
+        const baseName = (p.name as string) || "Unknown";
+        const variety = varMap.get(id) || "";
+        // Show "Tomato · Cherry" so two same-named rows are distinguishable
+        // at a glance. Falls back to bare name when no variety is set.
+        const label = variety ? `${baseName} · ${variety}` : baseName;
+        return {
+          id,
+          label,
+          description: (p.scientific_name_species as string) || "",
+          icon: imgMap.get(id) ? (
+            <img
+              src={imgMap.get(id) as string}
+              className="h-9 w-9 rounded object-cover"
+              alt=""
+            />
+          ) : undefined,
+        };
+      });
       setOptions(rows);
       return rows;
     },

--- a/plant-swipe/src/components/admin/AdminExportPanel.tsx
+++ b/plant-swipe/src/components/admin/AdminExportPanel.tsx
@@ -19,6 +19,7 @@ import {
   Ruler,
   ScrollText,
   ChevronsDown,
+  Shovel,
   Copy,
   Check,
   type LucideIcon,
@@ -182,6 +183,7 @@ type IconSet = {
   scrollGold: HTMLImageElement | null;
   chevDown: HTMLImageElement | null;
   chevDownInk: HTMLImageElement | null;
+  shovel: HTMLImageElement | null;
   sunCream: HTMLImageElement | null;
 };
 
@@ -1116,8 +1118,13 @@ function drawCardIdentity(
   });
 
   // BOX 2: Water
+  // Show the HOT-season frequency (peak demand) when set; fall back to the
+  // cold-season value so plants that only have one of the two recorded
+  // still display a real number instead of an em-dash.
   const water = waterLevel(plant);
   const warmFreq = Number(plant.watering_frequency_warm) || 0;
+  const coldFreq = Number(plant.watering_frequency_cold) || 0;
+  const primaryWaterFreq = warmFreq || coldFreq;
   drawStatBox(1, 0, icons?.dropletFilled ?? null, "Water", (x, y, w) => {
     drawIconRow(
       ctx,
@@ -1130,7 +1137,7 @@ function drawCardIdentity(
       22,
       8,
     );
-    const v = warmFreq > 0 ? `${warmFreq}× / WEEK` : "—";
+    const v = primaryWaterFreq > 0 ? `${primaryWaterFreq}× / WEEK` : "—";
     const sz = fitText(ctx, v, w - 36, 18, 12, "700", FONT_MONO);
     ctx.font = `700 ${sz}px ${FONT_MONO}`;
     ctx.fillStyle = C.ink;
@@ -1194,17 +1201,17 @@ function drawCardIdentity(
   // *live with* the plant. Toxicity gets its own box (was crammed into the
   // Care box footnote); cold-season watering and form/habit complete the row.
 
-  // Cold-season watering — distinct from warm; gardeners often miss the
-  // shift and rot the plant in winter.
-  const coldFreq = Number(plant.watering_frequency_cold) || 0;
-  drawStatBox(0, 1, icons?.dropletEmpty ?? null, "Water · Cold", (x, y, w) => {
-    const v = coldFreq > 0 ? `${coldFreq}× / WEEK` : "—";
-    const sz = fitText(ctx, v, w - 36, 22, 13, "700", FONT_MONO);
+  // Soil / substrate — what the plant likes to live in. The water box
+  // already covers both seasons (hot value with cold fallback), so this
+  // slot is freed for a different living-with-it stat.
+  const substrate = tidy(asArr(plant.substrate)[0] || "—");
+  drawStatBox(0, 1, icons?.shovel ?? null, "Soil", (x, y, w) => {
+    const sz = fitText(ctx, substrate.toUpperCase(), w - 36, 22, 13, "700", FONT_MONO);
     ctx.font = `700 ${sz}px ${FONT_MONO}`;
     ctx.fillStyle = C.ink;
     ctx.textAlign = "left";
     ctx.textBaseline = "middle";
-    ctx.fillText(v, x + 18, y + 90);
+    ctx.fillText(substrate.toUpperCase(), x + 18, y + 90);
   });
 
   // Toxicity — own box now, with severity-coloured chip when relevant.
@@ -2251,6 +2258,7 @@ export function AdminExportPanel() {
         scrollGold,
         chevDown,
         chevDownInk,
+        shovel,
         sunCream,
       ] = await Promise.all([
         lucideImage(Sun, C.gold, 64, 2.4),
@@ -2273,6 +2281,7 @@ export function AdminExportPanel() {
         // Emerald-dark chevron for Card 4's cream surface — using the
         // cream-tinted version on the light bg made the cue invisible.
         lucideImage(ChevronsDown, "#059669", 96, 2.5),
+        lucideImage(Shovel, C.ink, 64, 2),
         lucideImage(Sun, C.cream, 64, 2.2),
       ]);
       if (cancelled) return;
@@ -2295,6 +2304,7 @@ export function AdminExportPanel() {
         scrollGold,
         chevDown,
         chevDownInk,
+        shovel,
         sunCream,
       });
     })();

--- a/plant-swipe/src/components/admin/AdminExportPanel.tsx
+++ b/plant-swipe/src/components/admin/AdminExportPanel.tsx
@@ -2352,20 +2352,15 @@ export function AdminExportPanel() {
         const id = p.id as string;
         const baseName = (p.name as string) || "Unknown";
         const variety = varMap.get(id) || "";
-        // Show "Tomato · Cherry" so two same-named rows are distinguishable
-        // at a glance. Falls back to bare name when no variety is set.
-        const label = variety ? `${baseName} · ${variety}` : baseName;
+        const photoUrl = imgMap.get(id) || "";
+        // Garden-style tile rendering — icon, label, description carry just
+        // what the custom renderItem needs. Family / scientific name dropped
+        // intentionally so the tile reads cleanly.
         return {
           id,
-          label,
-          description: (p.scientific_name_species as string) || "",
-          icon: imgMap.get(id) ? (
-            <img
-              src={imgMap.get(id) as string}
-              className="h-9 w-9 rounded object-cover"
-              alt=""
-            />
-          ) : undefined,
+          label: baseName,
+          description: variety,
+          meta: photoUrl,
         };
       });
       setOptions(rows);
@@ -2629,6 +2624,39 @@ export function AdminExportPanel() {
             description="Select a plant — we generate four Instagram-ready cards"
             searchPlaceholder="Search plants by name"
             className="min-w-[280px]"
+            renderItem={(option) => {
+              const photoUrl = option.meta || "";
+              const variety = (option.description || "").trim();
+              return (
+                <div className="flex flex-col w-full">
+                  <div className="relative aspect-[4/3] bg-gradient-to-br from-stone-100 to-stone-200 dark:from-stone-800 dark:to-stone-900 overflow-hidden">
+                    {photoUrl ? (
+                      <img
+                        src={photoUrl}
+                        alt={option.label}
+                        loading="lazy"
+                        className="absolute inset-0 w-full h-full object-cover"
+                      />
+                    ) : (
+                      <div className="absolute inset-0 flex items-center justify-center text-3xl opacity-40">
+                        🌿
+                      </div>
+                    )}
+                    <div className="absolute inset-0 bg-gradient-to-t from-black/30 via-transparent to-transparent" />
+                  </div>
+                  <div className="px-3 py-2.5">
+                    <div className="font-semibold text-sm text-stone-900 dark:text-white truncate">
+                      {option.label}
+                    </div>
+                    {variety && (
+                      <div className="mt-0.5 text-xs font-extrabold bg-gradient-to-r from-emerald-500 to-teal-500 bg-clip-text text-transparent tracking-tight truncate">
+                        &lsquo;{variety}&rsquo;
+                      </div>
+                    )}
+                  </div>
+                </div>
+              );
+            }}
           />
           <Button onClick={() => void generate()} disabled={!picked || loading}>
             {loading ? (

--- a/plant-swipe/src/components/admin/AdminExportPanel.tsx
+++ b/plant-swipe/src/components/admin/AdminExportPanel.tsx
@@ -230,6 +230,7 @@ async function fetchExportAiContent(
   plantName: string,
   scientificName: string,
   family: string,
+  variety: string,
   signal?: AbortSignal,
 ): Promise<ExportAiContent> {
   if (!plantName) return EMPTY_AI_CONTENT;
@@ -238,7 +239,7 @@ async function fetchExportAiContent(
     const res = await fetch("/api/admin/ai/plant-export-content", {
       method: "POST",
       headers,
-      body: JSON.stringify({ plantName, scientificName, family }),
+      body: JSON.stringify({ plantName, scientificName, family, variety }),
       signal,
     });
     if (!res.ok) return EMPTY_AI_CONTENT;
@@ -1665,13 +1666,13 @@ function drawCardDeep(
   ctx.textAlign = "left";
   ctx.textBaseline = "alphabetic";
   ctx.letterSpacing = "6px";
-  ctx.fillText("◇ HISTORICAL RECORD", factX + 96, factTop + 44);
+  ctx.fillText("◇ FROM THE ARCHIVES", factX + 96, factTop + 44);
   ctx.letterSpacing = "0px";
 
   ctx.fillStyle = "rgba(224,178,82,0.7)";
   ctx.font = `500 11px ${FONT_MONO}`;
   ctx.letterSpacing = "5px";
-  ctx.fillText("VERIFIED ARCHIVED FACT", factX + 96, factTop + 66);
+  ctx.fillText("HISTORY · MYTH · MEANING", factX + 96, factTop + 66);
   ctx.letterSpacing = "0px";
 
   if (historicalFact) {
@@ -1692,7 +1693,7 @@ function drawCardDeep(
       ctx.fillStyle = "rgba(245,239,226,0.55)";
       ctx.font = `400 16px ${FONT_MONO}`;
       ctx.fillText(
-        "No verified historical record surfaced this generation.",
+        "No verified history, myth, or naming story surfaced for this plant.",
         factX + 24,
         factTop + 130,
       );
@@ -2461,7 +2462,7 @@ export function AdminExportPanel() {
       const plantUrl = plantId ? `https://aphylia.app/plants/${plantId}` : "https://aphylia.app";
       const [loaded, ai] = await Promise.all([
         Promise.all(rawImgs.map((r) => loadCanvasImage(r.link))),
-        fetchExportAiContent(plantNameStr, sciNameStr, familyStr),
+        fetchExportAiContent(plantNameStr, sciNameStr, familyStr, variety),
       ]);
       const images = loaded.filter((i): i is HTMLImageElement => !!i);
 


### PR DESCRIPTION
This pull request enhances the plant export content workflow and exported card visuals, with a focus on better handling and display of plant varieties/cultivars, improved historical fact generation, and clearer, more accurate card UI. The changes affect both the backend API and the frontend admin export panel, including prompt construction, data flow, and canvas rendering.

**Plant Variety Handling & Data Flow:**
- Added support for a `variety` field throughout the export pipeline (API, prompt, and frontend) to ensure content and visuals are specific to the selected cultivar, not just the species. This includes passing `variety` from the frontend to the backend and updating prompt instructions to prioritize variety-specific facts when available. [[1]](diffhunk://#diff-99182e20b9c32cc827fc17ed8b1d952085cbaa0564a2530ce6c774a004cdf8f9R5340) [[2]](diffhunk://#diff-ae5d2b3f3c3c3d0e66bc450bea40e902e58eb5d31640e79c656545186c05b462R235) [[3]](diffhunk://#diff-ae5d2b3f3c3c3d0e66bc450bea40e902e58eb5d31640e79c656545186c05b462L240-R244) [[4]](diffhunk://#diff-ae5d2b3f3c3c3d0e66bc450bea40e902e58eb5d31640e79c656545186c05b462R898) [[5]](diffhunk://#diff-ae5d2b3f3c3c3d0e66bc450bea40e902e58eb5d31640e79c656545186c05b462R1725)

**AI Prompt & Fact Generation Improvements:**
- Refined the historical fact prompt to use a strict, tiered priority system for fact selection (history, then mythology, then etymology), with clear instructions to exhaust each tier and cite sources, ensuring only attested, variety-specific content is generated. Updated fact confidence rules for better filtering.

**Card Visual & UI Improvements:**
- On card covers and identity panels, the variety is now rendered as a distinct, prominent line below the plant name, with clear styling to disambiguate cultivars. Scientific name is shown as a third row, and the layout adapts for absent varieties. [[1]](diffhunk://#diff-ae5d2b3f3c3c3d0e66bc450bea40e902e58eb5d31640e79c656545186c05b462L769-R810) [[2]](diffhunk://#diff-ae5d2b3f3c3c3d0e66bc450bea40e902e58eb5d31640e79c656545186c05b462R966-L940)
- The water stat box now shows the hot-season frequency, falling back to cold-season if needed, and the cold-season stat box is replaced with a new "Soil" box showing the preferred substrate. [[1]](diffhunk://#diff-ae5d2b3f3c3c3d0e66bc450bea40e902e58eb5d31640e79c656545186c05b462R1121-R1127) [[2]](diffhunk://#diff-ae5d2b3f3c3c3d0e66bc450bea40e902e58eb5d31640e79c656545186c05b462L1082-R1140) [[3]](diffhunk://#diff-ae5d2b3f3c3c3d0e66bc450bea40e902e58eb5d31640e79c656545186c05b462L1146-R1214)

**Card Export Branding & Messaging:**
- Updated the "historical record" section to "FROM THE ARCHIVES" and broadened the fallback message to cover history, myth, and naming stories. [[1]](diffhunk://#diff-ae5d2b3f3c3c3d0e66bc450bea40e902e58eb5d31640e79c656545186c05b462L1618-R1682) [[2]](diffhunk://#diff-ae5d2b3f3c3c3d0e66bc450bea40e902e58eb5d31640e79c656545186c05b462L1645-R1703)
- The "Wild" card's hero image overlays are stronger for improved text legibility, and the "reasons to use" section now features honest, single-tier statements about the site's offerings, removing any unsubstantiated claims or numbers. [[1]](diffhunk://#diff-ae5d2b3f3c3c3d0e66bc450bea40e902e58eb5d31640e79c656545186c05b462L1695-R1768) [[2]](diffhunk://#diff-ae5d2b3f3c3c3d0e66bc450bea40e902e58eb5d31640e79c656545186c05b462L1761-R1837) [[3]](diffhunk://#diff-ae5d2b3f3c3c3d0e66bc450bea40e902e58eb5d31640e79c656545186c05b462L1778-R1857) [[4]](diffhunk://#diff-ae5d2b3f3c3c3d0e66bc450bea40e902e58eb5d31640e79c656545186c05b462L1808-R1885)

**Icon & Asset Updates:**
- Added new icons (`shovel`, `chevDownInk`) to the icon set for use in the new "Soil" stat box and other UI elements. [[1]](diffhunk://#diff-ae5d2b3f3c3c3d0e66bc450bea40e902e58eb5d31640e79c656545186c05b462R22) [[2]](diffhunk://#diff-ae5d2b3f3c3c3d0e66bc450bea40e902e58eb5d31640e79c656545186c05b462R185-R186)

These changes collectively make the export process and resulting plant cards more accurate, visually clear, and variety-aware, while improving the reliability and specificity of AI-generated content.