### PR TITLE
🎨 Palette: Accessible icon-only buttons in AdminTeamPanel

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -55,3 +55,6 @@
 ## 2024-04-26 - Accessible Action Buttons within Preview Cards
 **Learning:** Action buttons overlaid on media/link preview cards (like Download or External Link icons) often lack explicit screen reader labels and keyboard focus indicators (`focus-visible`). This makes these contextual actions completely inaccessible to users relying on assistive technology or keyboard navigation.
 **Action:** Always add `aria-label` (translated via `t()`) and `focus-visible` utility classes (e.g. `focus-visible:ring-2 focus-visible:outline-none`) to any overlaid icon-only action button inside preview components. Also, ensure the preview container itself (if interactive/clickable) has a clear focus indicator.
+## 2026-05-02 - Accessible Icon-Only Buttons in Drag-and-Drop Lists
+**Learning:** Action buttons in sortable lists (like team members) often rely purely on icons for up/down movement, visibility toggling, editing, and deletion. Without explicitly defined ARIA labels and focus indicators, these list management interactions are completely invisible to screen readers and difficult to navigate via keyboard.
+**Action:** Always ensure that every icon-only button inside mapped lists or drag-and-drop sortable components includes an `aria-label` (or dynamically interpolated label) and a `focus-visible:ring-2` utility class.

--- a/plant-swipe/src/components/admin/AdminTeamPanel.tsx
+++ b/plant-swipe/src/components/admin/AdminTeamPanel.tsx
@@ -341,8 +341,9 @@ export const AdminTeamPanel: React.FC = () => {
                         type="button"
                         onClick={() => handleMoveUp(member)}
                         disabled={index === 0}
-                        className="p-1 rounded hover:bg-stone-200 dark:hover:bg-stone-700 disabled:opacity-30 disabled:cursor-not-allowed"
+                        className="p-1 rounded hover:bg-stone-200 dark:hover:bg-stone-700 disabled:opacity-30 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500"
                         title="Move up"
+                        aria-label="Move up"
                       >
                         <ChevronUp className="h-4 w-4 text-stone-500" />
                       </button>
@@ -351,8 +352,9 @@ export const AdminTeamPanel: React.FC = () => {
                         type="button"
                         onClick={() => handleMoveDown(member)}
                         disabled={index === teamMembers.length - 1}
-                        className="p-1 rounded hover:bg-stone-200 dark:hover:bg-stone-700 disabled:opacity-30 disabled:cursor-not-allowed"
+                        className="p-1 rounded hover:bg-stone-200 dark:hover:bg-stone-700 disabled:opacity-30 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500"
                         title="Move down"
+                        aria-label="Move down"
                       >
                         <ChevronDown className="h-4 w-4 text-stone-500" />
                       </button>
@@ -404,12 +406,13 @@ export const AdminTeamPanel: React.FC = () => {
                         type="button"
                         onClick={() => handleToggleActive(member)}
                         className={cn(
-                          "p-2 rounded-lg transition-colors",
+                          "p-2 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500",
                           member.is_active
                             ? "hover:bg-stone-100 dark:hover:bg-stone-800 text-emerald-600"
                             : "hover:bg-stone-100 dark:hover:bg-stone-800 text-stone-400"
                         )}
                         title={member.is_active ? "Hide from About page" : "Show on About page"}
+                        aria-label={member.is_active ? "Hide from About page" : "Show on About page"}
                       >
                         {member.is_active ? (
                           <Eye className="h-4 w-4" />
@@ -420,16 +423,18 @@ export const AdminTeamPanel: React.FC = () => {
                       <button
                         type="button"
                         onClick={() => handleOpenEdit(member)}
-                        className="p-2 rounded-lg hover:bg-stone-100 dark:hover:bg-stone-800 text-stone-600 dark:text-stone-400"
-                        title="Edit"
+                        className="p-2 rounded-lg hover:bg-stone-100 dark:hover:bg-stone-800 text-stone-600 dark:text-stone-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500"
+                        title="Edit member"
+                        aria-label="Edit member"
                       >
                         <Pencil className="h-4 w-4" />
                       </button>
                       <button
                         type="button"
                         onClick={() => setDeleteConfirmId(member.id)}
-                        className="p-2 rounded-lg hover:bg-red-50 dark:hover:bg-red-900/20 text-red-500"
-                        title="Delete"
+                        className="p-2 rounded-lg hover:bg-red-50 dark:hover:bg-red-900/20 text-red-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
+                        title="Delete member"
+                        aria-label="Delete member"
                       >
                         <Trash2 className="h-4 w-4" />
                       </button>


### PR DESCRIPTION
💡 What: Added missing `aria-label` attributes and `focus-visible` utility classes to the icon-only interaction buttons inside the Admin Team Member management panel.
🎯 Why: Screen reader users could not understand the purpose of the icon-only action buttons (move up, move down, hide/show, edit, delete). Keyboard users lacked explicit visual indicators for their current focus within the list items.
♿ Accessibility:
- Added explicit `aria-label` attributes for list reordering (`Move up`, `Move down`), visibility (`Hide from/Show on About page`), editing, and deleting.
- Added `focus-visible:outline-none focus-visible:ring-2` to all buttons (using emerald for standard actions, red for delete) to ensure strong contrast during keyboard navigation.

---
*PR created automatically by Jules for task [8786087638177725844](https://jules.google.com/task/8786087638177725844) started by @FrenchFive*