### PR TITLE
Fix service worker skip waiting and update UI labels

### DIFF
--- a/plant-swipe/public/locales/en/common.json
+++ b/plant-swipe/public/locales/en/common.json
@@ -793,6 +793,7 @@
     "pageTitle": "Plant Scanner",
     "pageDescription": "Identify any plant by taking a photo or uploading an image",
     "title": "Plant Scanner",
+    "menuLabel": "Scanner",
     "subtitle": "Take a photo or upload an image to identify any plant",
     "signInTitle": "Sign in to Scan Plants",
     "signInDescription": "Please log in to identify plants and save your scan history.",

--- a/plant-swipe/public/locales/en/common.json
+++ b/plant-swipe/public/locales/en/common.json
@@ -325,7 +325,7 @@
       "empty": "Deck warming up..."
     },
     "tags": {
-      "plantOfMonth": "Plant of the Month",
+      "plantOfMonth": "Featured",
       "new": "New",
       "popular": "Popular"
     },

--- a/plant-swipe/public/locales/fr/common.json
+++ b/plant-swipe/public/locales/fr/common.json
@@ -325,7 +325,7 @@
       "empty": "Le paquet s'échauffe..."
     },
     "tags": {
-      "plantOfMonth": "Plante du mois",
+      "plantOfMonth": "En vedette",
       "new": "Nouveau",
       "popular": "Populaire"
     },

--- a/plant-swipe/public/locales/fr/common.json
+++ b/plant-swipe/public/locales/fr/common.json
@@ -793,6 +793,7 @@
     "pageTitle": "Scanner de Plantes",
     "pageDescription": "Identifiez n'importe quelle plante en prenant une photo ou en téléchargeant une image",
     "title": "Scanner de Plantes",
+    "menuLabel": "Scanner",
     "subtitle": "Prenez une photo ou téléchargez une image pour identifier n'importe quelle plante",
     "signInTitle": "Connectez-vous pour Scanner",
     "signInDescription": "Veuillez vous connecter pour identifier les plantes et sauvegarder votre historique de scans.",

--- a/plant-swipe/src/components/layout/TopBar.tsx
+++ b/plant-swipe/src/components/layout/TopBar.tsx
@@ -204,7 +204,7 @@ const TopBarComponent: React.FC<TopBarProps> = ({ openLogin, openSignup, user, d
                     )}
                   </button>
                   <button onMouseDown={(e) => { e.stopPropagation(); setMenuOpen(false); navigate('/scan') }} className="w-full text-left px-3 py-2 rounded-lg hover:bg-stone-50 dark:hover:bg-[#2d2d30] flex items-center gap-2 text-emerald-600 dark:text-emerald-400" role="menuitem">
-                    <ScanLine className="h-4 w-4" /> {t('scan.title', { defaultValue: 'Scan' })}
+                    <ScanLine className="h-4 w-4" /> {t('scan.menuLabel', { defaultValue: 'Scanner' })}
                   </button>
                   <button onMouseDown={(e) => { e.stopPropagation(); setMenuOpen(false); navigate('/friends') }} className="w-full text-left px-3 py-2 rounded-lg hover:bg-stone-50 dark:hover:bg-[#2d2d30] flex items-center gap-2" role="menuitem">
                     <HeartHandshake className="h-4 w-4" /> {t('common.friends')}

--- a/plant-swipe/src/components/pwa/ServiceWorkerToast.tsx
+++ b/plant-swipe/src/components/pwa/ServiceWorkerToast.tsx
@@ -499,22 +499,54 @@ export function ServiceWorkerToast() {
     // Do NOT reset updateShownRef — a reload is pending; no reason to
     // allow the popup to re-appear if the reload takes a moment.
     pendingReloadRef.current = true
-    const wb = wbRef.current
-    const postSkipWaiting = () => {
-      if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) return
-      if (navigator.serviceWorker?.controller) {
-        navigator.serviceWorker.controller.postMessage({ type: 'SKIP_WAITING' })
+    setVisible(false)
+
+    // SKIP_WAITING must go to the *waiting* SW, not `navigator.serviceWorker.controller`
+    // (which is the currently-active old SW — telling it to skipWaiting is a no-op).
+    const postSkipWaitingToWaiting = async (): Promise<boolean> => {
+      if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) return false
+      try {
+        const reg = await navigator.serviceWorker.getRegistration()
+        if (reg?.waiting) {
+          reg.waiting.postMessage({ type: 'SKIP_WAITING' })
+          return true
+        }
+      } catch {
+        /* ignore */
       }
+      return false
     }
 
-    if (wb) {
-      wb.messageSW({ type: 'SKIP_WAITING' }).catch(() => {
-        postSkipWaiting()
-      })
-    } else {
-      postSkipWaiting()
-    }
-    setVisible(false)
+    const wb = wbRef.current
+    void (async () => {
+      let messaged = false
+      if (wb) {
+        try {
+          // messageSkipWaiting targets the waiting SW; messageSW targets the controller.
+          if (typeof (wb as unknown as { messageSkipWaiting?: () => void }).messageSkipWaiting === 'function') {
+            ;(wb as unknown as { messageSkipWaiting: () => void }).messageSkipWaiting()
+            messaged = true
+          } else {
+            await wb.messageSW({ type: 'SKIP_WAITING' })
+            messaged = true
+          }
+        } catch {
+          messaged = await postSkipWaitingToWaiting()
+        }
+      } else {
+        messaged = await postSkipWaitingToWaiting()
+      }
+
+      // Safety net: if controllerchange never fires (waiting SW absent, browser
+      // quirks, etc.), reload anyway after a short grace period. The new SW
+      // will activate on next load even without skipWaiting.
+      window.setTimeout(() => {
+        if (pendingReloadRef.current) {
+          pendingReloadRef.current = false
+          window.location.reload()
+        }
+      }, messaged ? 2500 : 250)
+    })()
   }
 
   const retryConnection = async () => {


### PR DESCRIPTION
## Summary
This PR fixes the service worker update flow to properly target the waiting service worker instance, adds a safety net reload mechanism, and updates UI labels for consistency.

## Key Changes

### Service Worker Update Flow (ServiceWorkerToast.tsx)
- **Fixed SKIP_WAITING messaging**: Changed from posting to `navigator.serviceWorker.controller` (the active old SW) to properly targeting `reg.waiting` (the waiting new SW). The controller cannot skip itself, making the previous approach ineffective.
- **Improved fallback logic**: Added `postSkipWaitingToWaiting()` function that directly accesses the service worker registration as a fallback when the workbox library isn't available.
- **Added safety net reload**: Implemented an automatic reload after a grace period (2.5s if message sent, 250ms otherwise) if the `controllerchange` event doesn't fire. This handles edge cases where the waiting SW might not activate.
- **Better error handling**: Wrapped the entire flow in async/try-catch with proper fallback chains.
- **Attempted messageSkipWaiting usage**: Added type-safe check for workbox's `messageSkipWaiting()` method if available, with fallback to `messageSW()`.

### UI Label Updates
- **Scan menu label**: Changed from using `scan.title` to `scan.menuLabel` in TopBar navigation menu for better semantic separation between page title and menu label.
- **Localization updates** (en/fr):
  - "Plant of the Month" → "Featured" (English)
  - "Plante du mois" → "En vedette" (French)
  - Added `menuLabel: "Scanner"` to scan section in both locales

## Implementation Details
- The service worker fix addresses a critical bug where update notifications would appear but the new SW wouldn't activate until manual reload
- The grace period timeout ensures the app reloads even if browser quirks prevent the controllerchange event
- Localization changes improve consistency and clarity in the UI

https://claude.ai/code/session_01NN6Qav8mgkKVzjT7jFxDqB